### PR TITLE
feat: add sync_strategy config and --merge/--rebase flags

### DIFF
--- a/cmd/ezs/commands/commit.go
+++ b/cmd/ezs/commands/commit.go
@@ -7,37 +7,37 @@ import (
 	"github.com/KulkarniKaustubh/ezstack/internal/git"
 	"github.com/KulkarniKaustubh/ezstack/internal/stack"
 	"github.com/KulkarniKaustubh/ezstack/internal/ui"
-	"github.com/spf13/pflag"
 )
 
 // Commit wraps git commit and auto-syncs child branches
 func Commit(args []string) error {
-	fs := pflag.NewFlagSet("commit", pflag.ContinueOnError)
-	fs.Usage = func() {
+	// Only parse --help ourselves; pass everything else to git
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
 		fmt.Fprintf(os.Stderr, `%sCommit changes and auto-sync child branches%s
 
 %sUSAGE%s
-    ezs commit [git-commit-options]
+    ezs commit [git-commit-options] [--merge|--rebase]
 
 %sDESCRIPTION%s
-    Wraps 'git commit' and then automatically rebases any child branches
+    Wraps 'git commit' and then automatically syncs any child branches
     in the stack onto the updated branch. All arguments are passed through
     to git commit.
+
+    Uses the configured sync_strategy (default: rebase). Override with
+    --merge or --rebase.
 
 %sEXAMPLES%s
     ezs commit -m "Add feature"
     ezs commit -a -m "Fix bug"
     ezs commit --amend
+    ezs commit -m "Fix" --merge
 
 %sOPTIONS%s
+    --merge       Use git merge to sync children (overrides config)
+    --rebase      Use git rebase to sync children (overrides config)
     -h, --help    Show this help message
     All other flags are passed directly to git commit.
 `, ui.Bold, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset)
-	}
-
-	// Only parse --help ourselves; pass everything else to git
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
-		fs.Usage()
 		return nil
 	}
 
@@ -46,16 +46,18 @@ func Commit(args []string) error {
 
 // Amend wraps git commit --amend and auto-syncs child branches
 func Amend(args []string) error {
-	fs := pflag.NewFlagSet("amend", pflag.ContinueOnError)
-	fs.Usage = func() {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
 		fmt.Fprintf(os.Stderr, `%sAmend the last commit and auto-sync child branches%s
 
 %sUSAGE%s
-    ezs amend [git-commit-options]
+    ezs amend [git-commit-options] [--merge|--rebase]
 
 %sDESCRIPTION%s
-    Wraps 'git commit --amend' and then automatically rebases any child
+    Wraps 'git commit --amend' and then automatically syncs any child
     branches in the stack onto the updated branch.
+
+    Uses the configured sync_strategy (default: rebase). Override with
+    --merge or --rebase.
 
 %sEXAMPLES%s
     ezs amend                        # amend with editor
@@ -63,13 +65,11 @@ func Amend(args []string) error {
     ezs amend -m "New message"       # amend with new message
 
 %sOPTIONS%s
+    --merge       Use git merge to sync children (overrides config)
+    --rebase      Use git rebase to sync children (overrides config)
     -h, --help    Show this help message
     All other flags are passed directly to git commit --amend.
 `, ui.Bold, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset)
-	}
-
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
-		fs.Usage()
 		return nil
 	}
 
@@ -85,12 +85,29 @@ func commitInternal(args []string, amend bool) error {
 
 	g := git.New(cwd)
 
+	// Extract --merge/--rebase flags before passing args to git
+	var mergeOverride, rebaseOverride bool
+	var gitPassthroughArgs []string
+	for _, arg := range args {
+		switch arg {
+		case "--merge":
+			mergeOverride = true
+		case "--rebase":
+			rebaseOverride = true
+		default:
+			gitPassthroughArgs = append(gitPassthroughArgs, arg)
+		}
+	}
+	if mergeOverride && rebaseOverride {
+		return fmt.Errorf("cannot use both --merge and --rebase")
+	}
+
 	// Build git commit args
 	gitArgs := []string{"commit"}
 	if amend {
 		gitArgs = append(gitArgs, "--amend")
 	}
-	gitArgs = append(gitArgs, args...)
+	gitArgs = append(gitArgs, gitPassthroughArgs...)
 
 	// Run git commit interactively so the user can use their editor
 	if err := g.RunInteractive(gitArgs...); err != nil {
@@ -156,17 +173,32 @@ func commitInternal(args []string, amend bool) error {
 		return nil
 	}
 
+	// Resolve merge vs rebase: flags override config
+	useMerge := false
+	if mergeOverride {
+		useMerge = true
+	} else if rebaseOverride {
+		useMerge = false
+	} else {
+		useMerge = mgr.GetConfig().GetSyncStrategy(mgr.GetRepoDir()) == "merge"
+	}
+
 	ui.Info(fmt.Sprintf("Syncing %d child branch(es)...", len(children)))
-	results, err := mgr.RebaseChildren()
+	results, err := mgr.RebaseChildren(useMerge)
 	if err != nil {
 		ui.Warn(fmt.Sprintf("Failed to sync children: %v", err))
 		return nil
 	}
 
+	continueCmd := "git rebase --continue"
+	if useMerge {
+		continueCmd = "git merge --continue"
+	}
+
 	for _, result := range results {
 		if result.HasConflict {
 			ui.Warn(fmt.Sprintf("Conflict in '%s': resolve in %s", result.Branch, result.WorktreePath))
-			ui.Info("To resolve: cd to the worktree, fix conflicts, run 'git add .' then 'git rebase --continue'")
+			ui.Info(fmt.Sprintf("To resolve: cd to the worktree, fix conflicts, run 'git add .' then '%s'", continueCmd))
 			return nil
 		} else if result.Error != nil {
 			ui.Warn(fmt.Sprintf("Failed to sync '%s': %v", result.Branch, result.Error))

--- a/cmd/ezs/commands/commit.go
+++ b/cmd/ezs/commands/commit.go
@@ -85,10 +85,19 @@ func commitInternal(args []string, amend bool) error {
 
 	g := git.New(cwd)
 
-	// Extract --merge/--rebase flags before passing args to git
+	// Extract --merge/--rebase flags before passing args to git.
+	// Skip args that are values of git flags that take a string argument
+	// (e.g., -m "--merge" should pass "--merge" as the commit message, not
+	// be interpreted as our flag).
 	var mergeOverride, rebaseOverride bool
 	var gitPassthroughArgs []string
+	skipNext := false
 	for _, arg := range args {
+		if skipNext {
+			gitPassthroughArgs = append(gitPassthroughArgs, arg)
+			skipNext = false
+			continue
+		}
 		switch arg {
 		case "--merge":
 			mergeOverride = true
@@ -96,6 +105,13 @@ func commitInternal(args []string, amend bool) error {
 			rebaseOverride = true
 		default:
 			gitPassthroughArgs = append(gitPassthroughArgs, arg)
+			// These git flags take the next arg as a value — don't interpret it as our flag
+			switch arg {
+			case "-m", "--message", "-F", "--file", "-c", "--reedit-message",
+				"-C", "--reuse-message", "--fixup", "--squash", "--author",
+				"--date", "--cleanup", "-t", "--template", "--trailer":
+				skipNext = true
+			}
 		}
 	}
 	if mergeOverride && rebaseOverride {

--- a/cmd/ezs/commands/config.go
+++ b/cmd/ezs/commands/config.go
@@ -27,6 +27,7 @@ func printConfigUsage() {
     github_token          GitHub token for API access
     cd_after_new          Auto-cd to new worktree (true/false, per-repo)
     use_worktrees         Use git worktrees for new branches (true/false, per-repo)
+    sync_strategy         Sync method: "rebase" or "merge" (per-repo)
 
 %sOPTIONS%s
     -h, --help    Show this help message
@@ -151,8 +152,23 @@ func configSet(key, value string) error {
 		repoCfg.UseWorktrees = &boolVal
 		cfg.SetRepoConfig(repoPath, repoCfg)
 		ui.Info(fmt.Sprintf("Setting use_worktrees for repo: %s", repoPath))
+	case "sync_strategy":
+		repoPath, err := getCurrentRepoPath()
+		if err != nil {
+			return fmt.Errorf("sync_strategy is a per-repo setting: %w", err)
+		}
+		if value != "rebase" && value != "merge" {
+			return fmt.Errorf("sync_strategy must be 'rebase' or 'merge'")
+		}
+		repoCfg := cfg.GetRepoConfig(repoPath)
+		if repoCfg == nil {
+			repoCfg = &config.RepoConfig{}
+		}
+		repoCfg.SyncStrategy = value
+		cfg.SetRepoConfig(repoPath, repoCfg)
+		ui.Info(fmt.Sprintf("Setting sync_strategy for repo: %s", repoPath))
 	default:
-		return fmt.Errorf("unknown config key: %s\nValid keys: worktree_base_dir, default_base_branch, github_token, cd_after_new, use_worktrees", key)
+		return fmt.Errorf("unknown config key: %s\nValid keys: worktree_base_dir, default_base_branch, github_token, cd_after_new, use_worktrees, sync_strategy", key)
 	}
 
 	if err := cfg.Save(); err != nil {
@@ -212,6 +228,11 @@ func configShow() error {
 				fmt.Fprintf(os.Stderr, "  use_worktrees: %v\n", *repoCfg.UseWorktrees)
 			} else {
 				fmt.Fprintf(os.Stderr, "  use_worktrees: true (default)\n")
+			}
+			if repoCfg.SyncStrategy != "" {
+				fmt.Fprintf(os.Stderr, "  sync_strategy: %s\n", repoCfg.SyncStrategy)
+			} else {
+				fmt.Fprintf(os.Stderr, "  sync_strategy: rebase (default)\n")
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "  worktree_base_dir: %s(not configured for this repo)%s\n", ui.Yellow, ui.Reset)
@@ -321,6 +342,20 @@ func configInteractive() error {
 	repoCfg.CdAfterNew = &cdAfterNew
 	configChanged = true
 	ui.Success(fmt.Sprintf("Set cd_after_new = %v", cdAfterNew))
+
+	// Sync strategy: rebase or merge
+	currentSyncStrategy := "rebase"
+	if repoCfg.SyncStrategy != "" {
+		currentSyncStrategy = repoCfg.SyncStrategy
+	}
+	useMergeSync := ui.ConfirmTUIWithDefault("Use merge instead of rebase for sync (avoids force pushes)", currentSyncStrategy == "merge")
+	if useMergeSync {
+		repoCfg.SyncStrategy = "merge"
+	} else {
+		repoCfg.SyncStrategy = "rebase"
+	}
+	configChanged = true
+	ui.Success(fmt.Sprintf("Set sync_strategy = %s", repoCfg.SyncStrategy))
 
 	if configChanged {
 		cfg.SetRepoConfig(repoPath, repoCfg)

--- a/cmd/ezs/commands/reparent.go
+++ b/cmd/ezs/commands/reparent.go
@@ -23,19 +23,21 @@ func Reparent(args []string) error {
 %sOPTIONS%s
     -b, --branch <name>     Branch to reparent
     -p, --parent <name>     New parent branch
+    --merge                 Use git merge instead of git rebase
+    --rebase                Use git rebase (overrides config)
     -h, --help              Show this help message
 
 %sDESCRIPTION%s
-    Changes the parent of a branch and rebases commits onto the new parent.
+    Changes the parent of a branch and syncs commits onto the new parent.
     This can be used to:
 
     1. Move a branch to a different parent within the same stack
     2. Add a standalone worktree/branch to an existing stack
     3. Split a stack by reparenting branches to different parents
 
-    Reparenting always rebases to keep the stack consistent. If the rebase
-    conflicts, the reparent metadata is still updated and you can resolve
-    conflicts manually.
+    Uses the configured sync_strategy (default: rebase). Override with
+    --merge or --rebase. If the sync conflicts, the reparent metadata is
+    still updated and you can resolve conflicts manually.
 
 %sEXAMPLES%s
     ezs reparent                        Interactive mode
@@ -46,6 +48,8 @@ func Reparent(args []string) error {
 
 	branchFlag := fs.StringP("branch", "b", "", "Branch to reparent")
 	parentFlag := fs.StringP("parent", "p", "", "New parent branch")
+	mergeFlag := fs.Bool("merge", false, "Use git merge instead of git rebase")
+	rebaseFlag := fs.Bool("rebase", false, "Use git rebase (overrides config)")
 	helpFlag := fs.BoolP("help", "h", false, "Show help")
 
 	if err := fs.Parse(args); err != nil {
@@ -86,17 +90,30 @@ func Reparent(args []string) error {
 		newParent = fs.Arg(1)
 	}
 
+	// Resolve merge vs rebase: flags override config
+	if *mergeFlag && *rebaseFlag {
+		return fmt.Errorf("cannot use both --merge and --rebase")
+	}
+	useMerge := false
+	if *mergeFlag {
+		useMerge = true
+	} else if *rebaseFlag {
+		useMerge = false
+	} else {
+		useMerge = mgr.GetConfig().GetSyncStrategy(mgr.GetRepoDir()) == "merge"
+	}
+
 	// Interactive mode if branch or parent not specified
 	if branchName == "" || newParent == "" {
-		return reparentInteractive(mgr, g, branchName, newParent)
+		return reparentInteractive(mgr, g, branchName, newParent, useMerge)
 	}
 
 	// Non-interactive mode
-	return doReparent(mgr, branchName, newParent)
+	return doReparentWithMerge(mgr, branchName, newParent, useMerge)
 }
 
 // reparentInteractive handles interactive branch and parent selection
-func reparentInteractive(mgr *stack.Manager, g *git.Git, branchName, newParent string) error {
+func reparentInteractive(mgr *stack.Manager, g *git.Git, branchName, newParent string, useMerge bool) error {
 	cfg := mgr.GetConfig()
 	baseBranch := cfg.GetBaseBranch(mgr.GetRepoDir())
 
@@ -118,7 +135,7 @@ func reparentInteractive(mgr *stack.Manager, g *git.Git, branchName, newParent s
 		}
 	}
 
-	return doReparent(mgr, branchName, newParent)
+	return doReparentWithMerge(mgr, branchName, newParent, useMerge)
 }
 
 // selectBranchToReparent shows a selection UI for choosing which branch to reparent
@@ -252,20 +269,20 @@ func IsDescendantOf(mgr *stack.Manager, branchName, ancestorName string) bool {
 	}
 }
 
-// doReparent performs the actual reparent operation (used by both `ezs reparent` and `ezs stack`)
-func doReparent(mgr *stack.Manager, branchName, newParent string) error {
-	return doReparentCore(mgr, branchName, newParent, true)
+// doReparentWithMerge performs reparent with explicit merge/rebase choice
+func doReparentWithMerge(mgr *stack.Manager, branchName, newParent string, useMerge bool) error {
+	return doReparentCore(mgr, branchName, newParent, true, useMerge)
 }
 
 // doReparentNoRebase performs a reparent without rebasing (used by `ezs stack`)
 func doReparentNoRebase(mgr *stack.Manager, branchName, newParent string) error {
-	return doReparentCore(mgr, branchName, newParent, false)
+	return doReparentCore(mgr, branchName, newParent, false, false)
 }
 
 // doReparentCore is the shared implementation for reparent and stack commands.
-// When rebase=true, commits are rebased onto the new parent and force-push is offered.
+// When rebase=true, commits are synced onto the new parent and push is offered.
 // When rebase=false, only the tracking metadata is updated.
-func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase bool) error {
+func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase bool, useMerge bool) error {
 	// Get current parent for display
 	existingBranch := mgr.GetBranch(branchName)
 	oldParent := ""
@@ -281,7 +298,11 @@ func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase boo
 	}
 
 	if rebase {
-		ui.Info("Will rebase commits onto new parent")
+		if useMerge {
+			ui.Info("Will merge new parent into branch")
+		} else {
+			ui.Info("Will rebase commits onto new parent")
+		}
 	}
 
 	confirmMsg := "Proceed?"
@@ -294,7 +315,7 @@ func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase boo
 	}
 
 	oldStack := mgr.GetStackForBranch(branchName)
-	result, err := mgr.ReparentBranch(branchName, newParent, rebase)
+	result, err := mgr.ReparentBranch(branchName, newParent, rebase, useMerge)
 	if err != nil {
 		return err
 	}
@@ -305,9 +326,15 @@ func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase boo
 	branch := result.Branch
 
 	if result.HasConflict {
-		ui.Warn(fmt.Sprintf("Reparented '%s' to '%s' (config updated), but rebase has conflicts", branch.Name, branch.Parent))
+		syncType := "rebase"
+		continueCmd := "git rebase --continue"
+		if useMerge {
+			syncType = "merge"
+			continueCmd = "git merge --continue"
+		}
+		ui.Warn(fmt.Sprintf("Reparented '%s' to '%s' (config updated), but %s has conflicts", branch.Name, branch.Parent, syncType))
 		ui.Warn(fmt.Sprintf("Resolve conflicts in: %s", result.ConflictDir))
-		ui.Info("Then run: git rebase --continue")
+		ui.Info(fmt.Sprintf("Then run: %s", continueCmd))
 	} else {
 		if oldParent != "" {
 			ui.Success(fmt.Sprintf("Reparented '%s' to '%s'", branch.Name, branch.Parent))
@@ -321,15 +348,20 @@ func doReparentCore(mgr *stack.Manager, branchName, newParent string, rebase boo
 	cwd, _ := os.Getwd()
 	g := git.New(cwd)
 
-	// Offer force push if rebased and branch has a PR
+	// Offer push if synced and branch has a PR
 	pushSucceeded := true
 	if rebase && !result.HasConflict && branch.PRNumber > 0 {
-		ui.Info("Branch was rebased. Force-push required to update the PR.")
 		worktreePath := cwd
 		if branch.WorktreePath != "" {
 			worktreePath = branch.WorktreePath
 		}
-		pushSucceeded = OfferForcePush(branchName, worktreePath)
+		if useMerge {
+			ui.Info("Branch was merged. Push to update the PR.")
+			pushSucceeded = OfferPush(branchName, worktreePath)
+		} else {
+			ui.Info("Branch was rebased. Force-push required to update the PR.")
+			pushSucceeded = OfferForcePush(branchName, worktreePath)
+		}
 	}
 
 	// Update PR metadata on GitHub

--- a/cmd/ezs/commands/sync.go
+++ b/cmd/ezs/commands/sync.go
@@ -30,6 +30,7 @@ func Sync(args []string) error {
     -p, --parent           Rebase current branch onto its parent
     -C, --children         Rebase child branches onto current branch
     --merge                Use git merge instead of git rebase
+    --rebase               Use git rebase (overrides sync_strategy config)
     --no-delete-local      Don't delete local branches after their PRs are merged
     --dry-run              Preview what would be synced without making changes
     --no-autostash         Don't stash uncommitted changes before rebase
@@ -47,7 +48,9 @@ func Sync(args []string) error {
     5. Rebase child branches onto current branch
 
     By default, sync uses git rebase. Use --merge to use git merge instead,
-    which preserves commit history and avoids force pushes.
+    which preserves commit history and avoids force pushes. The default
+    strategy can be set per-repo with: ezs config set sync_strategy merge
+    Use --rebase or --merge to override the configured strategy.
 
     When run from main (not in a stack worktree), shows a menu to choose
     which stack to sync. You can also pass a stack hash prefix (minimum
@@ -71,6 +74,7 @@ func Sync(args []string) error {
 	parentFlag := fs.BoolP("parent", "p", false, "Rebase onto parent")
 	childrenFlag := fs.BoolP("children", "C", false, "Rebase children")
 	mergeFlag := fs.Bool("merge", false, "Use git merge instead of git rebase")
+	rebaseFlag := fs.Bool("rebase", false, "Use git rebase (overrides config)")
 	noDeleteLocal := fs.Bool("no-delete-local", false, "Don't delete local branches after their PRs are merged")
 	dryRunFlag := fs.Bool("dry-run", false, "Preview what would be synced")
 	noAutostashFlag := fs.Bool("no-autostash", false, "Don't stash uncommitted changes before rebase")
@@ -104,8 +108,20 @@ func Sync(args []string) error {
 
 	dryRun := *dryRunFlag
 	autostash := !*noAutostashFlag
-	useMerge := *mergeFlag
 	jsonOutput := *jsonFlag
+
+	// Resolve merge vs rebase: flags override config
+	useMerge := false
+	if *mergeFlag && *rebaseFlag {
+		return fmt.Errorf("cannot use both --merge and --rebase")
+	} else if *mergeFlag {
+		useMerge = true
+	} else if *rebaseFlag {
+		useMerge = false
+	} else {
+		// No flag specified — use config
+		useMerge = mgr.GetConfig().GetSyncStrategy(mgr.GetRepoDir()) == "merge"
+	}
 
 	if jsonOutput && !dryRun {
 		return fmt.Errorf("--json requires --dry-run")

--- a/cmd/ezs/commands/sync.go
+++ b/cmd/ezs/commands/sync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/KulkarniKaustubh/ezstack/internal/config"
 	"github.com/KulkarniKaustubh/ezstack/internal/git"
@@ -706,15 +707,21 @@ func syncOntoParent(mgr *stack.Manager, branch *config.Branch, useMerge bool) er
 		ui.Info("Rebasing onto parent...")
 	}
 	if err := mgr.RebaseOnParent(useMerge); err != nil {
-		// Interactive merge/rebase returns an error on conflict — the user
-		// sees the conflict output directly on the terminal, so just give
-		// them the resolution instructions instead of a raw "exit status 1".
-		if useMerge {
-			ui.Warn("Merge has conflicts. Resolve them, then run: git add . && git merge --continue")
-		} else {
-			ui.Warn("Rebase has conflicts. Resolve them, then run: git add . && git rebase --continue")
+		// Interactive merge/rebase returns an exit status error on conflict.
+		// The user sees the conflict output directly on the terminal, so
+		// give them resolution instructions instead of a raw "exit status 1".
+		// But if the error is NOT an exit status (e.g., GetCurrentStack failed),
+		// propagate it as-is.
+		errStr := err.Error()
+		if strings.Contains(errStr, "exit status") {
+			if useMerge {
+				ui.Warn("Merge has conflicts. Resolve them, then run: git add . && git merge --continue")
+			} else {
+				ui.Warn("Rebase has conflicts. Resolve them, then run: git add . && git rebase --continue")
+			}
+			return nil
 		}
-		return nil
+		return err
 	}
 	if useMerge {
 		ui.Success("Merge complete")

--- a/cmd/ezs/commands/sync.go
+++ b/cmd/ezs/commands/sync.go
@@ -706,7 +706,15 @@ func syncOntoParent(mgr *stack.Manager, branch *config.Branch, useMerge bool) er
 		ui.Info("Rebasing onto parent...")
 	}
 	if err := mgr.RebaseOnParent(useMerge); err != nil {
-		return err
+		// Interactive merge/rebase returns an error on conflict — the user
+		// sees the conflict output directly on the terminal, so just give
+		// them the resolution instructions instead of a raw "exit status 1".
+		if useMerge {
+			ui.Warn("Merge has conflicts. Resolve them, then run: git add . && git merge --continue")
+		} else {
+			ui.Warn("Rebase has conflicts. Resolve them, then run: git add . && git rebase --continue")
+		}
+		return nil
 	}
 	if useMerge {
 		ui.Success("Merge complete")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type RepoConfig struct {
 	CdAfterNew          *bool  `json:"cd_after_new,omitempty"`
 	UseWorktrees        *bool  `json:"use_worktrees,omitempty"`
 	AutoDraftWipCommits *bool  `json:"auto_draft_wip_commits,omitempty"`
+	SyncStrategy        string `json:"sync_strategy,omitempty"` // "rebase" (default) or "merge"
 }
 
 // GetRepoConfig returns the configuration for a specific repo path
@@ -109,6 +110,14 @@ func (c *Config) GetUseWorktrees(repoPath string) bool {
 		return *repoCfg.UseWorktrees
 	}
 	return true
+}
+
+// GetSyncStrategy returns the sync strategy for a repo ("rebase" or "merge", default "rebase")
+func (c *Config) GetSyncStrategy(repoPath string) string {
+	if repoCfg := c.GetRepoConfig(repoPath); repoCfg != nil && repoCfg.SyncStrategy != "" {
+		return repoCfg.SyncStrategy
+	}
+	return "rebase"
 }
 
 // BranchTree is a recursive map representing the stack hierarchy

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -525,3 +525,111 @@ func TestBranch_Fields(t *testing.T) {
 		t.Error("IsMerged should be false")
 	}
 }
+
+func TestConfig_GetSyncStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Config
+		repoPath string
+		want     string
+	}{
+		{
+			name: "repo-specific merge",
+			config: &Config{
+				Repos: map[string]*RepoConfig{
+					"/repo": {SyncStrategy: "merge"},
+				},
+			},
+			repoPath: "/repo",
+			want:     "merge",
+		},
+		{
+			name: "repo-specific rebase",
+			config: &Config{
+				Repos: map[string]*RepoConfig{
+					"/repo": {SyncStrategy: "rebase"},
+				},
+			},
+			repoPath: "/repo",
+			want:     "rebase",
+		},
+		{
+			name: "empty defaults to rebase",
+			config: &Config{
+				Repos: map[string]*RepoConfig{
+					"/repo": {},
+				},
+			},
+			repoPath: "/repo",
+			want:     "rebase",
+		},
+		{
+			name: "no repo config defaults to rebase",
+			config: &Config{
+				Repos: make(map[string]*RepoConfig),
+			},
+			repoPath: "/unknown/repo",
+			want:     "rebase",
+		},
+		{
+			name:     "nil repos defaults to rebase",
+			config:   &Config{},
+			repoPath: "/repo",
+			want:     "rebase",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.GetSyncStrategy(tt.repoPath)
+			if got != tt.want {
+				t.Errorf("GetSyncStrategy() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_SyncStrategy_Persistence(t *testing.T) {
+	// Test that sync_strategy survives save/load cycle
+	tmpDir, err := os.MkdirTemp("", "ezstack-config-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	originalHome := os.Getenv("EZSTACK_HOME")
+	defer os.Setenv("EZSTACK_HOME", originalHome)
+	os.Setenv("EZSTACK_HOME", tmpDir)
+
+	// Create config with sync_strategy
+	cfg := &Config{
+		DefaultBaseBranch: "main",
+		Repos: map[string]*RepoConfig{
+			"/test/repo": {
+				RepoPath:     "/test/repo",
+				SyncStrategy: "merge",
+			},
+		},
+	}
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Load it back
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	got := loaded.GetSyncStrategy("/test/repo")
+	if got != "merge" {
+		t.Errorf("After save/load, GetSyncStrategy() = %q, want %q", got, "merge")
+	}
+
+	// Verify empty sync_strategy is also preserved correctly
+	got = loaded.GetSyncStrategy("/other/repo")
+	if got != "rebase" {
+		t.Errorf("Unknown repo GetSyncStrategy() = %q, want %q", got, "rebase")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -438,18 +438,20 @@ func (g *Git) MergeNonInteractive(target string) RebaseResult {
 
 	cmd := exec.Command("git", "merge", target, "--no-edit")
 	cmd.Dir = g.RepoDir
-	var stderr bytes.Buffer
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 	if err != nil {
-		stderrStr := stderr.String()
-		if strings.Contains(stderrStr, "CONFLICT") ||
-			strings.Contains(stderrStr, "Automatic merge failed") ||
-			strings.Contains(stderrStr, "fix conflicts") {
+		// git merge outputs conflict info to stdout, not stderr
+		combined := stdout.String() + stderr.String()
+		if strings.Contains(combined, "CONFLICT") ||
+			strings.Contains(combined, "Automatic merge failed") ||
+			strings.Contains(combined, "fix conflicts") {
 			return RebaseResult{HasConflict: true, Error: fmt.Errorf("merge conflict")}
 		}
-		return RebaseResult{Error: fmt.Errorf("merge failed: %s", stderrStr)}
+		return RebaseResult{Error: fmt.Errorf("merge failed: %s", combined)}
 	}
 	return RebaseResult{Success: true}
 }

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -614,7 +614,7 @@ type ReparentResult struct {
 // If doRebase is true, performs git rebase --onto to move commits.
 // Config changes are always saved first. If rebase has conflicts, the result
 // will have HasConflict=true but the branch will still be returned (config is updated).
-func (m *Manager) ReparentBranch(branchName, newParentName string, doRebase bool) (*ReparentResult, error) {
+func (m *Manager) ReparentBranch(branchName, newParentName string, doRebase bool, useMerge ...bool) (*ReparentResult, error) {
 	if branchName == newParentName {
 		return nil, fmt.Errorf("cannot stack a branch on itself")
 	}
@@ -622,21 +622,23 @@ func (m *Manager) ReparentBranch(branchName, newParentName string, doRebase bool
 		return nil, fmt.Errorf("new parent '%s' does not exist", newParentName)
 	}
 
+	merge := len(useMerge) > 0 && useMerge[0]
+
 	// Check if branch is already registered in a stack
 	existingBranch := m.GetBranch(branchName)
 
 	if existingBranch != nil {
 		// Branch is already in a stack - update its parent
-		return m.reparentExistingBranch(existingBranch, newParentName, doRebase)
+		return m.reparentExistingBranch(existingBranch, newParentName, doRebase, merge)
 	}
 
 	// Branch is not in any stack - need to add it
-	return m.addBranchWithParent(branchName, newParentName, doRebase)
+	return m.addBranchWithParent(branchName, newParentName, doRebase, merge)
 }
 
 // reparentExistingBranch handles reparenting a branch that's already in a stack.
 // Config changes are saved first, then rebase is attempted if requested.
-func (m *Manager) reparentExistingBranch(branch *config.Branch, newParentName string, doRebase bool) (*ReparentResult, error) {
+func (m *Manager) reparentExistingBranch(branch *config.Branch, newParentName string, doRebase bool, useMerge bool) (*ReparentResult, error) {
 	oldParent := branch.Parent
 	oldStackKey := m.findStackForBranch(branch.Name)
 	newParentStackKey := m.findStackForBranch(newParentName)
@@ -695,26 +697,34 @@ func (m *Manager) reparentExistingBranch(branch *config.Branch, newParentName st
 
 	result := &ReparentResult{Branch: m.GetBranch(branch.Name)}
 
-	// Perform git rebase if requested (after config is saved)
+	// Perform git rebase/merge if requested (after config is saved)
 	if doRebase && branch.WorktreePath != "" {
 		g := git.New(branch.WorktreePath)
-
-		// Get the merge-base between current branch and old parent
-		oldParentRef := m.getParentRef(oldParent)
-		mergeBase, err := m.git.GetMergeBase(branch.Name, oldParentRef)
-		if err != nil {
-			mergeBase = oldParentRef
-		}
-
 		newParentRef := m.getParentRef(newParentName)
 
-		// Rebase onto new parent
-		rebaseResult := g.RebaseOntoNonInteractive(newParentRef, mergeBase)
-		if rebaseResult.HasConflict {
-			result.HasConflict = true
-			result.ConflictDir = branch.WorktreePath
-		} else if rebaseResult.Error != nil {
-			return result, fmt.Errorf("rebase failed: %w", rebaseResult.Error)
+		if useMerge {
+			syncResult := g.MergeNonInteractive(newParentRef)
+			if syncResult.HasConflict {
+				result.HasConflict = true
+				result.ConflictDir = branch.WorktreePath
+			} else if syncResult.Error != nil {
+				return result, fmt.Errorf("merge failed: %w", syncResult.Error)
+			}
+		} else {
+			// Get the merge-base between current branch and old parent
+			oldParentRef := m.getParentRef(oldParent)
+			mergeBase, err := m.git.GetMergeBase(branch.Name, oldParentRef)
+			if err != nil {
+				mergeBase = oldParentRef
+			}
+
+			rebaseResult := g.RebaseOntoNonInteractive(newParentRef, mergeBase)
+			if rebaseResult.HasConflict {
+				result.HasConflict = true
+				result.ConflictDir = branch.WorktreePath
+			} else if rebaseResult.Error != nil {
+				return result, fmt.Errorf("rebase failed: %w", rebaseResult.Error)
+			}
 		}
 	}
 
@@ -723,7 +733,7 @@ func (m *Manager) reparentExistingBranch(branch *config.Branch, newParentName st
 
 // addBranchWithParent adds a standalone git branch to a stack with the specified parent.
 // Config changes are saved first, then rebase is attempted if requested.
-func (m *Manager) addBranchWithParent(branchName, newParentName string, doRebase bool) (*ReparentResult, error) {
+func (m *Manager) addBranchWithParent(branchName, newParentName string, doRebase bool, useMerge bool) (*ReparentResult, error) {
 	// Check if the git branch exists
 	if !m.git.BranchExists(branchName) {
 		return nil, fmt.Errorf("git branch '%s' does not exist", branchName)
@@ -780,19 +790,27 @@ func (m *Manager) addBranchWithParent(branchName, newParentName string, doRebase
 
 	result := &ReparentResult{Branch: m.GetBranch(branchName)}
 
-	// Perform git rebase if requested and we have a worktree (after config is saved)
+	// Perform git rebase/merge if requested and we have a worktree (after config is saved)
 	if doRebase && worktreePath != "" {
 		g := git.New(worktreePath)
-
 		newParentRef := m.getParentRef(newParentName)
 
-		// Simple rebase onto new parent
-		rebaseResult := g.RebaseNonInteractive(newParentRef)
-		if rebaseResult.HasConflict {
-			result.HasConflict = true
-			result.ConflictDir = worktreePath
-		} else if rebaseResult.Error != nil {
-			return result, fmt.Errorf("rebase failed: %w", rebaseResult.Error)
+		if useMerge {
+			syncResult := g.MergeNonInteractive(newParentRef)
+			if syncResult.HasConflict {
+				result.HasConflict = true
+				result.ConflictDir = worktreePath
+			} else if syncResult.Error != nil {
+				return result, fmt.Errorf("merge failed: %w", syncResult.Error)
+			}
+		} else {
+			rebaseResult := g.RebaseNonInteractive(newParentRef)
+			if rebaseResult.HasConflict {
+				result.HasConflict = true
+				result.ConflictDir = worktreePath
+			} else if rebaseResult.Error != nil {
+				return result, fmt.Errorf("rebase failed: %w", rebaseResult.Error)
+			}
 		}
 	}
 

--- a/itests/merge_test.go
+++ b/itests/merge_test.go
@@ -1,0 +1,439 @@
+package itests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/internal/config"
+	"github.com/KulkarniKaustubh/ezstack/internal/stack"
+)
+
+// TestRebaseChildren_Merge tests that RebaseChildren with useMerge=true
+// uses merge instead of rebase
+func TestRebaseChildren_Merge(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create a stack: main -> parent-branch -> child-branch
+	CreateBranchWithCommit(t, env, "parent-branch", "main")
+	CreateBranchWithCommit(t, env, "child-branch", "parent-branch")
+
+	childWorktree := filepath.Join(env.WorktreeDir, "child-branch")
+
+	// Add a new commit to parent
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent-branch")
+	GitCommit(t, parentWorktree, "parent-update.txt", "updated", "Update parent")
+
+	// Sync children using merge
+	mgr, err := stack.NewManager(parentWorktree)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	results, err := mgr.RebaseChildren(true) // useMerge=true
+	if err != nil {
+		t.Fatalf("RebaseChildren(merge) failed: %v", err)
+	}
+
+	// Check results
+	if len(results) == 0 {
+		t.Fatal("Expected at least one result")
+	}
+
+	for _, r := range results {
+		if r.HasConflict {
+			t.Errorf("Unexpected conflict in %s", r.Branch)
+		}
+		if r.Error != nil {
+			t.Errorf("Unexpected error in %s: %v", r.Branch, r.Error)
+		}
+		if !r.Success {
+			t.Errorf("Expected success for %s", r.Branch)
+		}
+	}
+
+	// Verify merge commit exists (merge creates a merge commit)
+	logOutput, err := exec.Command("git", "-C", childWorktree, "log", "--oneline", "-5").Output()
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	if !strings.Contains(string(logOutput), "Merge") {
+		t.Errorf("Expected merge commit in log, got: %s", string(logOutput))
+	}
+
+	// Verify the parent's commit content is in the child
+	if _, err := os.Stat(filepath.Join(childWorktree, "parent-update.txt")); os.IsNotExist(err) {
+		t.Error("parent-update.txt should exist in child worktree after merge")
+	}
+}
+
+// TestRebaseChildren_Rebase tests that RebaseChildren with useMerge=false
+// uses rebase (default behavior)
+func TestRebaseChildren_Rebase(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create a stack: main -> parent-branch -> child-branch
+	CreateBranchWithCommit(t, env, "parent-branch", "main")
+	CreateBranchWithCommit(t, env, "child-branch", "parent-branch")
+
+	// Add a new commit to parent
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent-branch")
+	GitCommit(t, parentWorktree, "parent-update.txt", "updated", "Update parent")
+
+	// Sync children using rebase (default)
+	mgr, err := stack.NewManager(parentWorktree)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	results, err := mgr.RebaseChildren(false) // useMerge=false
+	if err != nil {
+		t.Fatalf("RebaseChildren(rebase) failed: %v", err)
+	}
+
+	for _, r := range results {
+		if r.HasConflict {
+			t.Errorf("Unexpected conflict in %s", r.Branch)
+		}
+		if !r.Success {
+			t.Errorf("Expected success for %s", r.Branch)
+		}
+	}
+
+	// Verify the parent's commit is in the child
+	childWorktree := filepath.Join(env.WorktreeDir, "child-branch")
+	if _, err := os.Stat(filepath.Join(childWorktree, "parent-update.txt")); os.IsNotExist(err) {
+		t.Error("parent-update.txt should exist in child worktree after rebase")
+	}
+}
+
+// TestReparentBranch_WithMerge tests reparenting a branch using merge
+func TestReparentBranch_WithMerge(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create: main -> branch-a, main -> branch-b (separate stacks)
+	CreateBranchWithCommit(t, env, "branch-a", "main")
+	CreateBranchWithCommit(t, env, "branch-b", "main")
+
+	// Add a unique commit to branch-a
+	worktreeA := filepath.Join(env.WorktreeDir, "branch-a")
+	GitCommit(t, worktreeA, "a-only.txt", "only in a", "Only in branch-a")
+
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	// Reparent branch-b onto branch-a using merge
+	result, err := mgr.ReparentBranch("branch-b", "branch-a", true, true) // doRebase=true, useMerge=true
+	if err != nil {
+		t.Fatalf("ReparentBranch with merge failed: %v", err)
+	}
+
+	if result.HasConflict {
+		t.Fatal("Unexpected conflict during merge reparent")
+	}
+
+	// Verify parent was updated
+	AssertBranchParent(t, env, "branch-b", "branch-a")
+
+	// Verify branch-a's content is now in branch-b
+	worktreeB := filepath.Join(env.WorktreeDir, "branch-b")
+	if _, err := os.Stat(filepath.Join(worktreeB, "a-only.txt")); os.IsNotExist(err) {
+		t.Error("a-only.txt should exist in branch-b after merge reparent")
+	}
+}
+
+// TestReparentBranch_WithRebase tests reparenting a branch using rebase (default)
+func TestReparentBranch_WithRebase(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create: main -> branch-a, main -> branch-b
+	CreateBranchWithCommit(t, env, "branch-a", "main")
+	CreateBranchWithCommit(t, env, "branch-b", "main")
+
+	// Add a unique commit to branch-a
+	worktreeA := filepath.Join(env.WorktreeDir, "branch-a")
+	GitCommit(t, worktreeA, "a-only.txt", "only in a", "Only in branch-a")
+
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	// Reparent branch-b onto branch-a using rebase (no useMerge arg = default false)
+	result, err := mgr.ReparentBranch("branch-b", "branch-a", true)
+	if err != nil {
+		t.Fatalf("ReparentBranch with rebase failed: %v", err)
+	}
+
+	if result.HasConflict {
+		t.Fatal("Unexpected conflict during rebase reparent")
+	}
+
+	// Verify parent was updated
+	AssertBranchParent(t, env, "branch-b", "branch-a")
+
+	// Verify branch-a's content is now in branch-b
+	worktreeB := filepath.Join(env.WorktreeDir, "branch-b")
+	if _, err := os.Stat(filepath.Join(worktreeB, "a-only.txt")); os.IsNotExist(err) {
+		t.Error("a-only.txt should exist in branch-b after rebase reparent")
+	}
+}
+
+// TestReparentBranch_MergeConflict tests reparent with merge when there's a conflict
+func TestReparentBranch_MergeConflict(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create: main -> branch-a, main -> branch-b
+	CreateBranch(t, env, "branch-a", "main")
+	CreateBranch(t, env, "branch-b", "main")
+
+	// Create conflicting changes in same file
+	worktreeA := filepath.Join(env.WorktreeDir, "branch-a")
+	worktreeB := filepath.Join(env.WorktreeDir, "branch-b")
+	GitCommit(t, worktreeA, "conflict.txt", "content from A", "Branch A change")
+	GitCommit(t, worktreeB, "conflict.txt", "content from B", "Branch B change")
+
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	// Reparent branch-b onto branch-a using merge — expect conflict
+	result, err := mgr.ReparentBranch("branch-b", "branch-a", true, true)
+	if err != nil {
+		t.Fatalf("ReparentBranch error: %v", err)
+	}
+
+	if !result.HasConflict {
+		t.Error("Expected conflict during merge reparent with conflicting files")
+	}
+
+	// Config should still be saved (parent updated even on conflict)
+	AssertBranchParent(t, env, "branch-b", "branch-a")
+
+	// Abort the merge to clean up
+	exec.Command("git", "-C", worktreeB, "merge", "--abort").Run()
+}
+
+// TestSyncBranch_Merge tests syncing a branch behind its parent using merge
+func TestSyncBranch_Merge(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create a stack: main -> parent -> child
+	// SyncBranch for non-root branches syncs against parent, not origin
+	CreateBranchWithCommit(t, env, "parent-sync", "main")
+	CreateBranchWithCommit(t, env, "child-sync", "parent-sync")
+
+	// Add commits to parent
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent-sync")
+	GitCommit(t, parentWorktree, "parent-update.txt", "parent update", "Update parent")
+
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	// Sync child branch using merge
+	result, err := mgr.SyncBranch("child-sync", nil, true) // useMerge=true
+	if err != nil {
+		t.Fatalf("SyncBranch(merge) failed: %v", err)
+	}
+
+	if result != nil && result.HasConflict {
+		t.Error("Unexpected conflict")
+	}
+	if result != nil && !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+
+	// Verify parent's commit is now in the child branch
+	childWorktree := filepath.Join(env.WorktreeDir, "child-sync")
+	if _, err := os.Stat(filepath.Join(childWorktree, "parent-update.txt")); os.IsNotExist(err) {
+		t.Error("parent-update.txt should exist in child worktree after merge sync")
+	}
+}
+
+// TestSyncBranch_Rebase tests syncing a branch behind its parent using rebase
+func TestSyncBranch_Rebase(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create a stack: main -> parent -> child
+	CreateBranchWithCommit(t, env, "parent-sync", "main")
+	CreateBranchWithCommit(t, env, "child-sync", "parent-sync")
+
+	// Add commits to parent
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent-sync")
+	GitCommit(t, parentWorktree, "parent-update.txt", "parent update", "Update parent")
+
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	// Sync child branch using rebase
+	result, err := mgr.SyncBranch("child-sync", nil, false) // useMerge=false
+	if err != nil {
+		t.Fatalf("SyncBranch(rebase) failed: %v", err)
+	}
+
+	if result != nil && result.HasConflict {
+		t.Error("Unexpected conflict")
+	}
+	if result != nil && !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+
+	// Verify parent's commit is now in the child branch
+	childWorktree := filepath.Join(env.WorktreeDir, "child-sync")
+	if _, err := os.Stat(filepath.Join(childWorktree, "parent-update.txt")); os.IsNotExist(err) {
+		t.Error("parent-update.txt should exist in child worktree after rebase sync")
+	}
+}
+
+// TestSyncStrategy_ConfigPersistence tests that sync_strategy is preserved in config
+func TestSyncStrategy_ConfigPersistence(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Load config and set sync_strategy
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load config failed: %v", err)
+	}
+
+	repoCfg := cfg.GetRepoConfig(env.RepoDir)
+	if repoCfg == nil {
+		repoCfg = &config.RepoConfig{}
+	}
+	repoCfg.SyncStrategy = "merge"
+	cfg.SetRepoConfig(env.RepoDir, repoCfg)
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save config failed: %v", err)
+	}
+
+	// Reload and verify
+	cfg2, err := config.Load()
+	if err != nil {
+		t.Fatalf("Reload config failed: %v", err)
+	}
+
+	strategy := cfg2.GetSyncStrategy(env.RepoDir)
+	if strategy != "merge" {
+		t.Errorf("GetSyncStrategy() = %q, want %q", strategy, "merge")
+	}
+}
+
+// TestSyncStrategy_DefaultRebase tests that unset sync_strategy defaults to rebase
+func TestSyncStrategy_DefaultRebase(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load config failed: %v", err)
+	}
+
+	strategy := cfg.GetSyncStrategy(env.RepoDir)
+	if strategy != "rebase" {
+		t.Errorf("Default GetSyncStrategy() = %q, want %q", strategy, "rebase")
+	}
+}
+
+// TestRebaseChildren_MergeConflict tests merge conflict handling during child sync
+func TestRebaseChildren_MergeConflict(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create: main -> parent -> child
+	CreateBranch(t, env, "parent-branch", "main")
+	CreateBranch(t, env, "child-branch", "parent-branch")
+
+	// Create conflicting changes
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent-branch")
+	childWorktree := filepath.Join(env.WorktreeDir, "child-branch")
+	GitCommit(t, parentWorktree, "shared.txt", "parent version", "Parent change")
+	GitCommit(t, childWorktree, "shared.txt", "child version", "Child change")
+
+	mgr, err := stack.NewManager(parentWorktree)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	results, err := mgr.RebaseChildren(true) // useMerge=true
+	if err != nil {
+		t.Fatalf("RebaseChildren(merge) failed: %v", err)
+	}
+
+	// Should have conflict
+	foundConflict := false
+	for _, r := range results {
+		if r.HasConflict {
+			foundConflict = true
+		}
+	}
+	if !foundConflict {
+		t.Error("Expected merge conflict when syncing children with conflicting changes")
+	}
+
+	// Abort merge to clean up
+	exec.Command("git", "-C", childWorktree, "merge", "--abort").Run()
+}
+
+// TestRebaseChildren_MergeMultipleChildren tests merge with multiple children
+func TestRebaseChildren_MergeMultipleChildren(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Create: main -> parent -> child-a, parent -> child-b
+	CreateBranchWithCommit(t, env, "parent", "main")
+	CreateBranchWithCommit(t, env, "child-a", "parent")
+	CreateBranchWithCommit(t, env, "child-b", "parent")
+
+	// Add commit to parent
+	parentWorktree := filepath.Join(env.WorktreeDir, "parent")
+	GitCommit(t, parentWorktree, "parent-new.txt", "new content", "New parent commit")
+
+	mgr, err := stack.NewManager(parentWorktree)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	results, err := mgr.RebaseChildren(true)
+	if err != nil {
+		t.Fatalf("RebaseChildren(merge) failed: %v", err)
+	}
+
+	successCount := 0
+	for _, r := range results {
+		if r.HasConflict {
+			t.Errorf("Unexpected conflict in %s", r.Branch)
+		}
+		if r.Success {
+			successCount++
+		}
+	}
+
+	if successCount < 2 {
+		t.Errorf("Expected at least 2 successful syncs, got %d", successCount)
+	}
+
+	// Verify both children have the new file
+	for _, child := range []string{"child-a", "child-b"} {
+		childWorktree := filepath.Join(env.WorktreeDir, child)
+		if _, err := os.Stat(filepath.Join(childWorktree, "parent-new.txt")); os.IsNotExist(err) {
+			t.Errorf("parent-new.txt should exist in %s after merge", child)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add per-repo `sync_strategy` config setting (`"rebase"` or `"merge"`) to control the default sync method across all commands
- Add `--merge` and `--rebase` flags to `ezs sync`, `ezs commit`, `ezs amend`, and `ezs reparent` — flags override the config
- `ezs config set sync_strategy merge` or interactive `ezs config` to configure
- When merge is used: regular push (not force push), `git merge --continue` in conflict messages, merge-appropriate UI text

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `SyncStrategy` field to `RepoConfig`, add `GetSyncStrategy()` getter |
| `cmd/ezs/commands/config.go` | Add `sync_strategy` to `set`, `show`, and interactive config |
| `cmd/ezs/commands/sync.go` | Add `--rebase` flag, resolve merge/rebase from config when no flag given |
| `cmd/ezs/commands/commit.go` | Add `--merge`/`--rebase` flags, thread through `RebaseChildren` call |
| `cmd/ezs/commands/reparent.go` | Add `--merge`/`--rebase` flags, thread through `ReparentBranch`, adapt push/conflict messages |
| `internal/stack/stack.go` | Add `useMerge` variadic param to `ReparentBranch`, use merge in reparent internals |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [ ] `ezs config set sync_strategy merge` → verify `ezs config show` displays it
- [ ] `ezs sync` uses merge by default after config set
- [ ] `ezs sync --rebase` overrides config to use rebase
- [ ] `ezs commit -m "test" --merge` merges children instead of rebasing
- [ ] `ezs reparent --merge` uses merge during reparent
- [ ] `ezs sync --merge --rebase` returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)