### PR TITLE
feat(mcp): fill ezs-mcp tool gaps (commit, amend, diff, log, pr_update/draft, stack, unstack, config)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -633,8 +633,10 @@ editor, the desktop app, and Claude Code all stay in sync.
 ### MCP Server (Claude Code & other MCP clients)
 
 Located in `cmd/ezs-mcp/`. A standalone Model Context Protocol server that
-exposes the core stack operations as MCP tools. Point any MCP-compatible agent
-(Claude Code, Zed, etc.) at it and the agent can drive `ezs` directly.
+exposes the full stack workflow as MCP tools. Point any MCP-compatible agent
+(Claude Code, Zed, etc.) at it and the agent can drive `ezs` directly &mdash;
+inspect, mutate, navigate, and manage pull requests without leaving the agent
+loop. 21 tools, one binary.
 
 **Install**
 
@@ -660,26 +662,60 @@ when Claude launches the MCP server from a parent workspace directory.
 
 **Tools**
 
+**Inspection**
+
 | Tool | Annotation | Description |
 |---|---|---|
 | `ezstack_status` | read-only | Current stack with PR and CI status. `all`, `decorated`. |
 | `ezstack_list` | read-only | List all stacks and branches. `all`, `decorated`. |
-| `ezstack_sync` | destructive | Rebase (or merge) branches with their base. `stack`, `all`, `current`, `parent`, `children`, `merge`, `dry_run`. |
-| `ezstack_push` | destructive | Push current branch or entire stack. `stack`, `force`. |
-| `ezstack_pr_create` | &mdash; | Create a pull request for the current branch. `title`, `draft`. |
-| `ezstack_pr_stack` | &mdash; | Update every PR description in the stack with navigation links. |
-| `ezstack_pr_merge` | destructive | Merge the pull request for the current branch. |
+| `ezstack_diff` | read-only | Diff against parent branch as JSON numstat (default) or diffstat. `branch`, `stat`. |
+| `ezstack_log` | read-only | Commits since parent as JSON (hash, message, author, ISO date). `branch`. |
+| `ezstack_config_show` | read-only | Full ezstack configuration for the active repo. |
+
+**Branch management**
+
+| Tool | Annotation | Description |
+|---|---|---|
 | `ezstack_goto` | &mdash; | Switch to a branch. `branch` (required). |
 | `ezstack_new` | &mdash; | Create a new branch. `name` (required), `parent`. |
 | `ezstack_delete` | destructive | Delete a branch and its worktree. `branch` (required). |
 | `ezstack_reparent` | &mdash; | Move a branch to a new parent. `branch` and `new_parent` (both required). |
+| `ezstack_stack` | &mdash; | Add a standalone branch to a stack. `branch` (required), `parent` or `base`. |
+| `ezstack_unstack` | &mdash; | Remove a branch from ezstack tracking (leaves the git branch/worktree intact). `branch` (required). |
 
-Read-only tools return JSON by default; pass `decorated=true` to get the
-terminal-styled output. Destructive tools are tagged with the MCP destructive
-annotation so the client prompts before running them. Branch-management tools
-mark their positional arguments as `Required` in the tool schema so the agent
-cannot trigger an interactive `fzf` selection that would hang in a no-terminal
-context.
+**Committing & syncing**
+
+| Tool | Annotation | Description |
+|---|---|---|
+| `ezstack_commit` | destructive | Commit staged (or all) changes and auto-sync children. `message` (required), `all`, `merge`, `rebase`. Auto-pushes if the branch is already on the remote. |
+| `ezstack_amend` | destructive | Amend the last commit and auto-sync children. Optional `message` (otherwise `--no-edit`), `all`, `merge`, `rebase`. Force-pushes if the branch is already on the remote. |
+| `ezstack_sync` | destructive | Rebase (or merge) branches with their base. `stack`, `all`, `current`, `parent`, `children`, `merge`, `dry_run`, `resume` (maps to `--continue`). |
+| `ezstack_push` | destructive | Push current branch or entire stack. `stack`, `force`. |
+
+**Pull requests**
+
+| Tool | Annotation | Description |
+|---|---|---|
+| `ezstack_pr_create` | &mdash; | Create a pull request for the current branch. `title`, `draft`. |
+| `ezstack_pr_update` | destructive | Push the latest commits and refresh the PR base branch / stack description. `branch`. |
+| `ezstack_pr_merge` | destructive | Merge the pull request for the current branch. |
+| `ezstack_pr_draft` | &mdash; | Toggle a PR between draft and ready-for-review. `branch`. |
+| `ezstack_pr_stack` | &mdash; | Update every PR description in the stack with navigation links. |
+
+**Configuration**
+
+| Tool | Annotation | Description |
+|---|---|---|
+| `ezstack_config_set` | &mdash; | Set a config value. `key` and `value` (both required). Valid keys: `worktree_base_dir`, `default_base_branch`, `github_token`, `cd_after_new`, `use_worktrees`, `sync_strategy`, `agent_command`. |
+
+Read-only inspection tools return JSON by default; `ezstack_status` and
+`ezstack_list` accept `decorated=true` for terminal-styled output. Destructive
+tools are tagged with the MCP destructive annotation so the client prompts
+before running them. Branch-management tools mark their positional arguments as
+`Required` in the tool schema so the agent cannot trigger an interactive `fzf`
+selection that would hang in a no-terminal context. `ezstack_commit` requires
+an explicit `message` and `ezstack_amend` defaults to `--no-edit` so neither
+can ever launch `$EDITOR` and corrupt the JSON-RPC transport.
 
 **Safety** &mdash; every tool handler acquires a process-wide mutex before
 running, since `ezs` operates on shared process state (stdout/stderr, the

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Agent prompts are composed from three layers: a shipped prompt (updated with rel
 
 ## MCP Server (Claude Code & other MCP clients)
 
-ezstack ships a standalone MCP server, `ezs-mcp`, that exposes the core stack operations as Model Context Protocol tools. Point any MCP-compatible agent at it (Claude Code, Zed, etc.) and the agent can drive `ezs` directly — status, list, sync, push, PR create/merge, goto, new, delete, reparent.
+ezstack ships a standalone MCP server, `ezs-mcp`, that exposes the full stack workflow as Model Context Protocol tools. Point any MCP-compatible agent at it (Claude Code, Zed, etc.) and the agent can drive `ezs` directly: inspect (`status`, `list`, `diff`, `log`, `config_show`), mutate (`commit`, `amend`, `sync`, `push`, `new`, `delete`, `reparent`, `stack`, `unstack`, `config_set`), navigate (`goto`), and manage PRs (`pr_create`, `pr_update`, `pr_merge`, `pr_draft`, `pr_stack`). 21 tools, one binary.
 
 Install:
 
@@ -167,7 +167,7 @@ Register with Claude Code:
 claude mcp add ezstack -- ezs-mcp --repo "$(pwd)"
 ```
 
-`--repo` pins the server to a specific git repository root, which is useful when Claude launches the MCP server from a parent workspace directory. Read-only tools (`ezstack_status`, `ezstack_list`) return JSON by default, or pass `decorated=true` to get the terminal-styled output. Destructive tools (`ezstack_sync`, `ezstack_push`, `ezstack_delete`, `ezstack_pr_merge`) are tagged with the MCP destructive annotation so the client can prompt the user before running them.
+`--repo` pins the server to a specific git repository root, which is useful when Claude launches the MCP server from a parent workspace directory. Read-only tools (`ezstack_status`, `ezstack_list`, `ezstack_diff`, `ezstack_log`, `ezstack_config_show`) return JSON by default, or pass `decorated=true` (where supported) to get the terminal-styled output. Destructive tools (`ezstack_commit`, `ezstack_amend`, `ezstack_sync`, `ezstack_push`, `ezstack_delete`, `ezstack_pr_merge`, `ezstack_pr_update`) are tagged with the MCP destructive annotation so the client can prompt before running them. `ezstack_commit` requires an explicit `message` and `ezstack_amend` defaults to `--no-edit` so neither can ever launch `$EDITOR` and corrupt the JSON-RPC transport.
 
 Full feature tour and tool catalog: [mcp.html](https://kulkarnikaustubh.github.io/ezstack/mcp.html).
 

--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -321,6 +321,7 @@ func registerTools(s *server.MCPServer) {
 			mcp.WithBoolean("children", mcp.Description("Rebase children onto current branch")),
 			mcp.WithBoolean("merge", mcp.Description("Use merge instead of rebase")),
 			mcp.WithBoolean("dry_run", mcp.Description("Preview what would be synced without making changes")),
+			mcp.WithBoolean("resume", mcp.Description("Resume a sync after the user has resolved rebase conflicts (maps to ezs sync --continue)")),
 		),
 		toolHandler(commands.Sync, func(req mcp.CallToolRequest) []string {
 			var args []string
@@ -331,6 +332,7 @@ func registerTools(s *server.MCPServer) {
 			boolFlag(&args, req, "children", "--children")
 			boolFlag(&args, req, "merge", "--merge")
 			boolFlag(&args, req, "dry_run", "--dry-run")
+			boolFlag(&args, req, "resume", "--continue")
 			return args
 		}),
 	)
@@ -456,6 +458,201 @@ func registerTools(s *server.MCPServer) {
 			return []string{
 				req.GetString("branch", ""),
 				req.GetString("new_parent", ""),
+			}
+		}),
+	)
+
+	// ---- Commit & amend ----
+	//
+	// message is Required for ezstack_commit and --no-edit is forced for
+	// ezstack_amend (unless a new message is supplied), because ezs commit
+	// shells out via RunInteractive which inherits the parent's stdin. In
+	// the MCP server the parent stdin is the JSON-RPC transport, so letting
+	// git launch an editor would corrupt the protocol stream.
+	//
+	// Both handlers use yesModeHandler so the internal "Push to remote?"
+	// confirmation (ConfirmTUIWithDefault) is auto-accepted — the MCP
+	// client has no way to answer a stdin prompt. Commit will therefore
+	// push automatically when the branch already exists on the remote;
+	// agents that want a commit-without-push should use ezstack_commit
+	// on branches that have not been pushed yet.
+
+	s.AddTool(
+		mcp.NewTool("ezstack_commit",
+			mcp.WithDescription("Commit staged (or all) changes and auto-sync child branches. Auto-pushes when the branch already exists on the remote. Refuses to open an editor: message is required."),
+			mcp.WithString("message",
+				mcp.Description("Commit message — passed directly to git commit -m"),
+				mcp.Required(),
+			),
+			mcp.WithBoolean("all", mcp.Description("Stage all tracked modified files (git commit -a)")),
+			mcp.WithBoolean("merge", mcp.Description("Use merge instead of rebase when syncing children")),
+			mcp.WithBoolean("rebase", mcp.Description("Use rebase instead of merge when syncing children")),
+			mcp.WithDestructiveHintAnnotation(true),
+		),
+		yesModeHandler(commands.Commit, func(req mcp.CallToolRequest) []string {
+			var args []string
+			boolFlag(&args, req, "all", "-a")
+			args = append(args, "-m", req.GetString("message", ""))
+			boolFlag(&args, req, "merge", "--merge")
+			boolFlag(&args, req, "rebase", "--rebase")
+			return args
+		}),
+	)
+
+	s.AddTool(
+		mcp.NewTool("ezstack_amend",
+			mcp.WithDescription("Amend the last commit and auto-sync child branches. Force-pushes when the branch already exists on the remote (amend rewrites history). If message is omitted, --no-edit is forced to avoid launching an editor."),
+			mcp.WithString("message", mcp.Description("New commit message. If omitted, the existing message is preserved via --no-edit.")),
+			mcp.WithBoolean("all", mcp.Description("Stage all tracked modified files before amending (git commit -a)")),
+			mcp.WithBoolean("merge", mcp.Description("Use merge instead of rebase when syncing children")),
+			mcp.WithBoolean("rebase", mcp.Description("Use rebase instead of merge when syncing children")),
+			mcp.WithDestructiveHintAnnotation(true),
+		),
+		yesModeHandler(commands.Amend, func(req mcp.CallToolRequest) []string {
+			var args []string
+			boolFlag(&args, req, "all", "-a")
+			if msg := req.GetString("message", ""); msg != "" {
+				args = append(args, "-m", msg)
+			} else {
+				args = append(args, "--no-edit")
+			}
+			boolFlag(&args, req, "merge", "--merge")
+			boolFlag(&args, req, "rebase", "--rebase")
+			return args
+		}),
+	)
+
+	// ---- Inspection ----
+
+	s.AddTool(
+		mcp.NewTool("ezstack_diff",
+			mcp.WithDescription("Show diff between a branch and its parent in the stack. Returns structured JSON by default (file list with additions/deletions and totals)."),
+			mcp.WithString("branch", mcp.Description("Branch to diff (defaults to current)")),
+			mcp.WithBoolean("stat", mcp.Description("Return a diffstat summary instead of the JSON numstat view")),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		readOnlyHandler(commands.Diff, func(req mcp.CallToolRequest) []string {
+			var args []string
+			stringFlag(&args, req, "branch", "--branch")
+			// Default to --json unless the caller explicitly asked for stat
+			if req.GetBool("stat", false) {
+				args = append(args, "--stat")
+			} else {
+				args = append(args, "--json")
+			}
+			return args
+		}),
+	)
+
+	s.AddTool(
+		mcp.NewTool("ezstack_log",
+			mcp.WithDescription("Show commits in a branch since its parent. Always returns JSON (hash, message, author, ISO date, count)."),
+			mcp.WithString("branch", mcp.Description("Branch to show commits for (defaults to current)")),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		readOnlyHandler(commands.Log, func(req mcp.CallToolRequest) []string {
+			args := []string{"--json"}
+			stringFlag(&args, req, "branch", "--branch")
+			return args
+		}),
+	)
+
+	// ---- Additional PR operations ----
+
+	s.AddTool(
+		mcp.NewTool("ezstack_pr_update",
+			mcp.WithDescription("Push the latest commits and update the PR base branch and stack description to match the current stack structure."),
+			mcp.WithString("branch", mcp.Description("Branch whose PR to update (defaults to current)")),
+			mcp.WithDestructiveHintAnnotation(true),
+		),
+		yesModeHandler(commands.PR, func(req mcp.CallToolRequest) []string {
+			args := []string{"update"}
+			stringFlag(&args, req, "branch", "--branch")
+			return args
+		}),
+	)
+
+	s.AddTool(
+		mcp.NewTool("ezstack_pr_draft",
+			mcp.WithDescription("Toggle a pull request between draft and ready-for-review."),
+			mcp.WithString("branch", mcp.Description("Branch whose PR to toggle (defaults to current)")),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		yesModeHandler(commands.PR, func(req mcp.CallToolRequest) []string {
+			args := []string{"draft"}
+			stringFlag(&args, req, "branch", "--branch")
+			return args
+		}),
+	)
+
+	// ---- Stack membership ----
+
+	s.AddTool(
+		mcp.NewTool("ezstack_stack",
+			mcp.WithDescription("Add a branch to a stack by setting its parent. Pass either parent (to attach under an existing branch) or base (to start a new stack rooted on a non-default base branch like develop)."),
+			mcp.WithString("branch",
+				mcp.Description("Branch to add to the stack"),
+				mcp.Required(),
+			),
+			mcp.WithString("parent", mcp.Description("Parent branch in an existing stack")),
+			mcp.WithString("base", mcp.Description("Base branch for a new stack (mutually exclusive with parent)")),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		yesModeHandler(commands.Stack, func(req mcp.CallToolRequest) []string {
+			args := []string{"--branch", req.GetString("branch", "")}
+			stringFlag(&args, req, "parent", "--parent")
+			stringFlag(&args, req, "base", "--base")
+			return args
+		}),
+	)
+
+	s.AddTool(
+		mcp.NewTool("ezstack_unstack",
+			mcp.WithDescription("Remove a branch from ezstack tracking without deleting the git branch or worktree. Children are reparented to the untracked branch's parent."),
+			mcp.WithString("branch",
+				mcp.Description("Branch to untrack"),
+				mcp.Required(),
+			),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		yesModeHandler(commands.Unstack, func(req mcp.CallToolRequest) []string {
+			return []string{"--branch", req.GetString("branch", "")}
+		}),
+	)
+
+	// ---- Configuration ----
+
+	s.AddTool(
+		mcp.NewTool("ezstack_config_show",
+			mcp.WithDescription("Show the current ezstack configuration, including the config directory, global settings, and per-repo settings for the active repository."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		readOnlyHandler(commands.Config, func(req mcp.CallToolRequest) []string {
+			return []string{"show"}
+		}),
+	)
+
+	s.AddTool(
+		mcp.NewTool("ezstack_config_set",
+			mcp.WithDescription("Set an ezstack configuration value. Valid keys: worktree_base_dir, default_base_branch, github_token, cd_after_new, use_worktrees, sync_strategy, agent_command."),
+			mcp.WithString("key",
+				mcp.Description("Config key to set"),
+				mcp.Required(),
+			),
+			mcp.WithString("value",
+				mcp.Description("New value for the key"),
+				mcp.Required(),
+			),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		toolHandler(commands.Config, func(req mcp.CallToolRequest) []string {
+			return []string{
+				"set",
+				req.GetString("key", ""),
+				req.GetString("value", ""),
 			}
 		}),
 	)

--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -526,16 +526,19 @@ func registerTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("ezstack_diff",
-			mcp.WithDescription("Show diff between a branch and its parent in the stack. Returns structured JSON by default (file list with additions/deletions and totals)."),
+			mcp.WithDescription("Show diff between a branch and its parent in the stack. Returns structured JSON numstat (file list with additions/deletions and totals) by default, or a human-readable diffstat summary with stat=true."),
 			mcp.WithString("branch", mcp.Description("Branch to diff (defaults to current)")),
 			mcp.WithBoolean("stat", mcp.Description("Return a diffstat summary instead of the JSON numstat view")),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
 		),
-		readOnlyHandler(commands.Diff, func(req mcp.CallToolRequest) []string {
+		// Explicit toolHandler (not readOnlyHandler) because readOnlyHandler
+		// unconditionally appends --json, which would override --stat inside
+		// commands.Diff and silently return JSON when the caller asked for
+		// stat output.
+		toolHandler(commands.Diff, func(req mcp.CallToolRequest) []string {
 			var args []string
 			stringFlag(&args, req, "branch", "--branch")
-			// Default to --json unless the caller explicitly asked for stat
 			if req.GetBool("stat", false) {
 				args = append(args, "--stat")
 			} else {
@@ -552,7 +555,10 @@ func registerTools(s *server.MCPServer) {
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
 		),
-		readOnlyHandler(commands.Log, func(req mcp.CallToolRequest) []string {
+		// toolHandler + explicit --json: we always want JSON from Log, and
+		// keeping the flag in buildArgs makes the contract explicit in one
+		// place rather than depending on readOnlyHandler's injection.
+		toolHandler(commands.Log, func(req mcp.CallToolRequest) []string {
 			args := []string{"--json"}
 			stringFlag(&args, req, "branch", "--branch")
 			return args
@@ -630,7 +636,11 @@ func registerTools(s *server.MCPServer) {
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
 		),
-		readOnlyHandler(commands.Config, func(req mcp.CallToolRequest) []string {
+		// toolHandler (not readOnlyHandler) because `ezs config` has no
+		// --json mode — readOnlyHandler would inject an unknown flag that
+		// Config silently drops, leaving behavior correct-by-accident and
+		// the abstraction misleading.
+		toolHandler(commands.Config, func(req mcp.CallToolRequest) []string {
 			return []string{"show"}
 		}),
 	)

--- a/cmd/ezs-mcp/server_test.go
+++ b/cmd/ezs-mcp/server_test.go
@@ -85,10 +85,20 @@ func TestListTools_Registered(t *testing.T) {
 		"ezstack_pr_create",
 		"ezstack_pr_stack",
 		"ezstack_pr_merge",
+		"ezstack_pr_update",
+		"ezstack_pr_draft",
 		"ezstack_goto",
 		"ezstack_new",
 		"ezstack_delete",
 		"ezstack_reparent",
+		"ezstack_commit",
+		"ezstack_amend",
+		"ezstack_diff",
+		"ezstack_log",
+		"ezstack_stack",
+		"ezstack_unstack",
+		"ezstack_config_show",
+		"ezstack_config_set",
 	}
 	sort.Strings(want)
 	var got []string
@@ -116,6 +126,11 @@ func TestListTools_Registered(t *testing.T) {
 		{"ezstack_delete", "branch"},
 		{"ezstack_reparent", "branch"},
 		{"ezstack_reparent", "new_parent"},
+		{"ezstack_commit", "message"},
+		{"ezstack_stack", "branch"},
+		{"ezstack_unstack", "branch"},
+		{"ezstack_config_set", "key"},
+		{"ezstack_config_set", "value"},
 	}
 	for _, rc := range requiredChecks {
 		tl, ok := byName[rc.tool]
@@ -137,17 +152,27 @@ func TestListTools_Registered(t *testing.T) {
 
 	// Destructive annotation — sync rewrites history and must be flagged.
 	destructiveWant := map[string]bool{
-		"ezstack_status":    false,
-		"ezstack_list":      false,
-		"ezstack_sync":      true,
-		"ezstack_push":      true,
-		"ezstack_pr_create": false,
-		"ezstack_pr_stack":  false,
-		"ezstack_pr_merge":  true,
-		"ezstack_goto":      false,
-		"ezstack_new":       false,
-		"ezstack_delete":    true,
-		"ezstack_reparent":  false,
+		"ezstack_status":      false,
+		"ezstack_list":        false,
+		"ezstack_sync":        true,
+		"ezstack_push":        true,
+		"ezstack_pr_create":   false,
+		"ezstack_pr_stack":    false,
+		"ezstack_pr_merge":    true,
+		"ezstack_pr_update":   true,
+		"ezstack_pr_draft":    false,
+		"ezstack_goto":        false,
+		"ezstack_new":         false,
+		"ezstack_delete":      true,
+		"ezstack_reparent":    false,
+		"ezstack_commit":      true,
+		"ezstack_amend":       true,
+		"ezstack_diff":        false,
+		"ezstack_log":         false,
+		"ezstack_stack":       false,
+		"ezstack_unstack":     false,
+		"ezstack_config_show": false,
+		"ezstack_config_set":  false,
 	}
 	for name, want := range destructiveWant {
 		tl, ok := byName[name]

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -1130,8 +1130,10 @@ Options:
       editor, the desktop app, and Claude Code all stay in sync.</p>
       <h3 id="mcp-server-claude-code--other-mcp-clients">MCP Server (Claude Code &amp; other MCP clients)</h3>
       <p>Located in <code>cmd/ezs-mcp/</code>. A standalone Model Context Protocol server that
-      exposes the core stack operations as MCP tools. Point any MCP-compatible agent
-      (Claude Code, Zed, etc.) at it and the agent can drive <code>ezs</code> directly.</p>
+      exposes the full stack workflow as MCP tools. Point any MCP-compatible agent
+      (Claude Code, Zed, etc.) at it and the agent can drive <code>ezs</code> directly —
+      inspect, mutate, navigate, and manage pull requests without leaving the agent
+      loop. 21 tools, one binary.</p>
       <p><strong>Install</strong></p>
       <pre><code><span class="c-comment"># Homebrew (ships alongside ezs)</span>
 <span class="c-cmd">brew</span> <span class="c-flag">install</span> <span class="c-str">KulkarniKaustubh/ezstack/ezstack</span>
@@ -1148,6 +1150,7 @@ Options:
       <p><code>--repo</code> pins the server to a specific git repository root, which is useful
       when Claude launches the MCP server from a parent workspace directory.</p>
       <p><strong>Tools</strong></p>
+      <p><strong>Inspection</strong></p>
       <table>
       <thead>
       <tr>
@@ -1168,30 +1171,32 @@ Options:
       <td>List all stacks and branches. <code>all</code>, <code>decorated</code>.</td>
       </tr>
       <tr>
-      <td><code>ezstack_sync</code></td>
-      <td>destructive</td>
-      <td>Rebase (or merge) branches with their base. <code>stack</code>, <code>all</code>, <code>current</code>, <code>parent</code>, <code>children</code>, <code>merge</code>, <code>dry_run</code>.</td>
+      <td><code>ezstack_diff</code></td>
+      <td>read-only</td>
+      <td>Diff against parent branch as JSON numstat (default) or diffstat. <code>branch</code>, <code>stat</code>.</td>
       </tr>
       <tr>
-      <td><code>ezstack_push</code></td>
-      <td>destructive</td>
-      <td>Push current branch or entire stack. <code>stack</code>, <code>force</code>.</td>
+      <td><code>ezstack_log</code></td>
+      <td>read-only</td>
+      <td>Commits since parent as JSON (hash, message, author, ISO date). <code>branch</code>.</td>
       </tr>
       <tr>
-      <td><code>ezstack_pr_create</code></td>
-      <td>—</td>
-      <td>Create a pull request for the current branch. <code>title</code>, <code>draft</code>.</td>
+      <td><code>ezstack_config_show</code></td>
+      <td>read-only</td>
+      <td>Full ezstack configuration for the active repo.</td>
       </tr>
+      </tbody>
+      </table>
+      <p><strong>Branch management</strong></p>
+      <table>
+      <thead>
       <tr>
-      <td><code>ezstack_pr_stack</code></td>
-      <td>—</td>
-      <td>Update every PR description in the stack with navigation links.</td>
+      <th>Tool</th>
+      <th>Annotation</th>
+      <th>Description</th>
       </tr>
-      <tr>
-      <td><code>ezstack_pr_merge</code></td>
-      <td>destructive</td>
-      <td>Merge the pull request for the current branch.</td>
-      </tr>
+      </thead>
+      <tbody>
       <tr>
       <td><code>ezstack_goto</code></td>
       <td>—</td>
@@ -1212,14 +1217,112 @@ Options:
       <td>—</td>
       <td>Move a branch to a new parent. <code>branch</code> and <code>new_parent</code> (both required).</td>
       </tr>
+      <tr>
+      <td><code>ezstack_stack</code></td>
+      <td>—</td>
+      <td>Add a standalone branch to a stack. <code>branch</code> (required), <code>parent</code> or <code>base</code>.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_unstack</code></td>
+      <td>—</td>
+      <td>Remove a branch from ezstack tracking (leaves the git branch/worktree intact). <code>branch</code> (required).</td>
+      </tr>
       </tbody>
       </table>
-      <p>Read-only tools return JSON by default; pass <code>decorated=true</code> to get the
-      terminal-styled output. Destructive tools are tagged with the MCP destructive
-      annotation so the client prompts before running them. Branch-management tools
-      mark their positional arguments as <code>Required</code> in the tool schema so the agent
-      cannot trigger an interactive <code>fzf</code> selection that would hang in a no-terminal
-      context.</p>
+      <p><strong>Committing &amp; syncing</strong></p>
+      <table>
+      <thead>
+      <tr>
+      <th>Tool</th>
+      <th>Annotation</th>
+      <th>Description</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td><code>ezstack_commit</code></td>
+      <td>destructive</td>
+      <td>Commit staged (or all) changes and auto-sync children. <code>message</code> (required), <code>all</code>, <code>merge</code>, <code>rebase</code>. Auto-pushes if the branch is already on the remote.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_amend</code></td>
+      <td>destructive</td>
+      <td>Amend the last commit and auto-sync children. Optional <code>message</code> (otherwise <code>--no-edit</code>), <code>all</code>, <code>merge</code>, <code>rebase</code>. Force-pushes if the branch is already on the remote.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_sync</code></td>
+      <td>destructive</td>
+      <td>Rebase (or merge) branches with their base. <code>stack</code>, <code>all</code>, <code>current</code>, <code>parent</code>, <code>children</code>, <code>merge</code>, <code>dry_run</code>, <code>resume</code> (maps to <code>--continue</code>).</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_push</code></td>
+      <td>destructive</td>
+      <td>Push current branch or entire stack. <code>stack</code>, <code>force</code>.</td>
+      </tr>
+      </tbody>
+      </table>
+      <p><strong>Pull requests</strong></p>
+      <table>
+      <thead>
+      <tr>
+      <th>Tool</th>
+      <th>Annotation</th>
+      <th>Description</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td><code>ezstack_pr_create</code></td>
+      <td>—</td>
+      <td>Create a pull request for the current branch. <code>title</code>, <code>draft</code>.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_pr_update</code></td>
+      <td>destructive</td>
+      <td>Push the latest commits and refresh the PR base branch / stack description. <code>branch</code>.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_pr_merge</code></td>
+      <td>destructive</td>
+      <td>Merge the pull request for the current branch.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_pr_draft</code></td>
+      <td>—</td>
+      <td>Toggle a PR between draft and ready-for-review. <code>branch</code>.</td>
+      </tr>
+      <tr>
+      <td><code>ezstack_pr_stack</code></td>
+      <td>—</td>
+      <td>Update every PR description in the stack with navigation links.</td>
+      </tr>
+      </tbody>
+      </table>
+      <p><strong>Configuration</strong></p>
+      <table>
+      <thead>
+      <tr>
+      <th>Tool</th>
+      <th>Annotation</th>
+      <th>Description</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+      <td><code>ezstack_config_set</code></td>
+      <td>—</td>
+      <td>Set a config value. <code>key</code> and <code>value</code> (both required). Valid keys: <code>worktree_base_dir</code>, <code>default_base_branch</code>, <code>github_token</code>, <code>cd_after_new</code>, <code>use_worktrees</code>, <code>sync_strategy</code>, <code>agent_command</code>.</td>
+      </tr>
+      </tbody>
+      </table>
+      <p>Read-only inspection tools return JSON by default; <code>ezstack_status</code> and
+      <code>ezstack_list</code> accept <code>decorated=true</code> for terminal-styled output. Destructive
+      tools are tagged with the MCP destructive annotation so the client prompts
+      before running them. Branch-management tools mark their positional arguments as
+      <code>Required</code> in the tool schema so the agent cannot trigger an interactive <code>fzf</code>
+      selection that would hang in a no-terminal context. <code>ezstack_commit</code> requires
+      an explicit <code>message</code> and <code>ezstack_amend</code> defaults to <code>--no-edit</code> so neither
+      can ever launch <code>$EDITOR</code> and corrupt the JSON-RPC transport.</p>
       <p><strong>Safety</strong> — every tool handler acquires a process-wide mutex before
       running, since <code>ezs</code> operates on shared process state (stdout/stderr, the
       <code>ui.Backend</code>, <code>ui.YesMode</code>). Stdout and stderr are captured via concurrent pipe

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -67,7 +67,7 @@
           Back to ezstack
         </a>
         <h1>MCP Server<br>for Claude Code</h1>
-        <p class="hero-sub">ezstack ships a standalone Model Context Protocol server, <code>ezs-mcp</code>, that exposes the core stack operations as MCP tools. Point Claude Code (or any MCP-compatible agent) at it and it can drive <code>ezs</code> directly &mdash; status, list, sync, push, PR create/merge, goto, new, delete, reparent.</p>
+        <p class="hero-sub">ezstack ships a standalone Model Context Protocol server, <code>ezs-mcp</code>, that exposes the full stack workflow as MCP tools. Point Claude Code (or any MCP-compatible agent) at it and it can drive <code>ezs</code> directly &mdash; inspect, commit, sync, push, manage pull requests, navigate, and configure, all without leaving the agent loop.</p>
         <div class="hero-actions">
           <div class="install-cmd" id="hero-install">
             <span class="install-prompt">$</span>
@@ -91,7 +91,7 @@
     <div class="container">
       <div class="workflow-header" data-animate>
         <span class="mode-label mode-label-work">How It Works</span>
-        <h2>One binary. Eleven tools. Real <code>ezs</code> under the hood.</h2>
+        <h2>One binary. 21 tools. Real <code>ezs</code> under the hood.</h2>
         <p><code>ezs-mcp</code> is a separate binary that speaks JSON-RPC over stdio. Under the hood it invokes the same <code>ezs</code> command functions your shell uses &mdash; there is no second copy of the logic to drift. Your agent gets the identical behavior you'd get from the terminal, captured and handed back as structured tool results.</p>
       </div>
 
@@ -146,11 +146,12 @@
     <div class="container">
       <div class="workflow-header" data-animate>
         <span class="mode-label mode-label-feature">Tool Catalog</span>
-        <h2>Eleven tools, full stack coverage</h2>
-        <p>Every core ezstack operation an agent needs &mdash; inspect, mutate, push, PR &mdash; exposed with strict input schemas. Read-only tools default to JSON; destructive tools carry the MCP destructive annotation.</p>
+        <h2>Twenty-one tools, full stack coverage</h2>
+        <p>Every ezstack operation an agent needs &mdash; inspect, commit, sync, push, PR, configure &mdash; exposed with strict input schemas. Read-only tools default to JSON; destructive tools carry the MCP destructive annotation; tools that would normally launch an editor or an <code>fzf</code> picker have those paths closed off at the schema level so they can't hang the MCP transport.</p>
       </div>
 
       <div class="template-vars" data-animate>
+        <h3>Inspection</h3>
         <table class="var-table">
           <thead>
             <tr>
@@ -171,39 +172,44 @@
               <td>List all stacks and branches. <code>all</code>, <code>decorated</code>.</td>
             </tr>
             <tr>
-              <td><code>ezstack_sync</code></td>
-              <td><span class="mode-label mode-label-feature">destructive</span></td>
-              <td>Rebase (or merge) stack branches with their base. <code>stack</code>, <code>all</code>, <code>current</code>, <code>parent</code>, <code>children</code>, <code>merge</code>, <code>dry_run</code>.</td>
+              <td><code>ezstack_diff</code></td>
+              <td><span class="mode-label mode-label-work">read-only</span></td>
+              <td>Diff against parent branch as JSON numstat (default) or diffstat. <code>branch</code>, <code>stat</code>.</td>
             </tr>
             <tr>
-              <td><code>ezstack_push</code></td>
-              <td><span class="mode-label mode-label-feature">destructive</span></td>
-              <td>Push current branch or entire stack. <code>stack</code>, <code>force</code>.</td>
+              <td><code>ezstack_log</code></td>
+              <td><span class="mode-label mode-label-work">read-only</span></td>
+              <td>Commits since parent as JSON (hash, message, author, ISO date). <code>branch</code>.</td>
             </tr>
             <tr>
-              <td><code>ezstack_pr_create</code></td>
-              <td>&mdash;</td>
-              <td>Create a pull request for the current branch. <code>title</code>, <code>draft</code>.</td>
+              <td><code>ezstack_config_show</code></td>
+              <td><span class="mode-label mode-label-work">read-only</span></td>
+              <td>Full ezstack configuration for the active repo.</td>
             </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="template-vars" data-animate>
+        <h3>Branch management</h3>
+        <table class="var-table">
+          <thead>
             <tr>
-              <td><code>ezstack_pr_stack</code></td>
-              <td>&mdash;</td>
-              <td>Update every PR description in the stack with navigation links.</td>
+              <th>Tool</th>
+              <th>Annotation</th>
+              <th>Description</th>
             </tr>
-            <tr>
-              <td><code>ezstack_pr_merge</code></td>
-              <td><span class="mode-label mode-label-feature">destructive</span></td>
-              <td>Merge the pull request for the current branch.</td>
-            </tr>
+          </thead>
+          <tbody>
             <tr>
               <td><code>ezstack_goto</code></td>
               <td>&mdash;</td>
-              <td>Switch to a branch in the stack. <code>branch</code> (required).</td>
+              <td>Switch to a branch. <code>branch</code> (required).</td>
             </tr>
             <tr>
               <td><code>ezstack_new</code></td>
               <td>&mdash;</td>
-              <td>Create a new branch in the stack. <code>name</code> (required), <code>parent</code>.</td>
+              <td>Create a new branch. <code>name</code> (required), <code>parent</code>.</td>
             </tr>
             <tr>
               <td><code>ezstack_delete</code></td>
@@ -214,6 +220,111 @@
               <td><code>ezstack_reparent</code></td>
               <td>&mdash;</td>
               <td>Move a branch to a new parent. <code>branch</code> and <code>new_parent</code> (both required).</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_stack</code></td>
+              <td>&mdash;</td>
+              <td>Add a standalone branch to a stack. <code>branch</code> (required), <code>parent</code> or <code>base</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_unstack</code></td>
+              <td>&mdash;</td>
+              <td>Remove a branch from ezstack tracking (leaves the git branch and worktree intact). <code>branch</code> (required).</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="template-vars" data-animate>
+        <h3>Committing &amp; syncing</h3>
+        <table class="var-table">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Annotation</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ezstack_commit</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Commit staged (or all) changes and auto-sync children. <code>message</code> (required), <code>all</code>, <code>merge</code>, <code>rebase</code>. Auto-pushes if the branch is already on the remote.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_amend</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Amend the last commit and auto-sync children. Optional <code>message</code> (otherwise <code>--no-edit</code>), <code>all</code>, <code>merge</code>, <code>rebase</code>. Force-pushes if the branch is already on the remote.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_sync</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Rebase (or merge) stack branches with their base. <code>stack</code>, <code>all</code>, <code>current</code>, <code>parent</code>, <code>children</code>, <code>merge</code>, <code>dry_run</code>, <code>resume</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_push</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Push current branch or entire stack. <code>stack</code>, <code>force</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="template-vars" data-animate>
+        <h3>Pull requests</h3>
+        <table class="var-table">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Annotation</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ezstack_pr_create</code></td>
+              <td>&mdash;</td>
+              <td>Create a pull request for the current branch. <code>title</code>, <code>draft</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_pr_update</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Push the latest commits and refresh the PR base branch and stack description. <code>branch</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_pr_merge</code></td>
+              <td><span class="mode-label mode-label-feature">destructive</span></td>
+              <td>Merge the pull request for the current branch.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_pr_draft</code></td>
+              <td>&mdash;</td>
+              <td>Toggle a PR between draft and ready-for-review. <code>branch</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_pr_stack</code></td>
+              <td>&mdash;</td>
+              <td>Update every PR description in the stack with navigation links.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="template-vars" data-animate>
+        <h3>Configuration</h3>
+        <table class="var-table">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Annotation</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ezstack_config_set</code></td>
+              <td>&mdash;</td>
+              <td>Set a config value. <code>key</code> and <code>value</code> (both required). Valid keys: <code>worktree_base_dir</code>, <code>default_base_branch</code>, <code>github_token</code>, <code>cd_after_new</code>, <code>use_worktrees</code>, <code>sync_strategy</code>, <code>agent_command</code>.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Adds 10 new MCP tools to `ezs-mcp`, bringing the catalog to **21 tools** with full `ezs` workflow coverage: `commit`, `amend`, `diff`, `log`, `pr_update`, `pr_draft`, `stack`, `unstack`, `config_show`, `config_set`. Also adds a `resume` flag to `ezstack_sync` for rebase-conflict recovery.
- Schema-level safety: `ezstack_commit` requires `message`; `ezstack_amend` defaults to `--no-edit` — neither can ever launch `\$EDITOR` and corrupt the JSON-RPC transport. Destructive tools are annotated so clients can prompt.
- Docs refreshed end-to-end: `README.md`, `DOCUMENTATION.md`, and `docs/mcp.html` now show the categorized 21-tool catalog (Inspection / Branch / Commit & sync / PRs / Config). `docs/documentation.html` regenerated via `make docs`.
- Tests: `cmd/ezs-mcp/server_test.go` asserts the expanded registry, required-param schema, and destructive annotations for all 21 tools.

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `gofmt -l .` / `go vet ./...`
- [x] `make docs` (HTML regen)
- [ ] Manual smoke via Claude Code MCP client