### PR TITLE
feat(vscode): file explorer, folder decorations, and cross-stack navigation

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -17,8 +17,7 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:.git",
-    "onStartupFinished"
+    "workspaceContains:.git"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -137,9 +136,9 @@
       },
       {
         "command": "ezstack.openWorktree",
-        "title": "Open Worktree Folder",
+        "title": "Open in New Window",
         "category": "ezstack",
-        "icon": "$(folder-opened)"
+        "icon": "$(multiple-windows)"
       },
       {
         "command": "ezstack.renameStack",
@@ -437,42 +436,66 @@
       {
         "id": "ezstack.stack0",
         "description": "Color for stack group 0",
-        "defaults": { "dark": "#4FC1FF", "light": "#0066CC" }
+        "defaults": {
+          "dark": "#4FC1FF",
+          "light": "#0066CC"
+        }
       },
       {
         "id": "ezstack.stack1",
         "description": "Color for stack group 1",
-        "defaults": { "dark": "#C586C0", "light": "#AF00AF" }
+        "defaults": {
+          "dark": "#C586C0",
+          "light": "#AF00AF"
+        }
       },
       {
         "id": "ezstack.stack2",
         "description": "Color for stack group 2",
-        "defaults": { "dark": "#4EC9B0", "light": "#008060" }
+        "defaults": {
+          "dark": "#4EC9B0",
+          "light": "#008060"
+        }
       },
       {
         "id": "ezstack.stack3",
         "description": "Color for stack group 3",
-        "defaults": { "dark": "#DCDCAA", "light": "#795E26" }
+        "defaults": {
+          "dark": "#DCDCAA",
+          "light": "#795E26"
+        }
       },
       {
         "id": "ezstack.stack4",
         "description": "Color for stack group 4",
-        "defaults": { "dark": "#CE9178", "light": "#A31515" }
+        "defaults": {
+          "dark": "#CE9178",
+          "light": "#A31515"
+        }
       },
       {
         "id": "ezstack.stack5",
         "description": "Color for stack group 5",
-        "defaults": { "dark": "#D7BA7D", "light": "#B5651D" }
+        "defaults": {
+          "dark": "#D7BA7D",
+          "light": "#B5651D"
+        }
       },
       {
         "id": "ezstack.stack6",
         "description": "Color for stack group 6",
-        "defaults": { "dark": "#9CDCFE", "light": "#001080" }
+        "defaults": {
+          "dark": "#9CDCFE",
+          "light": "#001080"
+        }
       },
       {
         "id": "ezstack.stack7",
         "description": "Color for stack group 7",
-        "defaults": { "dark": "#F48771", "light": "#CD3131" }
+        "defaults": {
+          "dark": "#F48771",
+          "light": "#CD3131"
+        }
       }
     ],
     "configuration": {
@@ -487,6 +510,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically refresh stack view when config changes"
+        },
+        "ezstack.ticketPattern": {
+          "type": "string",
+          "default": "",
+          "description": "Regex pattern to extract ticket IDs from branch names (e.g. \"PROJ-\\d+\"). The first match is shown in the status bar and folder badges. Leave empty to disable."
         }
       }
     }
@@ -506,6 +534,6 @@
     "@vscode/vsce": "^2.22.0",
     "esbuild": "^0.19.0",
     "eslint": "^8.50.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -17,7 +17,8 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:.git"
+    "workspaceContains:.git",
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -35,6 +36,10 @@
         {
           "id": "ezstackStacks",
           "name": "Stacks"
+        },
+        {
+          "id": "ezstackFiles",
+          "name": "Files"
         }
       ]
     },
@@ -141,10 +146,100 @@
         "title": "Rename Stack",
         "category": "ezstack",
         "icon": "$(edit)"
+      },
+      {
+        "command": "ezstack.toggleFavorite",
+        "title": "Toggle Favorite",
+        "category": "ezstack",
+        "icon": "$(star)"
+      },
+      {
+        "command": "ezstack.filterFavorites",
+        "title": "Filter by Favorites",
+        "category": "ezstack",
+        "icon": "$(star-empty)"
+      },
+      {
+        "command": "ezstack.showAll",
+        "title": "Show All Files",
+        "category": "ezstack",
+        "icon": "$(star-full)"
+      },
+      {
+        "command": "ezstack.copyPath",
+        "title": "Copy Path",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.copyRelativePath",
+        "title": "Copy Relative Path",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.revealInFinder",
+        "title": "Reveal in Finder",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.openInTerminal",
+        "title": "Open in Integrated Terminal",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.revealInExplorer",
+        "title": "Reveal in Explorer",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.openBranchTerminal",
+        "title": "Open in Terminal",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.gitPull",
+        "title": "Fetch & Pull",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.openInNextPR",
+        "title": "Open File in Next PR",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.openInPreviousPR",
+        "title": "Open File in Previous PR",
+        "category": "ezstack"
+      },
+      {
+        "command": "ezstack.compareWithPreviousPR",
+        "title": "Compare File with Previous PR",
+        "category": "ezstack"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "ezstack.openInNextPR",
+        "key": "cmd+alt+down",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "ezstack.openInPreviousPR",
+        "key": "cmd+alt+up",
+        "when": "editorTextFocus"
       }
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "ezstack.filterFavorites",
+          "when": "view == ezstackFiles && !ezstack.filterByFavorites",
+          "group": "navigation"
+        },
+        {
+          "command": "ezstack.showAll",
+          "when": "view == ezstackFiles && ezstack.filterByFavorites",
+          "group": "navigation"
+        },
         {
           "command": "ezstack.refresh",
           "when": "view == ezstackStacks",
@@ -166,7 +261,91 @@
           "group": "navigation"
         }
       ],
+      "editor/title/context": [
+        {
+          "command": "ezstack.openInNextPR",
+          "when": "ezstack.hasNextPR",
+          "group": "ezstack@1"
+        },
+        {
+          "command": "ezstack.openInPreviousPR",
+          "when": "ezstack.hasPreviousPR",
+          "group": "ezstack@2"
+        },
+        {
+          "command": "ezstack.compareWithPreviousPR",
+          "when": "ezstack.hasPreviousPR",
+          "group": "ezstack@3"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "ezstack.openInNextPR",
+          "when": "ezstack.hasNextPR",
+          "group": "ezstack@1"
+        },
+        {
+          "command": "ezstack.openInPreviousPR",
+          "when": "ezstack.hasPreviousPR",
+          "group": "ezstack@2"
+        },
+        {
+          "command": "ezstack.compareWithPreviousPR",
+          "when": "ezstack.hasPreviousPR",
+          "group": "ezstack@3"
+        }
+      ],
       "view/item/context": [
+        {
+          "command": "ezstack.toggleFavorite",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "inline"
+        },
+        {
+          "command": "ezstack.copyPath",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "1_path@1"
+        },
+        {
+          "command": "ezstack.copyRelativePath",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "1_path@2"
+        },
+        {
+          "command": "ezstack.revealInFinder",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "2_system@1"
+        },
+        {
+          "command": "ezstack.openInTerminal",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "2_system@2"
+        },
+        {
+          "command": "ezstack.revealInExplorer",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "2_system@3"
+        },
+        {
+          "command": "ezstack.openInNextPR",
+          "when": "view == ezstackFiles && viewItem =~ /^(file|favoriteFile)$/ && ezstack.hasNextPR",
+          "group": "3_stack@1"
+        },
+        {
+          "command": "ezstack.openInPreviousPR",
+          "when": "view == ezstackFiles && viewItem =~ /^(file|favoriteFile)$/ && ezstack.hasPreviousPR",
+          "group": "3_stack@2"
+        },
+        {
+          "command": "ezstack.compareWithPreviousPR",
+          "when": "view == ezstackFiles && viewItem =~ /^(file|favoriteFile)$/ && ezstack.hasPreviousPR",
+          "group": "3_stack@3"
+        },
+        {
+          "command": "ezstack.toggleFavorite",
+          "when": "view == ezstackFiles && viewItem =~ /^(folder|file|favoriteFolder|favoriteFile)$/",
+          "group": "4_favorite@1"
+        },
         {
           "command": "ezstack.renameStack",
           "when": "view == ezstackStacks && viewItem == stack",
@@ -181,6 +360,26 @@
           "command": "ezstack.openPR",
           "when": "view == ezstackStacks && viewItem == branchWithPR",
           "group": "inline"
+        },
+        {
+          "command": "ezstack.openBranchTerminal",
+          "when": "view == ezstackStacks && viewItem =~ /^(branch|rootRepo)/",
+          "group": "0_terminal@1"
+        },
+        {
+          "command": "ezstack.newBranch",
+          "when": "view == ezstackStacks && viewItem == rootRepo",
+          "group": "1_actions@1"
+        },
+        {
+          "command": "ezstack.gitPull",
+          "when": "view == ezstackStacks && viewItem == rootRepo",
+          "group": "1_actions@2"
+        },
+        {
+          "command": "ezstack.sync",
+          "when": "view == ezstackStacks && viewItem == rootRepo",
+          "group": "1_actions@3"
         },
         {
           "command": "ezstack.push",
@@ -234,6 +433,48 @@
         }
       ]
     },
+    "colors": [
+      {
+        "id": "ezstack.stack0",
+        "description": "Color for stack group 0",
+        "defaults": { "dark": "#4FC1FF", "light": "#0066CC" }
+      },
+      {
+        "id": "ezstack.stack1",
+        "description": "Color for stack group 1",
+        "defaults": { "dark": "#C586C0", "light": "#AF00AF" }
+      },
+      {
+        "id": "ezstack.stack2",
+        "description": "Color for stack group 2",
+        "defaults": { "dark": "#4EC9B0", "light": "#008060" }
+      },
+      {
+        "id": "ezstack.stack3",
+        "description": "Color for stack group 3",
+        "defaults": { "dark": "#DCDCAA", "light": "#795E26" }
+      },
+      {
+        "id": "ezstack.stack4",
+        "description": "Color for stack group 4",
+        "defaults": { "dark": "#CE9178", "light": "#A31515" }
+      },
+      {
+        "id": "ezstack.stack5",
+        "description": "Color for stack group 5",
+        "defaults": { "dark": "#D7BA7D", "light": "#B5651D" }
+      },
+      {
+        "id": "ezstack.stack6",
+        "description": "Color for stack group 6",
+        "defaults": { "dark": "#9CDCFE", "light": "#001080" }
+      },
+      {
+        "id": "ezstack.stack7",
+        "description": "Color for stack group 7",
+        "defaults": { "dark": "#F48771", "light": "#CD3131" }
+      }
+    ],
     "configuration": {
       "title": "ezstack",
       "properties": {

--- a/vscode-extension/src/branchUtils.ts
+++ b/vscode-extension/src/branchUtils.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+
+/** Returns the user-configured ticket regex, or undefined if not set / invalid. */
+export function getTicketRegex(): RegExp | undefined {
+  const pattern = vscode.workspace
+    .getConfiguration("ezstack")
+    .get<string>("ticketPattern", "");
+  if (!pattern) {
+    return undefined;
+  }
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Extract a ticket label from a branch name using the configured pattern. */
+export function extractTicket(branchName: string): string | undefined {
+  const re = getTicketRegex();
+  if (!re) {
+    return undefined;
+  }
+  const match = branchName.match(re);
+  return match ? match[0] : undefined;
+}
+
+/** Extract a short display name from a dotted branch name (last segment). */
+export function shortBranchName(branchName: string): string {
+  const parts = branchName.split(".");
+  return parts.length > 1 ? parts[parts.length - 1] : branchName;
+}

--- a/vscode-extension/src/commands/fileNavigation.ts
+++ b/vscode-extension/src/commands/fileNavigation.ts
@@ -1,0 +1,212 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import { FolderDecorationProvider } from "../views/folderDecorations";
+
+interface FileArg {
+  absolutePath?: string;
+}
+
+/** Resolve a file URI from either a tree node argument or the active editor. */
+function resolveFileUri(node?: FileArg): vscode.Uri | undefined {
+  if (node?.absolutePath) {
+    return vscode.Uri.file(node.absolutePath);
+  }
+  return vscode.window.activeTextEditor?.document.uri;
+}
+
+export function registerFileNavigationCommands(
+  context: vscode.ExtensionContext,
+  decorations: FolderDecorationProvider,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.openInNextPR",
+      (node?: FileArg) => navigateFile(decorations, "next", node),
+    ),
+    vscode.commands.registerCommand(
+      "ezstack.openInPreviousPR",
+      (node?: FileArg) => navigateFile(decorations, "prev", node),
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.compareWithPreviousPR",
+      (node?: FileArg) => compareWithPrevious(decorations, node),
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() =>
+      updateContextKeys(decorations),
+    ),
+  );
+}
+
+async function navigateFile(
+  decorations: FolderDecorationProvider,
+  direction: "next" | "prev",
+  node?: FileArg,
+): Promise<void> {
+  const fileUri = resolveFileUri(node);
+  if (!fileUri) {
+    vscode.window.showInformationMessage("No file selected.");
+    return;
+  }
+
+  const ctx = decorations.getContextForUri(fileUri);
+  if (!ctx || !ctx.branch.worktree_path) {
+    vscode.window.showInformationMessage(
+      "File is not in a tracked stack worktree.",
+    );
+    return;
+  }
+
+  const neighbors = decorations.getNeighbors(ctx.branch.worktree_path);
+  if (!neighbors) {
+    return;
+  }
+
+  const target = direction === "next" ? neighbors.next : neighbors.prev;
+  if (!target) {
+    const label = direction === "next" ? "next" : "previous";
+    vscode.window.showInformationMessage(`No ${label} PR in the stack.`);
+    return;
+  }
+
+  if (!target.worktree_path) {
+    const parts = target.name.split(".");
+    const name = parts.length > 1 ? parts[parts.length - 1] : target.name;
+    vscode.window.showWarningMessage(
+      `Worktree for "${name}" does not exist locally.`,
+    );
+    return;
+  }
+
+  const relativePath = path.relative(
+    ctx.branch.worktree_path,
+    fileUri.fsPath,
+  );
+  const targetPath = path.join(target.worktree_path, relativePath);
+
+  try {
+    await fs.promises.access(targetPath);
+    const doc = await vscode.workspace.openTextDocument(
+      vscode.Uri.file(targetPath),
+    );
+    await vscode.window.showTextDocument(doc);
+  } catch {
+    const parts = target.name.split(".");
+    const name = parts.length > 1 ? parts[parts.length - 1] : target.name;
+    vscode.window.showWarningMessage(
+      `File does not exist in "${name}": ${relativePath}`,
+    );
+  }
+}
+
+async function compareWithPrevious(
+  decorations: FolderDecorationProvider,
+  node?: FileArg,
+): Promise<void> {
+  const fileUri = resolveFileUri(node);
+  if (!fileUri) {
+    vscode.window.showInformationMessage("No file selected.");
+    return;
+  }
+
+  const ctx = decorations.getContextForUri(fileUri);
+  if (!ctx || !ctx.branch.worktree_path) {
+    vscode.window.showInformationMessage(
+      "File is not in a tracked stack worktree.",
+    );
+    return;
+  }
+
+  const neighbors = decorations.getNeighbors(ctx.branch.worktree_path);
+  const prev = neighbors?.prev;
+  if (!prev) {
+    vscode.window.showInformationMessage(
+      "No previous PR in the stack to compare against.",
+    );
+    return;
+  }
+
+  if (!prev.worktree_path) {
+    const parts = prev.name.split(".");
+    const name = parts.length > 1 ? parts[parts.length - 1] : prev.name;
+    vscode.window.showWarningMessage(
+      `Worktree for "${name}" does not exist locally.`,
+    );
+    return;
+  }
+
+  const filePath = fileUri.fsPath;
+  const relativePath = path.relative(ctx.branch.worktree_path, filePath);
+  const prevPath = path.join(prev.worktree_path, relativePath);
+
+  try {
+    await fs.promises.access(prevPath);
+  } catch {
+    const parts = prev.name.split(".");
+    const name = parts.length > 1 ? parts[parts.length - 1] : prev.name;
+    vscode.window.showWarningMessage(
+      `File does not exist in "${name}": ${relativePath}`,
+    );
+    return;
+  }
+
+  const prevParts = prev.name.split(".");
+  const prevLabel =
+    prevParts.length > 1 ? prevParts[prevParts.length - 1] : prev.name;
+  const curParts = ctx.branch.name.split(".");
+  const curLabel =
+    curParts.length > 1 ? curParts[curParts.length - 1] : ctx.branch.name;
+  const fileName = path.basename(filePath);
+  const title = `${fileName}: ${prevLabel} ↔ ${curLabel}`;
+
+  await vscode.commands.executeCommand(
+    "vscode.diff",
+    vscode.Uri.file(prevPath),
+    vscode.Uri.file(filePath),
+    title,
+  );
+}
+
+export function updateContextKeys(
+  decorations: FolderDecorationProvider,
+): void {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.commands.executeCommand("setContext", "ezstack.hasNextPR", false);
+    vscode.commands.executeCommand(
+      "setContext",
+      "ezstack.hasPreviousPR",
+      false,
+    );
+    return;
+  }
+
+  const ctx = decorations.getContextForUri(editor.document.uri);
+  if (!ctx || !ctx.branch.worktree_path) {
+    vscode.commands.executeCommand("setContext", "ezstack.hasNextPR", false);
+    vscode.commands.executeCommand(
+      "setContext",
+      "ezstack.hasPreviousPR",
+      false,
+    );
+    return;
+  }
+
+  const neighbors = decorations.getNeighbors(ctx.branch.worktree_path);
+  vscode.commands.executeCommand(
+    "setContext",
+    "ezstack.hasNextPR",
+    !!neighbors?.next,
+  );
+  vscode.commands.executeCommand(
+    "setContext",
+    "ezstack.hasPreviousPR",
+    !!neighbors?.prev,
+  );
+}

--- a/vscode-extension/src/commands/fileNavigation.ts
+++ b/vscode-extension/src/commands/fileNavigation.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import { FolderDecorationProvider } from "../views/folderDecorations";
+import { shortBranchName } from "../branchUtils";
 
 interface FileArg {
   absolutePath?: string;
@@ -76,10 +77,8 @@ async function navigateFile(
   }
 
   if (!target.worktree_path) {
-    const parts = target.name.split(".");
-    const name = parts.length > 1 ? parts[parts.length - 1] : target.name;
     vscode.window.showWarningMessage(
-      `Worktree for "${name}" does not exist locally.`,
+      `Worktree for "${shortBranchName(target.name)}" does not exist locally.`,
     );
     return;
   }
@@ -97,10 +96,8 @@ async function navigateFile(
     );
     await vscode.window.showTextDocument(doc);
   } catch {
-    const parts = target.name.split(".");
-    const name = parts.length > 1 ? parts[parts.length - 1] : target.name;
     vscode.window.showWarningMessage(
-      `File does not exist in "${name}": ${relativePath}`,
+      `File does not exist in "${shortBranchName(target.name)}": ${relativePath}`,
     );
   }
 }
@@ -133,10 +130,8 @@ async function compareWithPrevious(
   }
 
   if (!prev.worktree_path) {
-    const parts = prev.name.split(".");
-    const name = parts.length > 1 ? parts[parts.length - 1] : prev.name;
     vscode.window.showWarningMessage(
-      `Worktree for "${name}" does not exist locally.`,
+      `Worktree for "${shortBranchName(prev.name)}" does not exist locally.`,
     );
     return;
   }
@@ -148,20 +143,14 @@ async function compareWithPrevious(
   try {
     await fs.promises.access(prevPath);
   } catch {
-    const parts = prev.name.split(".");
-    const name = parts.length > 1 ? parts[parts.length - 1] : prev.name;
     vscode.window.showWarningMessage(
-      `File does not exist in "${name}": ${relativePath}`,
+      `File does not exist in "${shortBranchName(prev.name)}": ${relativePath}`,
     );
     return;
   }
 
-  const prevParts = prev.name.split(".");
-  const prevLabel =
-    prevParts.length > 1 ? prevParts[prevParts.length - 1] : prev.name;
-  const curParts = ctx.branch.name.split(".");
-  const curLabel =
-    curParts.length > 1 ? curParts[curParts.length - 1] : ctx.branch.name;
+  const prevLabel = shortBranchName(prev.name);
+  const curLabel = shortBranchName(ctx.branch.name);
   const fileName = path.basename(filePath);
   const title = `${fileName}: ${prevLabel} ↔ ${curLabel}`;
 

--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { EzsCli } from "../ezsCli";
-import { StackTreeProvider, StackNode, BranchNode, StackTreeItem } from "../views/stackTreeProvider";
+import { StackTreeProvider, StackNode, BranchNode, RootRepoNode, StackTreeItem } from "../views/stackTreeProvider";
 import { StatusBarManager } from "../views/statusBarManager";
 
 const PR_TEMPLATE_PATHS = [
@@ -79,7 +79,6 @@ export function registerCommands(
     vscode.commands.registerCommand("ezstack.expandAll", async () => {
       const roots = await treeProvider.getChildren();
       for (const root of roots) {
-        // expand: number sets depth — 10 is more than enough for any stack
         await treeView.reveal(root, { expand: 10 });
       }
     }),
@@ -98,7 +97,6 @@ export function registerCommands(
           return;
         }
 
-        // Pick a parent — scope to the stack if invoked from a stack node
         let parent: string | undefined;
         try {
           if (node instanceof StackNode) {
@@ -145,7 +143,6 @@ export function registerCommands(
       "ezstack.sync",
       async (node?: StackNode) => {
         if (node instanceof StackNode) {
-          // Invoked from a stack context — sync that stack directly
           cli.syncInteractive("stack");
           return;
         }
@@ -160,7 +157,6 @@ export function registerCommands(
         if (!mode) {
           return;
         }
-        // Sync is interactive (may have conflicts), so run in terminal
         cli.syncInteractive(mode.value);
       },
     ),
@@ -191,12 +187,10 @@ export function registerCommands(
     vscode.commands.registerCommand(
       "ezstack.prCreate",
       async (node?: BranchNode) => {
-        // Determine which branch to create the PR for
         let branchName: string | undefined;
         if (node) {
           branchName = node.branch.name;
         } else {
-          // Pick from list
           const stacks = await cli.listStacks(true);
           const branches = stacks
             .flatMap((s) => s.branches)
@@ -240,7 +234,6 @@ export function registerCommands(
           return;
         }
 
-        // Open an editor for the PR description
         const workspaceRoot =
           vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
         const template = findPRTemplate(workspaceRoot);
@@ -262,7 +255,6 @@ export function registerCommands(
           return;
         }
 
-        // Read body from the editor that's still open
         const body = doc.getText().trim();
         await vscode.commands.executeCommand(
           "workbench.action.closeActiveEditor",
@@ -375,9 +367,7 @@ export function registerCommands(
         }
 
         const uri = vscode.Uri.file(pick.worktreePath);
-        await vscode.commands.executeCommand("vscode.openFolder", uri, {
-          forceNewWindow: false,
-        });
+        await vscode.commands.executeCommand("revealInExplorer", uri);
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         vscode.window.showErrorMessage(`Failed to list branches: ${msg}`);
@@ -405,7 +395,6 @@ export function registerCommands(
           .flatMap((s) => s.branches)
           .find((b) => b.name === current.parent);
         if (!parent) {
-          // Parent is the stack root (e.g., main) — not in branches list
           vscode.window.showInformationMessage(
             `Parent "${current.parent}" is the stack root.`,
           );
@@ -418,9 +407,7 @@ export function registerCommands(
           return;
         }
         const uri = vscode.Uri.file(parent.worktree_path);
-        await vscode.commands.executeCommand("vscode.openFolder", uri, {
-          forceNewWindow: false,
-        });
+        await vscode.commands.executeCommand("revealInExplorer", uri);
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         vscode.window.showErrorMessage(`Failed to navigate up: ${msg}`);
@@ -463,9 +450,7 @@ export function registerCommands(
         }
         if (target.worktree_path) {
           const uri = vscode.Uri.file(target.worktree_path);
-          await vscode.commands.executeCommand("vscode.openFolder", uri, {
-            forceNewWindow: false,
-          });
+          await vscode.commands.executeCommand("revealInExplorer", uri);
         }
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -569,7 +554,6 @@ export function registerCommands(
         if (node?.branch.pr_url) {
           prUrl = node.branch.pr_url;
         } else {
-          // No node context — pick from branches with PRs
           try {
             const stacks = await cli.listStacks(true);
             const withPRs = stacks
@@ -603,7 +587,7 @@ export function registerCommands(
     ),
   );
 
-  // ── Open Worktree Folder ──
+  // ── Open Worktree Folder (new window) ──
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "ezstack.openWorktree",
@@ -619,7 +603,7 @@ export function registerCommands(
         }
         const uri = vscode.Uri.file(worktreePath);
         await vscode.commands.executeCommand("vscode.openFolder", uri, {
-          forceNewWindow: false,
+          forceNewWindow: true,
         });
       },
     ),
@@ -637,7 +621,6 @@ export function registerCommands(
           stackHash = node.stack.hash;
           currentName = node.stack.name;
         } else {
-          // No node context — pick a stack from the list
           const stacks = await cli.listStacks(true);
           if (stacks.length === 0) {
             vscode.window.showInformationMessage("No stacks found.");
@@ -665,7 +648,6 @@ export function registerCommands(
           placeHolder: "my-feature",
           value: currentName ?? "",
         });
-        // undefined means the user pressed Escape
         if (newName === undefined) {
           return;
         }
@@ -677,6 +659,41 @@ export function registerCommands(
             : `Cleared name for stack ${stackHash}.`,
           () => cli.renameStack(stackHash!, newName),
         );
+      },
+    ),
+  );
+
+  // ── Open Branch in Terminal ──
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.openBranchTerminal",
+      (node?: BranchNode | RootRepoNode) => {
+        let cwd: string | undefined;
+        if (node instanceof BranchNode) {
+          cwd = node.branch.worktree_path;
+        } else if (node instanceof RootRepoNode) {
+          cwd = node.repoPath;
+        }
+        if (cwd) {
+          const terminal = vscode.window.createTerminal({ cwd });
+          terminal.show();
+        }
+      },
+    ),
+  );
+
+  // ── Fetch & Pull ──
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.gitPull",
+      (node?: RootRepoNode) => {
+        const cwd = node instanceof RootRepoNode ? node.repoPath : cli.getWorkspaceRoot();
+        const terminal = vscode.window.createTerminal({
+          name: "ezstack: fetch & pull",
+          cwd,
+        });
+        terminal.show();
+        terminal.sendText("git fetch && git pull");
       },
     ),
   );

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,9 +1,16 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { EzsCli } from "./ezsCli";
 import { StackTreeProvider } from "./views/stackTreeProvider";
+import { FileTreeProvider } from "./views/fileTreeProvider";
 import { StatusBarManager } from "./views/statusBarManager";
+import { FolderDecorationProvider } from "./views/folderDecorations";
 import { ConfigWatcher } from "./configWatcher";
 import { registerCommands } from "./commands/index";
+import {
+  registerFileNavigationCommands,
+  updateContextKeys,
+} from "./commands/fileNavigation";
 
 export async function activate(
   context: vscode.ExtensionContext,
@@ -15,13 +22,114 @@ export async function activate(
 
   const cli = new EzsCli(workspaceRoot);
 
-  // Always register tree view and commands first
+  // Stack overview tree (top panel)
   const treeProvider = new StackTreeProvider(cli);
   const treeView = vscode.window.createTreeView("ezstackStacks", {
     treeDataProvider: treeProvider,
     showCollapseAll: true,
   });
   context.subscriptions.push(treeView);
+
+  // File explorer tree (bottom panel)
+  const fileTreeProvider = new FileTreeProvider();
+  fileTreeProvider.initStorage(context.globalState);
+  const fileTreeView = vscode.window.createTreeView("ezstackFiles", {
+    treeDataProvider: fileTreeProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(fileTreeView, fileTreeProvider);
+
+  // Track expand/collapse for per-branch state persistence
+  context.subscriptions.push(...fileTreeProvider.bindTreeView(fileTreeView));
+
+  // Update file tree title when branch is selected
+  fileTreeProvider.onDidSelectBranch((worktreePath) => {
+    const branchName = path.basename(worktreePath);
+    fileTreeView.title = `Files: ${branchName}`;
+  });
+
+  // Command to select a branch for the file explorer
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.selectBranch",
+      (worktreePath: string) => {
+        const gitStatus = treeProvider.getGitStatus(worktreePath);
+        fileTreeProvider.selectBranch(worktreePath, gitStatus);
+      },
+    ),
+  );
+
+  // Favorites commands
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ezstack.toggleFavorite",
+      (node: { absolutePath: string }) => {
+        if (node?.absolutePath) {
+          fileTreeProvider.toggleFavorite(node.absolutePath);
+        }
+      },
+    ),
+    vscode.commands.registerCommand("ezstack.filterFavorites", () => {
+      fileTreeProvider.setFilterByFavorites(true);
+    }),
+    vscode.commands.registerCommand("ezstack.showAll", () => {
+      fileTreeProvider.setFilterByFavorites(false);
+    }),
+    vscode.commands.registerCommand(
+      "ezstack.copyPath",
+      (node: { absolutePath: string }) => {
+        if (node?.absolutePath) {
+          vscode.env.clipboard.writeText(node.absolutePath);
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
+      "ezstack.copyRelativePath",
+      (node: { absolutePath: string }) => {
+        if (node?.absolutePath) {
+          const selected = fileTreeProvider.getSelectedWorktree();
+          const rel = selected
+            ? path.relative(selected, node.absolutePath)
+            : node.absolutePath;
+          vscode.env.clipboard.writeText(rel);
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
+      "ezstack.revealInFinder",
+      (node: { absolutePath: string }) => {
+        if (node?.absolutePath) {
+          vscode.commands.executeCommand(
+            "revealFileInOS",
+            vscode.Uri.file(node.absolutePath),
+          );
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
+      "ezstack.openInTerminal",
+      (node: { absolutePath: string; isDirectory: boolean }) => {
+        if (node?.absolutePath) {
+          const dir = node.isDirectory
+            ? node.absolutePath
+            : path.dirname(node.absolutePath);
+          const terminal = vscode.window.createTerminal({ cwd: dir });
+          terminal.show();
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
+      "ezstack.revealInExplorer",
+      (node: { absolutePath: string }) => {
+        if (node?.absolutePath) {
+          vscode.commands.executeCommand(
+            "revealInExplorer",
+            vscode.Uri.file(node.absolutePath),
+          );
+        }
+      },
+    ),
+  );
 
   const statusBar = new StatusBarManager(cli);
   context.subscriptions.push(statusBar);
@@ -37,8 +145,48 @@ export async function activate(
     return;
   }
 
+  // Folder decorations (colored badges on workspace folders)
+  const decorations = new FolderDecorationProvider(cli);
+  context.subscriptions.push(
+    vscode.window.registerFileDecorationProvider(decorations),
+    decorations,
+  );
+  await decorations.refresh();
+
+  // File navigation commands (open in next/prev PR, compare with prev)
+  registerFileNavigationCommands(context, decorations);
+  updateContextKeys(decorations);
+
   // Now that we know ezs works, do the initial data load
   await statusBar.update();
+
+  // Follow active editor: switch file tree to the branch containing the focused file
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (!editor) {
+        return;
+      }
+      const filePath = editor.document.uri.fsPath;
+      const stacks = treeProvider.getStacks();
+      for (const stack of stacks) {
+        for (const branch of stack.branches) {
+          if (
+            branch.worktree_path &&
+            filePath.startsWith(branch.worktree_path + path.sep)
+          ) {
+            const currentSelection = fileTreeProvider.getSelectedWorktree();
+            if (currentSelection !== branch.worktree_path) {
+              const gitStatus = treeProvider.getGitStatus(
+                branch.worktree_path,
+              );
+              fileTreeProvider.selectBranch(branch.worktree_path, gitStatus);
+            }
+            return;
+          }
+        }
+      }
+    }),
+  );
 
   // Config watcher for auto-refresh
   const autoRefresh = vscode.workspace
@@ -55,10 +203,25 @@ export async function activate(
       debounceTimer = setTimeout(() => {
         treeProvider.refresh();
         statusBar.update();
+        decorations.refresh();
       }, 500);
     });
     context.subscriptions.push(watcher);
   }
+
+  // Refresh git status on file save (debounced)
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument(() => {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+      }
+      saveTimer = setTimeout(() => {
+        treeProvider.refresh();
+        fileTreeProvider.refresh();
+      }, 300);
+    }),
+  );
 
   // Listen for terminal close to refresh (after interactive commands)
   context.subscriptions.push(
@@ -67,6 +230,8 @@ export async function activate(
         setTimeout(() => {
           treeProvider.refresh();
           statusBar.update();
+          decorations.refresh();
+          fileTreeProvider.refresh();
         }, 1000);
       }
     }),

--- a/vscode-extension/src/ezsCli.ts
+++ b/vscode-extension/src/ezsCli.ts
@@ -7,6 +7,7 @@ import {
   StackJSON,
   StatusStackJSON,
   SyncInfoJSON,
+  WorktreeGitStatus,
 } from "./types";
 
 const COMMON_PATHS = [
@@ -49,6 +50,10 @@ export class EzsCli {
     private workspaceRoot: string,
   ) {
     this.outputChannel = vscode.window.createOutputChannel("ezstack");
+  }
+
+  getWorkspaceRoot(): string {
+    return this.workspaceRoot;
   }
 
   getOutputChannel(): vscode.OutputChannel {
@@ -134,13 +139,19 @@ export class EzsCli {
     return terminal;
   }
 
+  /** Fetch and pull in the given directory. */
+  async gitFetchPull(cwd?: string): Promise<void> {
+    await this.execGit(["fetch"], cwd);
+    await this.execGit(["pull"], cwd);
+  }
+
   /** Run a git command and return stdout. */
-  private execGit(args: string[]): Promise<string> {
+  private execGit(args: string[], cwd?: string): Promise<string> {
     return new Promise((resolve, reject) => {
       execFile(
         "git",
         args,
-        { cwd: this.workspaceRoot, timeout: 10_000 },
+        { cwd: cwd ?? this.workspaceRoot, timeout: 10_000 },
         (error, stdout) => {
           if (error) {
             reject(new Error(error.message));
@@ -150,6 +161,74 @@ export class EzsCli {
         },
       );
     });
+  }
+
+  /** Get git working tree status for a worktree directory. */
+  async getWorktreeGitStatus(worktreePath: string): Promise<WorktreeGitStatus> {
+    const result: WorktreeGitStatus = {
+      modified: 0,
+      staged: 0,
+      untracked: 0,
+      ahead: 0,
+      behind: 0,
+      files: new Map(),
+    };
+
+    try {
+      const porcelain = await this.execGit(
+        ["status", "--porcelain", "--branch"],
+        worktreePath,
+      );
+      const lines = porcelain.trim().split("\n").filter(Boolean);
+      for (const line of lines) {
+        if (line.startsWith("##")) {
+          const aheadMatch = line.match(/ahead (\d+)/);
+          const behindMatch = line.match(/behind (\d+)/);
+          if (aheadMatch) {
+            result.ahead = parseInt(aheadMatch[1], 10);
+          }
+          if (behindMatch) {
+            result.behind = parseInt(behindMatch[1], 10);
+          }
+          continue;
+        }
+        const indexChar = line[0];
+        const worktreeChar = line[1];
+        // File path starts at column 3; handle renames ("old -> new")
+        let filePath = line.substring(3);
+        const arrowIdx = filePath.indexOf(" -> ");
+        if (arrowIdx !== -1) {
+          filePath = filePath.substring(arrowIdx + 4);
+        }
+
+        if (indexChar === "?" && worktreeChar === "?") {
+          result.untracked++;
+          result.files.set(filePath, "untracked");
+        } else if (indexChar === "U" || worktreeChar === "U") {
+          result.files.set(filePath, "conflict");
+        } else {
+          const isStagedChange = indexChar !== " " && indexChar !== "?";
+          const isWorktreeChange = worktreeChar !== " " && worktreeChar !== "?";
+          if (isStagedChange) {
+            result.staged++;
+          }
+          if (isWorktreeChange) {
+            result.modified++;
+          }
+          if (isStagedChange && isWorktreeChange) {
+            result.files.set(filePath, "both");
+          } else if (isStagedChange) {
+            result.files.set(filePath, "staged");
+          } else {
+            result.files.set(filePath, "modified");
+          }
+        }
+      }
+    } catch {
+      // git status failed — return zeros
+    }
+
+    return result;
   }
 
   // ── Read operations ──

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -36,6 +36,20 @@ export interface StatusBranchJSON extends BranchJSON {
   deletions?: number;
 }
 
+/** Per-file git status indicator. */
+export type FileGitState = "modified" | "staged" | "untracked" | "both" | "conflict";
+
+/** Git working tree status for a worktree. */
+export interface WorktreeGitStatus {
+  modified: number;
+  staged: number;
+  untracked: number;
+  ahead: number;
+  behind: number;
+  /** Map of relative file path → git state. */
+  files: Map<string, FileGitState>;
+}
+
 /** Mirrors the Go syncInfoJSON struct from cmd/ezs/commands/sync.go */
 export interface SyncInfoJSON {
   branch: string;

--- a/vscode-extension/src/views/fileTreeProvider.ts
+++ b/vscode-extension/src/views/fileTreeProvider.ts
@@ -1,0 +1,316 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { FileGitState, WorktreeGitStatus } from "../types";
+
+const GIT_STATE_LABELS: Record<FileGitState, string> = {
+  modified: "M",
+  staged: "S",
+  untracked: "U",
+  both: "MS",
+  conflict: "!",
+};
+
+const GIT_STATE_COLORS: Record<FileGitState, string> = {
+  modified: "gitDecoration.modifiedResourceForeground",
+  staged: "gitDecoration.addedResourceForeground",
+  untracked: "gitDecoration.untrackedResourceForeground",
+  both: "gitDecoration.modifiedResourceForeground",
+  conflict: "gitDecoration.conflictingResourceForeground",
+};
+
+export class FileNode extends vscode.TreeItem {
+  constructor(
+    public readonly absolutePath: string,
+    public readonly isDirectory: boolean,
+    worktreeRoot: string,
+    isFavorite: boolean,
+    gitState?: FileGitState,
+    expanded?: boolean,
+  ) {
+    super(
+      path.basename(absolutePath),
+      isDirectory
+        ? expanded
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.Collapsed
+        : vscode.TreeItemCollapsibleState.None,
+    );
+
+    this.id = worktreeRoot + ":" + absolutePath;
+    this.resourceUri = vscode.Uri.file(absolutePath);
+
+    // Build description: git state + star indicator on the right
+    const descParts: string[] = [];
+    if (!isDirectory && gitState) {
+      descParts.push(GIT_STATE_LABELS[gitState]);
+    }
+    if (isFavorite) {
+      descParts.push("★");
+    }
+    if (descParts.length > 0) {
+      this.description = descParts.join(" ");
+    }
+
+    if (isDirectory) {
+      this.contextValue = isFavorite ? "favoriteFolder" : "folder";
+      this.iconPath = vscode.ThemeIcon.Folder;
+    } else {
+      this.contextValue = isFavorite ? "favoriteFile" : "file";
+      this.command = {
+        command: "vscode.open",
+        title: "Open File",
+        arguments: [vscode.Uri.file(absolutePath)],
+      };
+      if (gitState) {
+        this.iconPath = new vscode.ThemeIcon(
+          "file",
+          new vscode.ThemeColor(GIT_STATE_COLORS[gitState]),
+        );
+      } else {
+        this.iconPath = vscode.ThemeIcon.File;
+      }
+    }
+  }
+}
+
+const FAVORITES_STORAGE_KEY = "ezstack.favorites";
+
+export class FileTreeProvider implements vscode.TreeDataProvider<FileNode> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<
+    FileNode | undefined | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private worktreeRoot: string | undefined;
+  private gitStatus: WorktreeGitStatus | undefined;
+  private _onDidSelectBranch = new vscode.EventEmitter<string>();
+  readonly onDidSelectBranch = this._onDidSelectBranch.event;
+
+  private expandedState = new Map<string, Set<string>>();
+
+  /** Favorite relative paths (shared across all worktrees). */
+  private favorites = new Set<string>();
+  private filterByFavorites = false;
+  private globalState: vscode.Memento | undefined;
+
+  /** Load persisted favorites from extension globalState. */
+  initStorage(globalState: vscode.Memento): void {
+    this.globalState = globalState;
+    const saved = globalState.get<string[]>(FAVORITES_STORAGE_KEY, []);
+    this.favorites = new Set(saved);
+  }
+
+  private saveFavorites(): void {
+    this.globalState?.update(FAVORITES_STORAGE_KEY, [...this.favorites]);
+  }
+
+  toggleFavorite(absolutePath: string): void {
+    if (!this.worktreeRoot) {
+      return;
+    }
+    const relativePath = path.relative(this.worktreeRoot, absolutePath);
+    if (this.favorites.has(relativePath)) {
+      this.favorites.delete(relativePath);
+    } else {
+      this.favorites.add(relativePath);
+    }
+    this.saveFavorites();
+    this._onDidChangeTreeData.fire();
+  }
+
+  isFavorite(absolutePath: string): boolean {
+    if (!this.worktreeRoot) {
+      return false;
+    }
+    const relativePath = path.relative(this.worktreeRoot, absolutePath);
+    return this.favorites.has(relativePath);
+  }
+
+  /** Check if a path or any ancestor is a favorite. */
+  private isUnderFavorite(absolutePath: string): boolean {
+    if (!this.worktreeRoot) {
+      return false;
+    }
+    const relativePath = path.relative(this.worktreeRoot, absolutePath);
+    // Exact match
+    if (this.favorites.has(relativePath)) {
+      return true;
+    }
+    // Check if any favorite is a parent of this path
+    for (const fav of this.favorites) {
+      if (relativePath.startsWith(fav + path.sep)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Check if a directory contains any favorites (directly or nested). */
+  private containsFavorite(absolutePath: string): boolean {
+    if (!this.worktreeRoot) {
+      return false;
+    }
+    const relativePath = path.relative(this.worktreeRoot, absolutePath);
+    const prefix = relativePath + path.sep;
+    for (const fav of this.favorites) {
+      if (fav === relativePath || fav.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  setFilterByFavorites(enabled: boolean): void {
+    this.filterByFavorites = enabled;
+    vscode.commands.executeCommand(
+      "setContext",
+      "ezstack.filterByFavorites",
+      enabled,
+    );
+    this._onDidChangeTreeData.fire();
+  }
+
+  getFilterByFavorites(): boolean {
+    return this.filterByFavorites;
+  }
+
+  bindTreeView(treeView: vscode.TreeView<FileNode>): vscode.Disposable[] {
+    return [
+      treeView.onDidExpandElement((e) => {
+        if (this.worktreeRoot && e.element.isDirectory) {
+          this.getOrCreateExpanded(this.worktreeRoot).add(
+            e.element.absolutePath,
+          );
+        }
+      }),
+      treeView.onDidCollapseElement((e) => {
+        if (this.worktreeRoot && e.element.isDirectory) {
+          this.getOrCreateExpanded(this.worktreeRoot).delete(
+            e.element.absolutePath,
+          );
+        }
+      }),
+    ];
+  }
+
+  private getOrCreateExpanded(worktreePath: string): Set<string> {
+    let set = this.expandedState.get(worktreePath);
+    if (!set) {
+      set = new Set();
+      this.expandedState.set(worktreePath, set);
+    }
+    return set;
+  }
+
+  selectBranch(
+    worktreePath: string,
+    gitStatus?: WorktreeGitStatus,
+  ): void {
+    this.worktreeRoot = worktreePath;
+    this.gitStatus = gitStatus;
+    this._onDidSelectBranch.fire(worktreePath);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getSelectedWorktree(): string | undefined {
+    return this.worktreeRoot;
+  }
+
+  updateGitStatus(gitStatus?: WorktreeGitStatus): void {
+    this.gitStatus = gitStatus;
+    this._onDidChangeTreeData.fire();
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: FileNode): vscode.TreeItem {
+    return element;
+  }
+
+  private getFileGitState(
+    absolutePath: string,
+    isDirectory: boolean,
+  ): FileGitState | undefined {
+    if (!this.gitStatus || !this.worktreeRoot) {
+      return undefined;
+    }
+    const relativePath = path.relative(this.worktreeRoot, absolutePath);
+    if (!isDirectory) {
+      return this.gitStatus.files.get(relativePath);
+    }
+    const prefix = relativePath + path.sep;
+    for (const [filePath] of this.gitStatus.files) {
+      if (filePath.startsWith(prefix)) {
+        return "modified";
+      }
+    }
+    return undefined;
+  }
+
+  private isExpanded(absolutePath: string): boolean {
+    if (!this.worktreeRoot) {
+      return false;
+    }
+    const set = this.expandedState.get(this.worktreeRoot);
+    return set ? set.has(absolutePath) : false;
+  }
+
+  async getChildren(element?: FileNode): Promise<FileNode[]> {
+    const dirPath = element ? element.absolutePath : this.worktreeRoot;
+    if (!dirPath || !this.worktreeRoot) {
+      return [];
+    }
+
+    try {
+      const entries = await fs.promises.readdir(dirPath, {
+        withFileTypes: true,
+      });
+      const nodes: FileNode[] = [];
+      for (const entry of entries) {
+        if (entry.name.startsWith(".") || entry.name === "node_modules") {
+          continue;
+        }
+        const fullPath = path.join(dirPath, entry.name);
+        const isDir = entry.isDirectory();
+
+        // Filter by favorites: show items that are favorites, under a favorite,
+        // or (for directories) contain a favorite deeper inside
+        if (this.filterByFavorites) {
+          if (this.isUnderFavorite(fullPath)) {
+            // show — it's a favorite or inside one
+          } else if (isDir && this.containsFavorite(fullPath)) {
+            // show — it's a parent leading to a favorite
+          } else {
+            continue;
+          }
+        }
+
+        const gitState = this.getFileGitState(fullPath, isDir);
+        const fav = this.isFavorite(fullPath);
+        const expanded = isDir ? this.isExpanded(fullPath) : undefined;
+        nodes.push(
+          new FileNode(fullPath, isDir, this.worktreeRoot, fav, gitState, expanded),
+        );
+      }
+      nodes.sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) {
+          return a.isDirectory ? -1 : 1;
+        }
+        return path
+          .basename(a.absolutePath)
+          .localeCompare(path.basename(b.absolutePath));
+      });
+      return nodes;
+    } catch {
+      return [];
+    }
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+    this._onDidSelectBranch.dispose();
+  }
+}

--- a/vscode-extension/src/views/fileTreeProvider.ts
+++ b/vscode-extension/src/views/fileTreeProvider.ts
@@ -241,11 +241,37 @@ export class FileTreeProvider implements vscode.TreeDataProvider<FileNode> {
     if (!isDirectory) {
       return this.gitStatus.files.get(relativePath);
     }
+    // Aggregate: pick the most prominent state among children
     const prefix = relativePath + path.sep;
-    for (const [filePath] of this.gitStatus.files) {
-      if (filePath.startsWith(prefix)) {
-        return "modified";
+    let hasModified = false;
+    let hasStaged = false;
+    let hasUntracked = false;
+    let hasConflict = false;
+    for (const [filePath, state] of this.gitStatus.files) {
+      if (!filePath.startsWith(prefix)) {
+        continue;
       }
+      if (state === "conflict") {
+        hasConflict = true;
+      } else if (state === "modified" || state === "both") {
+        hasModified = true;
+      } else if (state === "staged") {
+        hasStaged = true;
+      } else if (state === "untracked") {
+        hasUntracked = true;
+      }
+    }
+    if (hasConflict) {
+      return "conflict";
+    }
+    if (hasModified) {
+      return "modified";
+    }
+    if (hasStaged) {
+      return "staged";
+    }
+    if (hasUntracked) {
+      return "untracked";
     }
     return undefined;
   }

--- a/vscode-extension/src/views/folderDecorations.ts
+++ b/vscode-extension/src/views/folderDecorations.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { EzsCli } from "../ezsCli";
 import { StackJSON, BranchJSON } from "../types";
+import { extractTicket, shortBranchName } from "../branchUtils";
 
-const TICKET_RE = /nos-(\d+)/i;
 const PALETTE_SIZE = 8;
 
 interface BranchContext {
@@ -11,14 +11,14 @@ interface BranchContext {
   branch: BranchJSON;
   position: number;
   stackSize: number;
-  ticketNumber: string | undefined;
+  ticket: string | undefined;
   colorIndex: number;
 }
 
-function colorIndexForTicket(ticketNumber: string): number {
+function colorIndexForHash(value: string): number {
   let hash = 0;
-  for (let i = 0; i < ticketNumber.length; i++) {
-    hash = ((hash << 5) - hash + ticketNumber.charCodeAt(i)) | 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
   }
   return ((hash % PALETTE_SIZE) + PALETTE_SIZE) % PALETTE_SIZE;
 }
@@ -70,15 +70,14 @@ export class FolderDecorationProvider
           continue;
         }
         const normalized = path.normalize(branch.worktree_path);
-        const match = branch.name.match(TICKET_RE);
-        const ticketNumber = match ? match[1] : undefined;
+        const ticket = extractTicket(branch.name);
         this.worktreeMap.set(normalized, {
           stack,
           branch,
           position: i,
           stackSize: stack.branches.length,
-          ticketNumber,
-          colorIndex: ticketNumber ? colorIndexForTicket(ticketNumber) : 0,
+          ticket,
+          colorIndex: ticket ? colorIndexForHash(ticket) : 0,
         });
       }
     }
@@ -97,10 +96,9 @@ export class FolderDecorationProvider
       ctx.position < 9
         ? String(ctx.position + 1)
         : String.fromCharCode(65 + ctx.position - 9);
-    const parts = ctx.branch.name.split(".");
-    const desc = parts.length > 1 ? parts[parts.length - 1] : ctx.branch.name;
-    const ticket = ctx.ticketNumber ? `NOS-${ctx.ticketNumber}` : "Stack";
-    const tooltip = `${ticket} [${ctx.position + 1}/${ctx.stackSize}] ${desc}`;
+    const desc = shortBranchName(ctx.branch.name);
+    const label = ctx.ticket ?? "Stack";
+    const tooltip = `${label} [${ctx.position + 1}/${ctx.stackSize}] ${desc}`;
 
     return {
       badge,

--- a/vscode-extension/src/views/folderDecorations.ts
+++ b/vscode-extension/src/views/folderDecorations.ts
@@ -1,0 +1,148 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { EzsCli } from "../ezsCli";
+import { StackJSON, BranchJSON } from "../types";
+
+const TICKET_RE = /nos-(\d+)/i;
+const PALETTE_SIZE = 8;
+
+interface BranchContext {
+  stack: StackJSON;
+  branch: BranchJSON;
+  position: number;
+  stackSize: number;
+  ticketNumber: string | undefined;
+  colorIndex: number;
+}
+
+function colorIndexForTicket(ticketNumber: string): number {
+  let hash = 0;
+  for (let i = 0; i < ticketNumber.length; i++) {
+    hash = ((hash << 5) - hash + ticketNumber.charCodeAt(i)) | 0;
+  }
+  return ((hash % PALETTE_SIZE) + PALETTE_SIZE) % PALETTE_SIZE;
+}
+
+export class FolderDecorationProvider
+  implements vscode.FileDecorationProvider, vscode.Disposable
+{
+  private readonly _onDidChangeFileDecorations =
+    new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
+  readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
+  private worktreeMap = new Map<string, BranchContext>();
+  private workspaceFolderPaths = new Set<string>();
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor(private readonly cli: EzsCli) {
+    this.refreshWorkspaceFolders();
+    this.disposables.push(this._onDidChangeFileDecorations);
+    this.disposables.push(
+      vscode.workspace.onDidChangeWorkspaceFolders(() => {
+        this.refreshWorkspaceFolders();
+        this._onDidChangeFileDecorations.fire(undefined);
+      }),
+    );
+  }
+
+  private refreshWorkspaceFolders(): void {
+    this.workspaceFolderPaths.clear();
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      this.workspaceFolderPaths.add(path.normalize(folder.uri.fsPath));
+    }
+  }
+
+  async refresh(): Promise<void> {
+    try {
+      const stacks = await this.cli.listStacks(true);
+      this.rebuildMap(stacks);
+    } catch {
+      this.worktreeMap.clear();
+    }
+    this._onDidChangeFileDecorations.fire(undefined);
+  }
+
+  private rebuildMap(stacks: StackJSON[]): void {
+    this.worktreeMap.clear();
+    for (const stack of stacks) {
+      for (let i = 0; i < stack.branches.length; i++) {
+        const branch = stack.branches[i];
+        if (!branch.worktree_path) {
+          continue;
+        }
+        const normalized = path.normalize(branch.worktree_path);
+        const match = branch.name.match(TICKET_RE);
+        const ticketNumber = match ? match[1] : undefined;
+        this.worktreeMap.set(normalized, {
+          stack,
+          branch,
+          position: i,
+          stackSize: stack.branches.length,
+          ticketNumber,
+          colorIndex: ticketNumber ? colorIndexForTicket(ticketNumber) : 0,
+        });
+      }
+    }
+  }
+
+  provideFileDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
+    const normalized = path.normalize(uri.fsPath);
+    if (!this.workspaceFolderPaths.has(normalized)) {
+      return undefined;
+    }
+    const ctx = this.worktreeMap.get(normalized);
+    if (!ctx) {
+      return undefined;
+    }
+    const badge =
+      ctx.position < 9
+        ? String(ctx.position + 1)
+        : String.fromCharCode(65 + ctx.position - 9);
+    const parts = ctx.branch.name.split(".");
+    const desc = parts.length > 1 ? parts[parts.length - 1] : ctx.branch.name;
+    const ticket = ctx.ticketNumber ? `NOS-${ctx.ticketNumber}` : "Stack";
+    const tooltip = `${ticket} [${ctx.position + 1}/${ctx.stackSize}] ${desc}`;
+
+    return {
+      badge,
+      tooltip,
+      color: new vscode.ThemeColor(
+        `ezstack.stack${ctx.colorIndex % PALETTE_SIZE}`,
+      ),
+    };
+  }
+
+  /** Look up a URI's branch context by walking up to find a worktree root. */
+  getContextForUri(uri: vscode.Uri): BranchContext | undefined {
+    let dir = uri.fsPath;
+    while (dir !== path.dirname(dir)) {
+      const ctx = this.worktreeMap.get(path.normalize(dir));
+      if (ctx) {
+        return ctx;
+      }
+      dir = path.dirname(dir);
+    }
+    return undefined;
+  }
+
+  /** Get adjacent branches for a given worktree path. */
+  getNeighbors(
+    worktreePath: string,
+  ): { prev?: BranchJSON; next?: BranchJSON } | undefined {
+    const ctx = this.worktreeMap.get(path.normalize(worktreePath));
+    if (!ctx) {
+      return undefined;
+    }
+    const branches = ctx.stack.branches;
+    return {
+      prev: ctx.position > 0 ? branches[ctx.position - 1] : undefined,
+      next:
+        ctx.position < branches.length - 1
+          ? branches[ctx.position + 1]
+          : undefined,
+    };
+  }
+
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose());
+  }
+}

--- a/vscode-extension/src/views/stackTreeProvider.ts
+++ b/vscode-extension/src/views/stackTreeProvider.ts
@@ -1,8 +1,23 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { EzsCli } from "../ezsCli";
-import { StatusStackJSON, StatusBranchJSON } from "../types";
+import { StatusStackJSON, StatusBranchJSON, WorktreeGitStatus } from "../types";
 
-export type StackTreeItem = StackNode | BranchNode;
+export type StackTreeItem = RootRepoNode | StackNode | BranchNode;
+
+export class RootRepoNode extends vscode.TreeItem {
+  constructor(public readonly repoPath: string) {
+    super(path.basename(repoPath), vscode.TreeItemCollapsibleState.None);
+    this.description = "main";
+    this.iconPath = new vscode.ThemeIcon("repo");
+    this.contextValue = "rootRepo";
+    this.command = {
+      command: "ezstack.selectBranch",
+      title: "Select Root Repo",
+      arguments: [repoPath],
+    };
+  }
+}
 
 export class StackNode extends vscode.TreeItem {
   constructor(public readonly stack: StatusStackJSON) {
@@ -21,6 +36,7 @@ export class BranchNode extends vscode.TreeItem {
     public readonly branch: StatusBranchJSON,
     public readonly stackHash: string,
     hasChildren: boolean,
+    gitStatus?: WorktreeGitStatus,
   ) {
     super(
       branch.name,
@@ -29,23 +45,25 @@ export class BranchNode extends vscode.TreeItem {
         : vscode.TreeItemCollapsibleState.None,
     );
 
-    this.description = BranchNode.buildDescription(branch);
-    this.iconPath = BranchNode.getIcon(branch);
+    this.description = BranchNode.buildDescription(branch, gitStatus);
+    this.iconPath = BranchNode.getIcon(branch, gitStatus);
     this.contextValue = branch.pr_number ? "branchWithPR" : "branch";
 
-    this.tooltip = BranchNode.buildTooltip(branch);
+    this.tooltip = BranchNode.buildTooltip(branch, gitStatus);
 
-    // Clicking a branch navigates to its worktree
     if (branch.worktree_path) {
       this.command = {
-        command: "ezstack.openWorktree",
-        title: "Open Worktree",
+        command: "ezstack.selectBranch",
+        title: "Select Branch",
         arguments: [branch.worktree_path],
       };
     }
   }
 
-  private static buildDescription(b: StatusBranchJSON): string {
+  private static buildDescription(
+    b: StatusBranchJSON,
+    git?: WorktreeGitStatus,
+  ): string {
     const parts: string[] = [];
     if (b.pr_number) {
       parts.push(`PR #${b.pr_number}`);
@@ -64,14 +82,50 @@ export class BranchNode extends vscode.TreeItem {
     if (b.additions || b.deletions) {
       parts.push(`+${b.additions ?? 0} -${b.deletions ?? 0}`);
     }
-    return parts.join(" ");
+
+    if (git) {
+      const gitParts: string[] = [];
+      if (git.staged > 0) {
+        gitParts.push(`+${git.staged}`);
+      }
+      if (git.modified > 0) {
+        gitParts.push(`~${git.modified}`);
+      }
+      if (git.untracked > 0) {
+        gitParts.push(`?${git.untracked}`);
+      }
+      if (gitParts.length > 0) {
+        parts.push(gitParts.join(" "));
+      }
+      if (git.ahead > 0 || git.behind > 0) {
+        const sync: string[] = [];
+        if (git.ahead > 0) {
+          sync.push(`↑${git.ahead}`);
+        }
+        if (git.behind > 0) {
+          sync.push(`↓${git.behind}`);
+        }
+        parts.push(sync.join(" "));
+      }
+    }
+
+    return parts.join("  ");
   }
 
-  private static getIcon(b: StatusBranchJSON): vscode.ThemeIcon {
+  private static getIcon(
+    b: StatusBranchJSON,
+    git?: WorktreeGitStatus,
+  ): vscode.ThemeIcon {
     if (b.is_merged) {
       return new vscode.ThemeIcon(
         "git-merge",
         new vscode.ThemeColor("gitDecoration.deletedResourceForeground"),
+      );
+    }
+    if (git && (git.modified > 0 || git.staged > 0 || git.untracked > 0)) {
+      return new vscode.ThemeIcon(
+        "circle-filled",
+        new vscode.ThemeColor("gitDecoration.modifiedResourceForeground"),
       );
     }
     if (b.is_current) {
@@ -83,7 +137,10 @@ export class BranchNode extends vscode.TreeItem {
     return new vscode.ThemeIcon("git-branch");
   }
 
-  private static buildTooltip(b: StatusBranchJSON): vscode.MarkdownString {
+  private static buildTooltip(
+    b: StatusBranchJSON,
+    git?: WorktreeGitStatus,
+  ): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
     md.appendMarkdown(`**${b.name}**\n\n`);
     md.appendMarkdown(`Parent: \`${b.parent}\`\n\n`);
@@ -105,11 +162,42 @@ export class BranchNode extends vscode.TreeItem {
       md.appendMarkdown(`Review: ${b.review_state.replace(/_/g, " ")}\n\n`);
     }
     if (b.additions || b.deletions) {
-      md.appendMarkdown(`Code Changes: +${b.additions ?? 0} / -${b.deletions ?? 0} lines\n\n`);
+      md.appendMarkdown(
+        `Code Changes: +${b.additions ?? 0} / -${b.deletions ?? 0} lines\n\n`,
+      );
     }
     if (b.mergeable) {
       md.appendMarkdown(`Mergeable: ${b.mergeable}\n\n`);
     }
+
+    if (git) {
+      const lines: string[] = [];
+      if (git.staged > 0) {
+        lines.push(`Staged: ${git.staged} file${git.staged !== 1 ? "s" : ""}`);
+      }
+      if (git.modified > 0) {
+        lines.push(`Modified: ${git.modified} file${git.modified !== 1 ? "s" : ""}`);
+      }
+      if (git.untracked > 0) {
+        lines.push(`Untracked: ${git.untracked} file${git.untracked !== 1 ? "s" : ""}`);
+      }
+      if (git.ahead > 0) {
+        lines.push(`${git.ahead} commit${git.ahead !== 1 ? "s" : ""} ahead of remote`);
+      }
+      if (git.behind > 0) {
+        lines.push(`${git.behind} commit${git.behind !== 1 ? "s" : ""} behind remote`);
+      }
+      if (lines.length > 0) {
+        md.appendMarkdown(`---\n\n**Git Status:**\n\n`);
+        for (const line of lines) {
+          md.appendMarkdown(`- ${line}\n`);
+        }
+        md.appendMarkdown("\n");
+      } else if (!b.is_merged) {
+        md.appendMarkdown(`---\n\n*Working tree clean*\n\n`);
+      }
+    }
+
     if (b.worktree_path) {
       md.appendMarkdown(`Worktree: \`${b.worktree_path}\`\n\n`);
     }
@@ -130,11 +218,9 @@ export class StackTreeProvider
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private stacks: StatusStackJSON[] = [];
-  // Map from "stackHash:parentName" → child branches (scoped per stack)
   private childrenMap = new Map<string, StatusBranchJSON[]>();
-  // Map from node key → parent node (for getParent)
+  private gitStatusMap = new Map<string, WorktreeGitStatus>();
   private parentMap = new Map<string, StackTreeItem>();
-  // Cache of created nodes by key
   private nodeCache = new Map<string, StackTreeItem>();
 
   constructor(private cli: EzsCli) {}
@@ -143,11 +229,22 @@ export class StackTreeProvider
     this._onDidChangeTreeData.fire();
   }
 
+  getStacks(): StatusStackJSON[] {
+    return this.stacks;
+  }
+
+  getGitStatus(worktreePath: string): WorktreeGitStatus | undefined {
+    return this.gitStatusMap.get(worktreePath);
+  }
+
   private childrenKey(stackHash: string, parentName: string): string {
     return `${stackHash}:${parentName}`;
   }
 
   private nodeKey(element: StackTreeItem): string {
+    if (element instanceof RootRepoNode) {
+      return `root:${element.repoPath}`;
+    }
     if (element instanceof StackNode) {
       return `stack:${element.stack.hash}`;
     }
@@ -155,8 +252,6 @@ export class StackTreeProvider
   }
 
   async fetchData(): Promise<void> {
-    // Try statusStacks first (includes PR/CI info), fall back to listStacks
-    // (fast, no gh auth needed) if status fails.
     try {
       this.stacks = await this.cli.statusStacks(true);
     } catch {
@@ -168,7 +263,6 @@ export class StackTreeProvider
       }
     }
 
-    // Build children map, keyed per stack to avoid cross-stack mixing
     this.childrenMap.clear();
     this.parentMap.clear();
     this.nodeCache.clear();
@@ -180,39 +274,54 @@ export class StackTreeProvider
         this.childrenMap.set(key, siblings);
       }
     }
+
+    this.gitStatusMap.clear();
+    const allBranches = this.stacks.flatMap((s) => s.branches);
+    const statusPromises = allBranches
+      .filter((b) => b.worktree_path && !b.is_merged)
+      .map(async (b) => {
+        const status = await this.cli.getWorktreeGitStatus(b.worktree_path!);
+        this.gitStatusMap.set(b.worktree_path!, status);
+      });
+    await Promise.all(statusPromises);
   }
 
   getTreeItem(element: StackTreeItem): vscode.TreeItem {
     return element;
   }
 
+  private makeBranchNode(b: StatusBranchJSON, hash: string): BranchNode {
+    const hasChildren =
+      (this.childrenMap.get(this.childrenKey(hash, b.name)) ?? []).length > 0;
+    const gitStatus = b.worktree_path
+      ? this.gitStatusMap.get(b.worktree_path)
+      : undefined;
+    return new BranchNode(b, hash, hasChildren, gitStatus);
+  }
+
   async getChildren(element?: StackTreeItem): Promise<StackTreeItem[]> {
     if (!element) {
-      // Root level: fetch data and return stacks
       await this.fetchData();
-      if (this.stacks.length === 0) {
-        return [];
+      const items: StackTreeItem[] = [];
+      const repoRoot = this.cli.getWorkspaceRoot();
+      if (repoRoot) {
+        const rootNode = new RootRepoNode(repoRoot);
+        items.push(rootNode);
+        this.nodeCache.set(this.nodeKey(rootNode), rootNode);
       }
-      const nodes = this.stacks.map((s) => new StackNode(s));
-      for (const n of nodes) {
+      const stackNodes = this.stacks.map((s) => new StackNode(s));
+      for (const n of stackNodes) {
         this.nodeCache.set(this.nodeKey(n), n);
       }
-      return nodes;
+      items.push(...stackNodes);
+      return items;
     }
 
     if (element instanceof StackNode) {
-      // Stack level: return top-level branches (children of root)
       const hash = element.stack.hash;
       const key = this.childrenKey(hash, element.stack.root);
       const topBranches = this.childrenMap.get(key) ?? [];
-      const nodes = topBranches.map(
-        (b) =>
-          new BranchNode(
-            b,
-            hash,
-            (this.childrenMap.get(this.childrenKey(hash, b.name)) ?? []).length > 0,
-          ),
-      );
+      const nodes = topBranches.map((b) => this.makeBranchNode(b, hash));
       for (const n of nodes) {
         const nk = this.nodeKey(n);
         this.nodeCache.set(nk, n);
@@ -222,18 +331,10 @@ export class StackTreeProvider
     }
 
     if (element instanceof BranchNode) {
-      // Branch level: return child branches
       const hash = element.stackHash;
       const key = this.childrenKey(hash, element.branch.name);
       const children = this.childrenMap.get(key) ?? [];
-      const nodes = children.map(
-        (b) =>
-          new BranchNode(
-            b,
-            hash,
-            (this.childrenMap.get(this.childrenKey(hash, b.name)) ?? []).length > 0,
-          ),
-      );
+      const nodes = children.map((b) => this.makeBranchNode(b, hash));
       for (const n of nodes) {
         const nk = this.nodeKey(n);
         this.nodeCache.set(nk, n);

--- a/vscode-extension/src/views/statusBarManager.ts
+++ b/vscode-extension/src/views/statusBarManager.ts
@@ -2,8 +2,11 @@ import * as vscode from "vscode";
 import { EzsCli } from "../ezsCli";
 import { StatusStackJSON } from "../types";
 
+const TICKET_RE = /nos-(\d+)/i;
+
 export class StatusBarManager {
   private item: vscode.StatusBarItem;
+  private readonly disposables: vscode.Disposable[] = [];
 
   constructor(private cli: EzsCli) {
     this.item = vscode.window.createStatusBarItem(
@@ -12,19 +15,29 @@ export class StatusBarManager {
     );
     this.item.command = "ezstack.goto";
     this.item.tooltip = "ezstack: Click to navigate branches";
+    this.disposables.push(this.item);
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor(() => this.update()),
+    );
   }
 
   async update(): Promise<void> {
     try {
-      const stacks = await this.cli.listStacks();
+      const stacks = await this.cli.listStacks(true);
       const current = this.findCurrentBranch(stacks);
       if (!current) {
         this.item.hide();
         return;
       }
-      const stackName =
-        current.stack.name || `Stack ${current.stack.hash.slice(0, 7)}`;
-      this.item.text = `$(layers) ${current.branchName} | ${stackName}`;
+      const { branchName, stack, position, stackSize } = current;
+      const match = branchName.match(TICKET_RE);
+      const ticket = match ? `NOS-${match[1]}` : "";
+      const parts = branchName.split(".");
+      const desc = parts.length > 1 ? parts[parts.length - 1] : branchName;
+      const posLabel = `[${position + 1}/${stackSize}]`;
+      const prefix = ticket ? `${ticket} ${posLabel}` : posLabel;
+      this.item.text = `$(layers) ${prefix} ${desc}`;
+      this.item.tooltip = `${branchName} | ${stack.name || `Stack ${stack.hash.slice(0, 7)}`}\nClick to navigate branches`;
       this.item.show();
     } catch {
       this.item.hide();
@@ -33,11 +46,22 @@ export class StatusBarManager {
 
   private findCurrentBranch(
     stacks: StatusStackJSON[],
-  ): { branchName: string; stack: StatusStackJSON } | null {
+  ): {
+    branchName: string;
+    stack: StatusStackJSON;
+    position: number;
+    stackSize: number;
+  } | null {
     for (const stack of stacks) {
-      for (const b of stack.branches) {
+      for (let i = 0; i < stack.branches.length; i++) {
+        const b = stack.branches[i];
         if (b.is_current) {
-          return { branchName: b.name, stack };
+          return {
+            branchName: b.name,
+            stack,
+            position: i,
+            stackSize: stack.branches.length,
+          };
         }
       }
     }
@@ -45,6 +69,6 @@ export class StatusBarManager {
   }
 
   dispose(): void {
-    this.item.dispose();
+    this.disposables.forEach((d) => d.dispose());
   }
 }

--- a/vscode-extension/src/views/statusBarManager.ts
+++ b/vscode-extension/src/views/statusBarManager.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 import { EzsCli } from "../ezsCli";
 import { StatusStackJSON } from "../types";
-
-const TICKET_RE = /nos-(\d+)/i;
+import { extractTicket, shortBranchName } from "../branchUtils";
 
 export class StatusBarManager {
   private item: vscode.StatusBarItem;
@@ -23,17 +22,15 @@ export class StatusBarManager {
 
   async update(): Promise<void> {
     try {
-      const stacks = await this.cli.listStacks(true);
+      const stacks = await this.cli.listStacks();
       const current = this.findCurrentBranch(stacks);
       if (!current) {
         this.item.hide();
         return;
       }
       const { branchName, stack, position, stackSize } = current;
-      const match = branchName.match(TICKET_RE);
-      const ticket = match ? `NOS-${match[1]}` : "";
-      const parts = branchName.split(".");
-      const desc = parts.length > 1 ? parts[parts.length - 1] : branchName;
+      const ticket = extractTicket(branchName) ?? "";
+      const desc = shortBranchName(branchName);
       const posLabel = `[${position + 1}/${stackSize}]`;
       const prefix = ticket ? `${ticket} ${posLabel}` : posLabel;
       this.item.text = `$(layers) ${prefix} ${desc}`;


### PR DESCRIPTION
## Summary

Adds several features to the VS Code extension for navigating multi-worktree stacks:

- **Split view**: Stack overview (top) + focused file explorer (bottom) showing one branch at a time
- **Folder color badges**: Workspace folders get colored badges showing stack position (1, 2, 3...)
- **Cross-stack file navigation**: `Cmd+Alt+Up/Down` opens the same file in the previous/next PR in the stack
- **Compare with Previous PR**: Diff a file against the same file in the adjacent worktree
- **Favorites**: Star directories/files and filter the file tree to show only favorites (persists across sessions, shared across worktrees)
- **Per-branch expand state**: File tree remembers which folders are expanded independently per branch
- **Git status**: Per-file modified/staged/untracked indicators in the file tree, and summary counts on branch nodes
- **Enhanced status bar**: Shows ticket number and stack position `NOS-5030 [2/4] fpga-hal`
- **Root repo node**: Quick access to main repo with Fetch & Pull and New Branch actions
- **Context menus**: Open in Terminal, Copy Path, Reveal in Finder/Explorer, plus stack navigation actions on files
- **Auto-refresh**: File tree and git status refresh on file save

## Test plan

- [ ] Open a multi-root workspace with ezstack worktrees
- [ ] Verify stack overview shows branches with git status indicators
- [ ] Click a branch — file explorer switches to that worktree
- [ ] Expand folders in branch A, switch to branch B, expand different folders, switch back to A — verify state is preserved
- [ ] Favorite a directory, toggle filter — verify only favorites shown
- [ ] Right-click a file in file tree — verify context menu has Copy Path, Reveal in Finder, Open in Terminal, stack navigation
- [ ] Use `Cmd+Alt+Down` on an open file — verify same file opens in next PR's worktree
- [ ] Right-click root repo node — verify Open in Terminal, New Branch, Fetch & Pull, Sync options
- [ ] Save a file — verify git status updates in both stack overview and file tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)