### PR TITLE
feat(cli): reject unknown flags + expand tab completion

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -127,6 +127,10 @@ ezs config set sync_strategy rebase                # switch to rebase-based sync
 ezs config set agent_command aider                 # switch the agent CLI
 ezs config set default_base_branch master          # override the global default base
 ezs config set github_token ghp_...                # optional; otherwise falls back to `gh auth`
+
+# Multi-word values (or any value starting with `-`) MUST be quoted so the
+# shell collapses them to a single argument. Common case is agent_command:
+ezs config set agent_command "claude --dangerously-skip-permissions"
 ```
 
 ### 4. Create your first stacked branch
@@ -271,9 +275,9 @@ echo 'eval "$(ezs --shell-init)"' >> ~/.bashrc
 echo 'eval "$(ezs --shell-init)"' >> ~/.zshrc
 ```
 
-This enables automatic directory changes for `goto`, `new`, `delete`, `sync`, `up`, and `down` commands.
+This enables automatic directory changes for `goto`, `new`, `delete`, `sync`, `up`, and `down` commands. It also installs bash/zsh tab completion for ezs subcommands, flags, branch names, stack hashes/names, and `config set` keys — `ezs <TAB>` shows commands, `ezs goto <TAB>` lists branches, `ezs sync <TAB>` lists stacks, `ezs config set <TAB>` lists valid keys, and `ezs <cmd> --<TAB>` lists that command's flags.
 
-Without shell integration, commands that would change your directory will instead print a helpful message with the path to `cd` to manually.
+Without shell integration, commands that would change your directory will instead print a helpful message with the path to `cd` to manually, and tab completion is unavailable.
 
 ---
 
@@ -608,7 +612,16 @@ ezs agent prompt --reset --repo feature
 ```bash
 # Set the agent CLI (default: claude)
 ezs config set agent_command claude
+
+# Pass flags to the agent CLI by quoting the whole value as one shell arg:
+ezs config set agent_command "claude --dangerously-skip-permissions"
+ezs config set agent_command "aider --model gpt-4"
 ```
+
+> Multi-word values must be quoted. The CLI takes `<value>` as a single
+> positional argument and rejects anything trailing — this keeps typos like
+> `ezs config set worktree_base_dir /tmp/foo --bogus` from being silently
+> stored as the literal path `/tmp/foo --bogus`.
 
 ---
 

--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -681,9 +681,8 @@ func registerTools(s *server.MCPServer) {
 			mcp.WithDestructiveHintAnnotation(false),
 		),
 		// toolHandler (not readOnlyHandler) because `ezs config` has no
-		// --json mode — readOnlyHandler would inject an unknown flag that
-		// Config silently drops, leaving behavior correct-by-accident and
-		// the abstraction misleading.
+		// --json mode — readOnlyHandler would inject `--json`, which the
+		// strict Config arg parser now rejects as an unknown subcommand.
 		toolHandler(commands.Config, func(req mcp.CallToolRequest) []string {
 			return []string{"show"}
 		}),

--- a/cmd/ezs/commands/config.go
+++ b/cmd/ezs/commands/config.go
@@ -62,19 +62,27 @@ func Config(args []string) error {
 		printConfigUsage()
 		return nil
 	case "set":
-		if len(args) < 3 {
-			return fmt.Errorf("usage: ezs config set <key> <value>")
+		// Always exactly 3 args. The previous code joined trailing tokens
+		// into the value with strings.Join, which silently absorbed typos
+		// like `set worktree_base_dir /tmp/foo --bogus` into the stored
+		// value. Multi-word values (notably agent_command shell command
+		// lines) must now be quoted: `set agent_command "claude --flag"`.
+		if len(args) != 3 {
+			return fmt.Errorf("usage: ezs config set <key> <value>\n(if the value contains spaces or starts with '-', wrap it in quotes — e.g. ezs config set agent_command \"claude --dangerously-skip-permissions\")")
 		}
-		return configSet(args[1], strings.Join(args[2:], " "))
+		return configSet(args[1], args[2])
 	case "show":
+		if len(args) != 1 {
+			return fmt.Errorf("usage: ezs config show")
+		}
 		return configShow()
 	case "export":
-		if len(args) < 2 {
+		if len(args) != 2 {
 			return fmt.Errorf("usage: ezs config export <file>")
 		}
 		return configExport(args[1])
 	case "import":
-		if len(args) < 2 {
+		if len(args) != 2 {
 			return fmt.Errorf("usage: ezs config import <file>")
 		}
 		return configImport(args[1])

--- a/cmd/ezs/commands/doctor.go
+++ b/cmd/ezs/commands/doctor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/ui"
+	"github.com/spf13/pflag"
 )
 
 // Doctor verifies that ezstack's runtime dependencies and config are healthy.
@@ -16,9 +17,9 @@ func Doctor(args []string) error {
 	if HasExamplesFlag("doctor", args) {
 		return nil
 	}
-	for _, a := range args {
-		if a == "-h" || a == "--help" {
-			fmt.Fprintf(os.Stderr, `%sCheck ezstack health%s
+	fs := pflag.NewFlagSet("doctor", pflag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%sCheck ezstack health%s
 
 %sUSAGE%s
     ezs doctor
@@ -26,8 +27,20 @@ func Doctor(args []string) error {
 Verifies required tools (git, gh, fzf) are installed and that the
 ezstack configuration is valid.
 `, ui.Bold, ui.Reset, ui.Cyan, ui.Reset)
+	}
+	helpFlag := fs.BoolP("help", "h", false, "Show help")
+	if err := fs.Parse(args); err != nil {
+		if err == pflag.ErrHelp {
 			return nil
 		}
+		return err
+	}
+	if *helpFlag {
+		fs.Usage()
+		return nil
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected argument: %s", fs.Arg(0))
 	}
 
 	fmt.Fprintf(os.Stderr, "%sezstack doctor%s\n\n", ui.Bold, ui.Reset)

--- a/cmd/ezs/commands/doctor.go
+++ b/cmd/ezs/commands/doctor.go
@@ -29,10 +29,10 @@ ezstack configuration is valid.
 `, ui.Bold, ui.Reset, ui.Cyan, ui.Reset)
 	}
 	helpFlag := fs.BoolP("help", "h", false, "Show help")
+	// pflag.ErrHelp is unreachable here because we registered our own --help
+	// flag (which sets *helpFlag instead of returning ErrHelp). Surface the
+	// help banner via the explicit *helpFlag branch below.
 	if err := fs.Parse(args); err != nil {
-		if err == pflag.ErrHelp {
-			return nil
-		}
 		return err
 	}
 	if *helpFlag {

--- a/cmd/ezs/commands/doctor.go
+++ b/cmd/ezs/commands/doctor.go
@@ -24,9 +24,12 @@ func Doctor(args []string) error {
 %sUSAGE%s
     ezs doctor
 
+%sOPTIONS%s
+    -h, --help    Show this help message
+
 Verifies required tools (git, gh, fzf) are installed and that the
 ezstack configuration is valid.
-`, ui.Bold, ui.Reset, ui.Cyan, ui.Reset)
+`, ui.Bold, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset)
 	}
 	helpFlag := fs.BoolP("help", "h", false, "Show help")
 	// pflag.ErrHelp is unreachable here because we registered our own --help

--- a/cmd/ezs/commands/doctor_test.go
+++ b/cmd/ezs/commands/doctor_test.go
@@ -188,6 +188,75 @@ func TestInfo_FallsBackToNotInstalledOnToolError(t *testing.T) {
 	}
 }
 
+// TestDoctor_RejectsUnknownFlag asserts that Doctor surfaces unknown flags as
+// errors instead of silently ignoring them. Before the pflag refactor, an
+// `ezs doctor --bogus` would run the full health check and exit 0 — masking
+// typos like `--debug` (intended for `list`) as success. This is the
+// regression gate.
+func TestDoctor_RejectsUnknownFlag(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmp)
+
+	var err error
+	captureStdAndErr(t, func() {
+		err = Doctor([]string{"--bogus-flag"})
+	})
+
+	if err == nil {
+		t.Fatal("Doctor with unknown flag returned nil — must reject")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("error %q should mention 'unknown flag'", err.Error())
+	}
+}
+
+// TestDoctor_RejectsExtraPositional pins down that Doctor takes no positional
+// args. Before the fix, extras were silently dropped on the floor.
+func TestDoctor_RejectsExtraPositional(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmp)
+
+	var err error
+	captureStdAndErr(t, func() {
+		err = Doctor([]string{"unexpected"})
+	})
+
+	if err == nil {
+		t.Fatal("Doctor with extra positional returned nil — must reject")
+	}
+	if !strings.Contains(err.Error(), "unexpected") {
+		t.Errorf("error %q should call out the unexpected argument", err.Error())
+	}
+}
+
+// TestDoctor_HelpFlagShortCircuits verifies the new pflag-driven --help path
+// returns nil without running the health checks (which would hit os.LookPath
+// and pollute stderr with the full report).
+func TestDoctor_HelpFlagShortCircuits(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmp)
+
+	for _, flag := range []string{"-h", "--help"} {
+		t.Run(flag, func(t *testing.T) {
+			var err error
+			_, stderr := captureStdAndErr(t, func() {
+				err = Doctor([]string{flag})
+			})
+			if err != nil {
+				t.Errorf("Doctor %s returned error: %v", flag, err)
+			}
+			if !strings.Contains(stderr, "Check ezstack health") {
+				t.Errorf("Doctor %s should print help banner:\n%s", flag, stderr)
+			}
+			// Health checks must not run on the help path — their output
+			// would include "git:" or "gh:" markers.
+			if strings.Contains(stderr, "ezstack doctor\n") {
+				t.Errorf("Doctor %s ran health checks instead of just help:\n%s", flag, stderr)
+			}
+		})
+	}
+}
+
 // TestInfo_ReportsConfigPresent writes a minimal config and asserts Info
 // reads it back instead of reporting missing.
 func TestInfo_ReportsConfigPresent(t *testing.T) {

--- a/cmd/ezs/commands/goto.go
+++ b/cmd/ezs/commands/goto.go
@@ -25,7 +25,8 @@ func Goto(args []string) error {
     ezs go [branch-name] [options]
 
 %sOPTIONS%s
-    -h, --help    Show this help message
+    --search <substring>    Fuzzy-match a branch name by substring (non-interactive)
+    -h, --help              Show this help message
 
 %sNOTES%s
     If branch-name is omitted, shows interactive selection of all worktrees.

--- a/cmd/ezs/commands/navigate.go
+++ b/cmd/ezs/commands/navigate.go
@@ -14,7 +14,7 @@ import (
 
 // Up navigates to the parent branch in the stack
 func Up(args []string) error {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+	if isNavigateHelpOnly(args) {
 		fmt.Fprintf(os.Stderr, `%sNavigate up the stack (toward parent/base)%s
 
 %sUSAGE%s
@@ -36,7 +36,7 @@ func Up(args []string) error {
 
 // Down navigates to a child branch in the stack
 func Down(args []string) error {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+	if isNavigateHelpOnly(args) {
 		fmt.Fprintf(os.Stderr, `%sNavigate down the stack (toward children/leaves)%s
 
 %sUSAGE%s
@@ -54,6 +54,15 @@ func Down(args []string) error {
 		return err
 	}
 	return navigate("down", steps)
+}
+
+// isNavigateHelpOnly returns true iff args is exactly one of `-h` or `--help`.
+// We require an exact match so `ezs up --help garbage` falls through to
+// parseNavigateArgs and gets rejected — matching the strict-flag philosophy
+// of the rest of this PR. The previous check looked only at args[0], which
+// let `--help <junk>` silently print help and exit 0.
+func isNavigateHelpOnly(args []string) bool {
+	return len(args) == 1 && (args[0] == "-h" || args[0] == "--help")
 }
 
 // parseNavigateArgs validates that args contains at most a single positive

--- a/cmd/ezs/commands/navigate.go
+++ b/cmd/ezs/commands/navigate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/git"
@@ -26,15 +27,10 @@ func Up(args []string) error {
 		return nil
 	}
 
-	steps := 1
-	if len(args) > 0 {
-		n, err := strconv.Atoi(args[0])
-		if err != nil || n < 1 {
-			return fmt.Errorf("invalid step count: %s. Must be a positive integer", args[0])
-		}
-		steps = n
+	steps, err := parseNavigateArgs("up", args)
+	if err != nil {
+		return err
 	}
-
 	return navigate("up", steps)
 }
 
@@ -53,16 +49,39 @@ func Down(args []string) error {
 		return nil
 	}
 
-	steps := 1
-	if len(args) > 0 {
-		n, err := strconv.Atoi(args[0])
-		if err != nil || n < 1 {
-			return fmt.Errorf("invalid step count: %s. Must be a positive integer", args[0])
-		}
-		steps = n
+	steps, err := parseNavigateArgs("down", args)
+	if err != nil {
+		return err
 	}
-
 	return navigate("down", steps)
+}
+
+// parseNavigateArgs validates that args contains at most a single positive
+// integer step count and returns it (defaulting to 1). Any flag-shaped arg or
+// extra positional arg is rejected so users learn about typos immediately
+// instead of silently no-oping.
+func parseNavigateArgs(direction string, args []string) (int, error) {
+	if len(args) == 0 {
+		return 1, nil
+	}
+	if len(args) > 1 {
+		return 0, fmt.Errorf("ezs %s takes at most one argument (step count); got %d", direction, len(args))
+	}
+	a := args[0]
+	// Try the integer parse first so "-1" gets the more specific
+	// "invalid step count" message rather than the misleading
+	// "unknown flag: -1". Any non-integer that starts with "-" is
+	// almost certainly a typoed flag, so we surface it as such.
+	if n, err := strconv.Atoi(a); err == nil {
+		if n < 1 {
+			return 0, fmt.Errorf("invalid step count: %s. Must be a positive integer", a)
+		}
+		return n, nil
+	}
+	if strings.HasPrefix(a, "-") {
+		return 0, fmt.Errorf("unknown flag: %s", a)
+	}
+	return 0, fmt.Errorf("invalid step count: %s. Must be a positive integer", a)
 }
 
 // navigate handles the shared logic for up/down navigation.

--- a/cmd/ezs/commands/navigate_test.go
+++ b/cmd/ezs/commands/navigate_test.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// parseNavigateArgs is the validation choke point for `ezs up`/`ezs down`.
+// Bash had a long-running silent-drop bug where `ezs up 1 typo` ignored the
+// extra arg and ran navigation anyway. These tests pin the validator against
+// every shape we've seen abused: missing arg, multiple positional args, a
+// flag-shaped token that the integer parser used to reject only because
+// strconv.Atoi happened to fail. The flag-shaped case is the load-bearing
+// one — it makes typos like `ezs up 2 --bogus` visible.
+
+func TestParseNavigateArgs_DefaultsToOne(t *testing.T) {
+	got, err := parseNavigateArgs("up", nil)
+	if err != nil {
+		t.Fatalf("nil args returned error: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("default = %d, want 1", got)
+	}
+}
+
+func TestParseNavigateArgs_AcceptsPositiveInt(t *testing.T) {
+	got, err := parseNavigateArgs("up", []string{"3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+
+func TestParseNavigateArgs_RejectsZeroAndNegative(t *testing.T) {
+	for _, bad := range []string{"0", "-1", "-99"} {
+		t.Run(bad, func(t *testing.T) {
+			_, err := parseNavigateArgs("up", []string{bad})
+			if err == nil {
+				t.Errorf("expected error for %q", bad)
+			}
+			// Negative integers must surface as "invalid step count", NOT
+			// "unknown flag" — the user clearly typed a number, even if a
+			// nonsensical one. The integer-parse-first ordering exists to
+			// give them the right diagnostic.
+			if !strings.Contains(err.Error(), "invalid step count") {
+				t.Errorf("error %q should say 'invalid step count' for %q", err.Error(), bad)
+			}
+		})
+	}
+}
+
+func TestParseNavigateArgs_RejectsNonInteger(t *testing.T) {
+	_, err := parseNavigateArgs("up", []string{"three"})
+	if err == nil {
+		t.Fatal("non-integer should be rejected")
+	}
+	if !strings.Contains(err.Error(), "invalid step count") {
+		t.Errorf("error %q should mention 'invalid step count'", err.Error())
+	}
+}
+
+// TestParseNavigateArgs_RejectsFlagShaped guards against the prior silent-
+// drop bug: `ezs up 1 --bogus` looked successful because `--bogus` was
+// dropped. Now any flag-shaped extra must surface as a flag error.
+func TestParseNavigateArgs_RejectsFlagShaped(t *testing.T) {
+	_, err := parseNavigateArgs("up", []string{"--bogus"})
+	if err == nil {
+		t.Fatal("flag-shaped arg should be rejected")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("error %q should mention 'unknown flag'", err.Error())
+	}
+}
+
+func TestParseNavigateArgs_RejectsExtraPositional(t *testing.T) {
+	_, err := parseNavigateArgs("down", []string{"1", "extra"})
+	if err == nil {
+		t.Fatal("extra positional should be rejected")
+	}
+	if !strings.Contains(err.Error(), "at most one argument") {
+		t.Errorf("error %q should mention the cardinality constraint", err.Error())
+	}
+}
+
+func TestParseNavigateArgs_RejectsExtraFlagAfterStep(t *testing.T) {
+	// The exact case the user originally hit: `ezs up 1 --bogus`. Two
+	// positional-shaped tokens — fail at the cardinality check. Whether
+	// the second token starts with `-` or not, we still reject.
+	_, err := parseNavigateArgs("up", []string{"1", "--bogus"})
+	if err == nil {
+		t.Fatal("step + bogus flag should be rejected")
+	}
+}
+
+func TestParseNavigateArgs_DirectionAppearsInError(t *testing.T) {
+	// The error message embeds direction so users can tell up vs down at a
+	// glance. Keep the string discoverable.
+	_, err := parseNavigateArgs("down", []string{"1", "2"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "down") {
+		t.Errorf("error %q should embed direction 'down'", err.Error())
+	}
+}

--- a/cmd/ezs/commands/navigate_test.go
+++ b/cmd/ezs/commands/navigate_test.go
@@ -105,3 +105,30 @@ func TestParseNavigateArgs_DirectionAppearsInError(t *testing.T) {
 		t.Errorf("error %q should embed direction 'down'", err.Error())
 	}
 }
+
+// TestIsNavigateHelpOnly pins down the strict shape of the help short-circuit.
+// The original code looked at args[0] only, so `ezs up --help garbage` printed
+// help and exited 0 — silently dropping the `garbage` token. The whole point
+// of this PR is "no silent acceptance of garbage", so we now require the args
+// list to be exactly one help token.
+func TestIsNavigateHelpOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"long help only", []string{"--help"}, true},
+		{"short help only", []string{"-h"}, true},
+		{"empty", nil, false},
+		{"step number", []string{"2"}, false},
+		{"help with extra positional", []string{"--help", "garbage"}, false},
+		{"help with extra flag", []string{"--help", "--bogus"}, false},
+		{"step then help", []string{"2", "--help"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNavigateHelpOnly(tc.args); got != tc.want {
+				t.Errorf("isNavigateHelpOnly(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -60,8 +60,8 @@ var commandFlags = map[string][]string{
 	"list":     {"--all", "-a", "--json", "--debug", "-d", "--help", "-h"},
 	"log":      {"--branch", "-b", "--json", "--help", "-h"},
 	"new":      {"--parent", "-p", "--worktree", "-w", "--template", "--cd", "-c", "--no-cd", "-C", "--init-submodules", "-s", "--no-init-submodules", "-S", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
-	"pr":       {"--help", "-h"},
-	"push":     {"--all", "-a", "--stack", "-s", "--branch", "-b", "--children", "--force", "-f", "--verify", "--all-remotes", "--help", "-h"},
+	"pr":       {"--draft-all", "--help", "-h"},
+	"push":     {"--stack", "-s", "--branch", "-b", "--force", "-f", "--verify", "--all-remotes", "--help", "-h"},
 	"reparent": {"--branch", "-b", "--parent", "-p", "--merge", "--rebase", "--no-rebase", "--help", "-h"},
 	"stack":    {"--branch", "-b", "--parent", "-p", "--base", "-B", "--help", "-h"},
 	"status":   {"--all", "-a", "--branch", "-b", "--debug", "-d", "--json", "--watch", "--help", "-h"},
@@ -79,6 +79,15 @@ var prSubcommandFlags = map[string][]string{
 	"merge":  {"--method", "-m", "--branch", "--no-delete-branch", "--help", "-h"},
 	"draft":  {"--branch", "--help", "-h"},
 	"stack":  {"--branch", "--help", "-h"},
+}
+
+// agentSubcommandFlags lists the flags `ezs agent prompt` accepts. Without
+// this, `agent prompt --<TAB>` falls through to commandFlags["agent"] and
+// suggests --cmd / --stack / --branch — flags from a different parser that
+// `prompt` doesn't accept. (`feature` / `feat` reuse the same flagset as
+// the default agent mode, so they pick up commandFlags["agent"] correctly.)
+var agentSubcommandFlags = map[string][]string{
+	"prompt": {"--shipped", "--custom", "--repo", "--edit", "--reset", "--help", "-h"},
 }
 
 // branchPositionalCommands take a branch name as their first positional arg.
@@ -186,6 +195,18 @@ func printCompletions(args []string) {
 		// having a rich flag set.
 		if cmd == "pr" && len(args) >= 3 {
 			if flags, ok := prSubcommandFlags[args[1]]; ok {
+				for _, f := range flags {
+					fmt.Println(f)
+				}
+				return
+			}
+		}
+		// `ezs agent prompt --<TAB>` — the prompt subcommand has its own
+		// flagset (--shipped/--custom/--repo/--edit/--reset). Without this
+		// branch we'd fall through to commandFlags["agent"] and suggest
+		// flags from the work/feature flagset that prompt doesn't accept.
+		if cmd == "agent" && len(args) >= 3 {
+			if flags, ok := agentSubcommandFlags[args[1]]; ok {
 				for _, f := range flags {
 					fmt.Println(f)
 				}

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -290,6 +290,14 @@ func printCompletions(args []string) {
 		return
 	}
 	if branchOrStackPositionalCommands[cmd] {
+		// `delete --stack` / `delete -s` narrows the positional to a stack
+		// hash (see delete.go); skip branches so the menu matches intent.
+		for _, a := range args[1 : len(args)-1] {
+			if a == "--stack" || a == "-s" {
+				printStackIdentifiers()
+				return
+			}
+		}
 		printBranchNames()
 		printStackIdentifiers()
 		return
@@ -327,7 +335,8 @@ func printBranchNames() {
 
 // printStackIdentifiers emits each stack's hash and (when set) its name.
 // Both forms are accepted by `ezs sync`/`ezs agent -s` so completing both is
-// useful. Best-effort: silent on lookup failure.
+// useful. De-dupes because Hash == Name (or two stacks sharing a name) would
+// otherwise emit the same string twice. Best-effort: silent on lookup failure.
 func printStackIdentifiers() {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -337,15 +346,22 @@ func printStackIdentifiers() {
 	if err != nil {
 		return
 	}
+	seen := map[string]struct{}{}
+	emit := func(id string) {
+		if id == "" {
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		fmt.Println(id)
+	}
 	for _, s := range mgr.ListStacks() {
 		if s == nil {
 			continue
 		}
-		if s.Hash != "" {
-			fmt.Println(s.Hash)
-		}
-		if s.Name != "" {
-			fmt.Println(s.Name)
-		}
+		emit(s.Hash)
+		emit(s.Name)
 	}
 }

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -40,13 +40,19 @@ var configKeys = []string{
 // only for completion. When a command gains/loses a flag, update both spots.
 //
 // TestCompletions_FlagTableMatchesHelpOutput in itests/completions_test.go is
-// a drift gate: it runs `ezs <cmd> --help` for every entry below, parses the
-// OPTIONS section, and asserts every flag printed by the binary appears in
-// this table. So forgetting to update the table after adding a flag fails
-// the test instead of silently shipping incomplete completion. The test is
-// asymmetric on purpose — extra entries here are tolerated (some commands
-// document help-only flags or pass-throughs to git), but missing entries are
-// treated as drift.
+// a *bidirectional* drift gate. For every command it asserts:
+//
+//  1. help ⊆ completion: every flag in `<cmd> --help` OPTIONS appears in
+//     this table. Catches "command grew a flag, table didn't".
+//  2. completion ⊆ help ∪ toleratedExtras: every flag this table emits is
+//     either documented in `<cmd> --help` OR explicitly allowlisted in the
+//     test's toleratedExtras map (for advanced flags that the parser
+//     accepts but the help banner intentionally omits, e.g. agent's
+//     internal --save-prompt/--no-push/--preset/--no-mcp).
+//
+// So both "missing entry" and "phantom entry" fail CI. Don't add a flag
+// here that the parser doesn't actually accept — it'll trip direction (2)
+// and confuse users who tab-complete to a flag the binary then rejects.
 var commandFlags = map[string][]string{
 	"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
 	"amend":    {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+)
+
+// topLevelCommands is what we emit for `ezs <TAB>`. Aliases (ls, st, ci, n,
+// rm, del, rp, go, cfg) are intentionally omitted — bash already does prefix
+// matching on the long names, and listing both forms doubles the menu without
+// helping anyone.
+var topLevelCommands = []string{
+	"agent", "amend", "commit", "config", "delete", "diff", "doctor", "down",
+	"goto", "list", "log", "menu", "new", "pr", "push",
+	"reparent", "stack", "status", "sync", "unstack", "up",
+}
+
+var prSubcommands = []string{"create", "draft", "merge", "stack", "update"}
+
+var configSubcommands = []string{"set", "show", "export", "import"}
+
+// configKeys mirrors the keys accepted by `configSet` in commands/config.go.
+// Keep in sync when a new key is added.
+var configKeys = []string{
+	"worktree_base_dir",
+	"default_base_branch",
+	"github_token",
+	"cd_after_new",
+	"use_worktrees",
+	"init_submodules",
+	"sync_strategy",
+	"agent_command",
+}
+
+// commandFlags lists the flags each command accepts. Source of truth lives
+// next to each command's pflag set; this map is a hand-maintained copy used
+// only for completion. When a command gains/loses a flag, update both spots.
+var commandFlags = map[string][]string{
+	"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
+	"amend":    {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
+	"commit":   {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
+	"config":   {"--help", "-h"},
+	"delete":   {"--force", "-f", "--stack", "-s", "--cascade", "--help", "-h"},
+	"diff":     {"--stat", "--help", "-h"},
+	"doctor":   {"--help", "-h"},
+	"down":     {"--help", "-h"},
+	"goto":     {"--search", "--help", "-h"},
+	"list":     {"--all", "-a", "--json", "--debug", "-d", "--help", "-h"},
+	"log":      {"--help", "-h"},
+	"new":      {"--parent", "-p", "--worktree", "-w", "--cd", "-c", "--no-cd", "-C", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
+	"pr":       {"--help", "-h"},
+	"push":     {"--all", "-a", "--force", "-f", "--children", "--help", "-h"},
+	"reparent": {"--branch", "-b", "--parent", "-p", "--help", "-h"},
+	"stack":    {"--branch", "-b", "--parent", "-p", "--help", "-h"},
+	"status":   {"--all", "-a", "--branch", "-b", "--debug", "-d", "--json", "--watch", "--help", "-h"},
+	"sync":     {"--stats", "--squash", "--stack", "-s", "--all", "-a", "--current", "-c", "--branch", "-b", "--parent", "-p", "--children", "-C", "--merge", "--rebase", "--no-delete-local", "--dry-run", "--continue", "--no-autostash", "--json", "--help", "-h"},
+	"unstack":  {"--branch", "-b", "--help", "-h"},
+	"up":       {"--help", "-h"},
+}
+
+// branchPositionalCommands take a branch name as their first positional arg.
+// `new` is intentionally excluded — its first positional is the *new* branch
+// name (which by definition doesn't exist yet), so completing existing branch
+// names there would be misleading.
+var branchPositionalCommands = map[string]bool{
+	"goto":     true,
+	"go":       true,
+	"reparent": true,
+	"rp":       true,
+	"unstack":  true,
+	"stack":    true,
+}
+
+// branchOrStackPositionalCommands accept either a branch name or a stack hash.
+var branchOrStackPositionalCommands = map[string]bool{
+	"delete": true,
+	"del":    true,
+	"rm":     true,
+}
+
+// stackPositionalCommands take a stack hash/name as their first positional arg.
+var stackPositionalCommands = map[string]bool{
+	"sync": true,
+}
+
+// branchValueFlags are flags whose value is a branch name. After one of these
+// in the previous word we complete branches.
+var branchValueFlags = map[string]bool{
+	"-b":       true,
+	"--branch": true,
+	"-p":       true,
+	"--parent": true,
+}
+
+// stackValueFlags are flags whose value is a stack hash/name. Note: `-s` is
+// boolean for sync/delete, only `agent -s <hash>` takes a value, so we keep
+// this map command-aware below rather than a flat lookup.
+var stackValueLongFlags = map[string]bool{
+	"--stack": true,
+}
+
+// printCompletions writes one candidate per line to stdout based on the
+// position of the cursor, encoded in args. Bash's compgen does the prefix
+// filtering, so we always dump the full candidate set for the current slot.
+//
+// args is exactly `${COMP_WORDS[@]:1}` from the shell function — every word
+// after `ezs`, including the (possibly empty) word under the cursor.
+func printCompletions(args []string) {
+	// `ezs <TAB>` or `ezs <prefix><TAB>` — only one word so far, complete a
+	// top-level command.
+	if len(args) <= 1 {
+		for _, cmd := range topLevelCommands {
+			fmt.Println(cmd)
+		}
+		return
+	}
+
+	cmd := args[0]
+	cur := args[len(args)-1]
+	prev := ""
+	if len(args) >= 2 {
+		prev = args[len(args)-2]
+	}
+
+	// Flag completion: when the user is typing a flag, show the flag set for
+	// this command. We do this before any positional logic so `-<TAB>` always
+	// resolves to flags rather than being interpreted as a value.
+	if strings.HasPrefix(cur, "-") {
+		// `config set agent_command claude --<TAB>` — the user is typing a
+		// flag *inside the value*, not for ezs itself. Suggesting ezs's own
+		// flags here would be actively wrong. Same applies to any `config
+		// set` value slot.
+		if cmd == "config" && len(args) >= 4 && args[1] == "set" {
+			return
+		}
+		if flags, ok := commandFlags[cmd]; ok {
+			for _, f := range flags {
+				fmt.Println(f)
+			}
+		}
+		return
+	}
+
+	// Value-of-flag completion: if the previous word is a flag whose value
+	// names a branch or stack, complete that.
+	if branchValueFlags[prev] {
+		printBranchNames()
+		return
+	}
+	if stackValueLongFlags[prev] || (cmd == "agent" && prev == "-s") {
+		printStackIdentifiers()
+		return
+	}
+
+	// Subcommand-aware completion.
+	switch cmd {
+	case "pr":
+		// `ezs pr <TAB>` — only the immediate slot after `pr` is a subcommand.
+		if len(args) == 2 {
+			for _, sub := range prSubcommands {
+				fmt.Println(sub)
+			}
+		}
+		return
+	case "config":
+		switch len(args) {
+		case 2:
+			for _, sub := range configSubcommands {
+				fmt.Println(sub)
+			}
+		case 3:
+			if args[1] == "set" {
+				for _, k := range configKeys {
+					fmt.Println(k)
+				}
+			}
+		}
+		return
+	case "agent":
+		// `ezs agent <TAB>` — first positional is a mode subcommand.
+		if len(args) == 2 {
+			fmt.Println("feature")
+			fmt.Println("feat")
+			fmt.Println("prompt")
+			return
+		}
+		// `ezs agent prompt <TAB>` — second positional is a prompt type.
+		if args[1] == "prompt" && len(args) == 3 {
+			fmt.Println("work")
+			fmt.Println("feature")
+		}
+		return
+	}
+
+	// Generic positional completion. Only the *first* positional after the
+	// command is meaningful for branch/stack completion in the current
+	// commands; subsequent positionals (e.g. `ezs reparent <branch> <parent>`)
+	// also want a branch name, so we check the count loosely.
+	if branchPositionalCommands[cmd] {
+		printBranchNames()
+		return
+	}
+	if branchOrStackPositionalCommands[cmd] {
+		printBranchNames()
+		printStackIdentifiers()
+		return
+	}
+	if stackPositionalCommands[cmd] {
+		printStackIdentifiers()
+	}
+}
+
+// printBranchNames emits all branches known to ezstack across every stack.
+// Best-effort: silently emits nothing if we can't load the stack manager
+// (e.g. running from outside a configured repo). De-dupes because the same
+// branch can appear in cross-stack contexts.
+func printBranchNames() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	mgr, err := stack.NewReadOnlyManager(cwd)
+	if err != nil {
+		return
+	}
+	seen := map[string]struct{}{}
+	for _, b := range mgr.GetAllBranchesInAllStacks() {
+		if b == nil || b.Name == "" {
+			continue
+		}
+		if _, dup := seen[b.Name]; dup {
+			continue
+		}
+		seen[b.Name] = struct{}{}
+		fmt.Println(b.Name)
+	}
+}
+
+// printStackIdentifiers emits each stack's hash and (when set) its name.
+// Both forms are accepted by `ezs sync`/`ezs agent -s` so completing both is
+// useful. Best-effort: silent on lookup failure.
+func printStackIdentifiers() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	mgr, err := stack.NewReadOnlyManager(cwd)
+	if err != nil {
+		return
+	}
+	for _, s := range mgr.ListStacks() {
+		if s == nil {
+			continue
+		}
+		if s.Hash != "" {
+			fmt.Println(s.Hash)
+		}
+		if s.Name != "" {
+			fmt.Println(s.Name)
+		}
+	}
+}

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -38,27 +38,47 @@ var configKeys = []string{
 // commandFlags lists the flags each command accepts. Source of truth lives
 // next to each command's pflag set; this map is a hand-maintained copy used
 // only for completion. When a command gains/loses a flag, update both spots.
+//
+// TestCompletions_FlagTableMatchesHelpOutput in itests/completions_test.go is
+// a drift gate: it runs `ezs <cmd> --help` for every entry below, parses the
+// OPTIONS section, and asserts every flag printed by the binary appears in
+// this table. So forgetting to update the table after adding a flag fails
+// the test instead of silently shipping incomplete completion. The test is
+// asymmetric on purpose — extra entries here are tolerated (some commands
+// document help-only flags or pass-throughs to git), but missing entries are
+// treated as drift.
 var commandFlags = map[string][]string{
 	"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
 	"amend":    {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
 	"commit":   {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
 	"config":   {"--help", "-h"},
 	"delete":   {"--force", "-f", "--stack", "-s", "--cascade", "--help", "-h"},
-	"diff":     {"--stat", "--help", "-h"},
+	"diff":     {"--branch", "-b", "--stat", "--json", "--help", "-h"},
 	"doctor":   {"--help", "-h"},
 	"down":     {"--help", "-h"},
 	"goto":     {"--search", "--help", "-h"},
 	"list":     {"--all", "-a", "--json", "--debug", "-d", "--help", "-h"},
-	"log":      {"--help", "-h"},
-	"new":      {"--parent", "-p", "--worktree", "-w", "--cd", "-c", "--no-cd", "-C", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
+	"log":      {"--branch", "-b", "--json", "--help", "-h"},
+	"new":      {"--parent", "-p", "--worktree", "-w", "--template", "--cd", "-c", "--no-cd", "-C", "--init-submodules", "-s", "--no-init-submodules", "-S", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
 	"pr":       {"--help", "-h"},
-	"push":     {"--all", "-a", "--force", "-f", "--children", "--help", "-h"},
-	"reparent": {"--branch", "-b", "--parent", "-p", "--help", "-h"},
-	"stack":    {"--branch", "-b", "--parent", "-p", "--help", "-h"},
+	"push":     {"--all", "-a", "--stack", "-s", "--branch", "-b", "--children", "--force", "-f", "--verify", "--all-remotes", "--help", "-h"},
+	"reparent": {"--branch", "-b", "--parent", "-p", "--merge", "--rebase", "--no-rebase", "--help", "-h"},
+	"stack":    {"--branch", "-b", "--parent", "-p", "--base", "-B", "--help", "-h"},
 	"status":   {"--all", "-a", "--branch", "-b", "--debug", "-d", "--json", "--watch", "--help", "-h"},
 	"sync":     {"--stats", "--squash", "--stack", "-s", "--all", "-a", "--current", "-c", "--branch", "-b", "--parent", "-p", "--children", "-C", "--merge", "--rebase", "--no-delete-local", "--dry-run", "--continue", "--no-autostash", "--json", "--help", "-h"},
 	"unstack":  {"--branch", "-b", "--help", "-h"},
 	"up":       {"--help", "-h"},
+}
+
+// prSubcommandFlags lists the flags each `pr <subcommand>` accepts. Used so
+// `ezs pr create --<TAB>` surfaces create's flags rather than just the
+// top-level `--help`/`-h` from `pr` itself. Same drift-gate test applies.
+var prSubcommandFlags = map[string][]string{
+	"create": {"--stack", "-s", "--draft-all", "--title", "-t", "--body", "-b", "--draft", "-d", "--branch", "--help", "-h"},
+	"update": {"--branch", "--help", "-h"},
+	"merge":  {"--method", "-m", "--branch", "--no-delete-branch", "--help", "-h"},
+	"draft":  {"--branch", "--help", "-h"},
+	"stack":  {"--branch", "--help", "-h"},
 }
 
 // branchPositionalCommands take a branch name as their first positional arg.
@@ -86,20 +106,36 @@ var stackPositionalCommands = map[string]bool{
 	"sync": true,
 }
 
-// branchValueFlags are flags whose value is a branch name. After one of these
-// in the previous word we complete branches.
-var branchValueFlags = map[string]bool{
-	"-b":       true,
-	"--branch": true,
-	"-p":       true,
-	"--parent": true,
+// branchValueFlagsByCmd lists the flags whose value is a branch name, scoped
+// per command. Some flags share a name across commands but have different
+// types — e.g. `-p`/`--parent` is a string (parent branch) for `new`, `stack`,
+// and `reparent`, but a *boolean* (rebase onto parent) for `sync`. A flat map
+// would emit branch completions after `ezs sync -p`, where the next slot is
+// not a value at all. Same for `-b`/`--branch`: value-bearing for most
+// commands but never used boolean — kept per-command for consistency and to
+// avoid surprises if a future command repurposes the short form.
+var branchValueFlagsByCmd = map[string]map[string]bool{
+	"new":      {"-p": true, "--parent": true},
+	"stack":    {"-b": true, "--branch": true, "-p": true, "--parent": true},
+	"reparent": {"-b": true, "--branch": true, "-p": true, "--parent": true},
+	"unstack":  {"-b": true, "--branch": true},
+	"sync":     {"-b": true, "--branch": true}, // -p is BOOL for sync; do NOT add
+	"delete":   {"-b": true, "--branch": true},
+	"status":   {"-b": true, "--branch": true},
+	"list":     {"-b": true, "--branch": true},
+	"diff":     {"-b": true, "--branch": true},
+	"log":      {"-b": true, "--branch": true},
+	"push":     {"-b": true, "--branch": true},
+	"agent":    {"-b": true, "--branch": true},
 }
 
-// stackValueFlags are flags whose value is a stack hash/name. Note: `-s` is
-// boolean for sync/delete, only `agent -s <hash>` takes a value, so we keep
-// this map command-aware below rather than a flat lookup.
-var stackValueLongFlags = map[string]bool{
-	"--stack": true,
+// stackValueFlagsByCmd lists the flags whose value is a stack hash/name,
+// scoped per command. `--stack`/`-s` is a *boolean* for `sync`, `delete`, and
+// `push` (means "operate on the current stack" or "treat positional as
+// stack"), but a *string* (stack hash/name to target) for `agent`. The flat
+// previous map mistakenly fired stack completion in all four commands.
+var stackValueFlagsByCmd = map[string]map[string]bool{
+	"agent": {"-s": true, "--stack": true},
 }
 
 // printCompletions writes one candidate per line to stdout based on the
@@ -120,9 +156,17 @@ func printCompletions(args []string) {
 
 	cmd := args[0]
 	cur := args[len(args)-1]
+	// Bash splits on `=` per default COMP_WORDBREAKS, so `--branch=foo<TAB>`
+	// arrives as ("--branch", "=", "foo"). Look one further back when the
+	// previous word is "=" so the value-of-flag router still recognizes the
+	// underlying flag. `--branch=` (no value yet) lands the cursor on "" with
+	// prev="=" and prev-prev="--branch", which is exactly what we want.
 	prev := ""
 	if len(args) >= 2 {
 		prev = args[len(args)-2]
+		if prev == "=" && len(args) >= 3 {
+			prev = args[len(args)-3]
+		}
 	}
 
 	// Flag completion: when the user is typing a flag, show the flag set for
@@ -136,6 +180,18 @@ func printCompletions(args []string) {
 		if cmd == "config" && len(args) >= 4 && args[1] == "set" {
 			return
 		}
+		// `ezs pr <sub> --<TAB>` — surface the subcommand's own flags rather
+		// than the bare `--help`/`-h` from `pr` itself. Without this branch,
+		// `pr create --<TAB>` was emitting just `--help`/`-h` despite create
+		// having a rich flag set.
+		if cmd == "pr" && len(args) >= 3 {
+			if flags, ok := prSubcommandFlags[args[1]]; ok {
+				for _, f := range flags {
+					fmt.Println(f)
+				}
+				return
+			}
+		}
 		if flags, ok := commandFlags[cmd]; ok {
 			for _, f := range flags {
 				fmt.Println(f)
@@ -145,12 +201,15 @@ func printCompletions(args []string) {
 	}
 
 	// Value-of-flag completion: if the previous word is a flag whose value
-	// names a branch or stack, complete that.
-	if branchValueFlags[prev] {
+	// names a branch or stack, complete that. Per-command lookup so that
+	// flags that share a name across commands but differ in type (e.g. -p
+	// is string for `new`/`reparent` but bool for `sync`) don't surface
+	// false-positive completions.
+	if branchValueFlagsByCmd[cmd][prev] {
 		printBranchNames()
 		return
 	}
-	if stackValueLongFlags[prev] || (cmd == "agent" && prev == "-s") {
+	if stackValueFlagsByCmd[cmd][prev] {
 		printStackIdentifiers()
 		return
 	}

--- a/cmd/ezs/completions_test.go
+++ b/cmd/ezs/completions_test.go
@@ -264,3 +264,142 @@ func TestPrintCompletions_NewExcludedFromBranchPositional(t *testing.T) {
 	}
 	_ = got
 }
+
+// TestPrintCompletions_SyncDashPNotBranchValue locks down that `-p`/`--parent`
+// is NOT routed to branch completion under `sync` — sync.go declares them
+// boolean (BoolP "Rebase onto parent"). The previous flat branchValueFlags
+// map fired branch completion regardless of command, which would have
+// surfaced false positives in a real repo.
+func TestPrintCompletions_SyncDashPNotBranchValue(t *testing.T) {
+	if branchValueFlagsByCmd["sync"]["-p"] {
+		t.Error("sync's -p must NOT be in branchValueFlagsByCmd['sync'] — it's a boolean flag in sync.go")
+	}
+	if branchValueFlagsByCmd["sync"]["--parent"] {
+		t.Error("sync's --parent must NOT be in branchValueFlagsByCmd['sync'] — it's a boolean flag in sync.go")
+	}
+	// And conversely, structural pin: `new`/`reparent`/`stack` SHOULD have
+	// it (they take a parent branch name as the value).
+	for _, cmd := range []string{"new", "reparent", "stack"} {
+		if !branchValueFlagsByCmd[cmd]["-p"] {
+			t.Errorf("%s's -p must be in branchValueFlagsByCmd[%q] — takes a branch value", cmd, cmd)
+		}
+		if !branchValueFlagsByCmd[cmd]["--parent"] {
+			t.Errorf("%s's --parent must be in branchValueFlagsByCmd[%q] — takes a branch value", cmd, cmd)
+		}
+	}
+}
+
+// TestPrintCompletions_StackFlagOnlyValueBearingForAgent locks down the
+// `--stack`/`-s` typing fix. agent.go uses StringP (value-bearing); sync,
+// delete, push use BoolP. The pre-fix flat stackValueLongFlags fired stack
+// completion in all four commands.
+func TestPrintCompletions_StackFlagOnlyValueBearingForAgent(t *testing.T) {
+	if !stackValueFlagsByCmd["agent"]["--stack"] {
+		t.Error("agent's --stack must be value-bearing (StringP in agent.go)")
+	}
+	if !stackValueFlagsByCmd["agent"]["-s"] {
+		t.Error("agent's -s must be value-bearing (StringP in agent.go)")
+	}
+	for _, cmd := range []string{"sync", "delete", "push"} {
+		if stackValueFlagsByCmd[cmd]["--stack"] {
+			t.Errorf("%s's --stack must NOT be value-bearing — it's BoolP in %s.go", cmd, cmd)
+		}
+		if stackValueFlagsByCmd[cmd]["-s"] {
+			t.Errorf("%s's -s must NOT be value-bearing — it's BoolP in %s.go", cmd, cmd)
+		}
+	}
+}
+
+// TestPrintCompletions_NewSurfacesAllFlags pins the regression that v1 of
+// this PR shipped: `--init-submodules`/`-s` and `--no-init-submodules`/`-S`
+// were defined in new.go:64-65 but missing from commandFlags["new"], so
+// `ezs new --<TAB>` silently dropped them. The integration-test drift
+// gate (TestCompletions_FlagTableMatchesHelpOutput) catches this for any
+// command going forward; this is the explicit case-by-case guard.
+func TestPrintCompletions_NewSurfacesAllFlags(t *testing.T) {
+	got := captureCompletions(t, []string{"new", "--"})
+	for _, want := range []string{
+		"--parent", "-p",
+		"--worktree", "-w",
+		"--cd", "-c",
+		"--no-cd", "-C",
+		"--init-submodules", "-s",
+		"--no-init-submodules", "-S",
+		"--from-worktree", "-f",
+		"--from-remote", "-r",
+		"--help", "-h",
+	} {
+		if !contains(got, want) {
+			t.Errorf("new --<TAB> missing %q; got %v", want, got)
+		}
+	}
+}
+
+// TestPrintCompletions_PRSubcommandFlagsSurface covers `ezs pr <sub> --<TAB>`.
+// Pre-fix this emitted only `--help`/`-h` (the bare pr commandFlags entry)
+// because the routing didn't know about per-subcommand flag sets.
+func TestPrintCompletions_PRSubcommandFlagsSurface(t *testing.T) {
+	tests := []struct {
+		sub  string
+		want []string
+	}{
+		{"create", []string{"--title", "-t", "--body", "-b", "--draft", "-d", "--stack", "-s", "--draft-all", "--branch"}},
+		{"update", []string{"--branch", "--help", "-h"}},
+		{"merge", []string{"--method", "-m", "--branch", "--no-delete-branch"}},
+		{"draft", []string{"--branch", "--help"}},
+		{"stack", []string{"--branch", "--help"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.sub, func(t *testing.T) {
+			got := captureCompletions(t, []string{"pr", tc.sub, "--"})
+			for _, w := range tc.want {
+				if !contains(got, w) {
+					t.Errorf("pr %s --<TAB> missing %q; got %v", tc.sub, w, got)
+				}
+			}
+		})
+	}
+}
+
+// TestPrintCompletions_BranchEqualsValueRoutesCorrectly covers the bash
+// COMP_WORDBREAKS-on-`=` quirk: `--branch=foo<TAB>` arrives as
+// (..., "--branch", "=", "foo"). The previous-word router must look one
+// further back when prev is "=" so it still fires branch completion.
+func TestPrintCompletions_BranchEqualsValueRoutesCorrectly(t *testing.T) {
+	// Out-of-repo, branch lookup is silent (best-effort), so we can't
+	// assert specific branch names. What we CAN assert is that we don't
+	// fall through to the wrong code path: stack hashes for sync, or
+	// pr subcommands, or anything else.
+	got := captureCompletions(t, []string{"sync", "--branch", "=", ""})
+	for _, leaked := range []string{
+		"--all", "--squash", "create", "draft", "set", "show", "feature",
+	} {
+		if contains(got, leaked) {
+			t.Errorf("`--branch=<TAB>` leaked %q (should be branch-completion path): %v", leaked, got)
+		}
+	}
+}
+
+// TestPrintCompletions_StackBoolFlagSyncFallsThrough: pre-fix, `sync --stack
+// <TAB>` fired the value-of-flag path (treated --stack as value-bearing) and
+// emitted stack hashes for the wrong reason. Post-fix, --stack is recognized
+// as boolean for sync, so we fall through to the positional path —
+// stackPositionalCommands["sync"] still emits stack hashes, just for the
+// right reason. We can't tell the two paths apart from output alone (both
+// emit stacks), so the structural test
+// TestPrintCompletions_StackFlagOnlyValueBearingForAgent above is the real
+// gate; this one just guards that we don't accidentally regress to emitting
+// branches (which the value-of-flag path never did, but which a future
+// refactor might wrongly add).
+func TestPrintCompletions_StackBoolFlagSyncFallsThrough(t *testing.T) {
+	// We deliberately don't seed branches here — out-of-repo, branch lookup
+	// is silent. The test value is asserting that no _other_ token leaks
+	// (e.g. flags or subcommand names) — a cleanliness check on the
+	// fall-through path.
+	got := captureCompletions(t, []string{"sync", "--stack", ""})
+	for _, leaked := range []string{"--all", "--squash", "create", "set", "feature", "prompt"} {
+		if contains(got, leaked) {
+			t.Errorf("sync --stack <TAB> leaked %q from a wrong path: %v", leaked, got)
+		}
+	}
+}

--- a/cmd/ezs/completions_test.go
+++ b/cmd/ezs/completions_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// captureCompletions runs printCompletions with the given args and returns
+// the lines emitted to stdout. printCompletions writes one candidate per
+// line and never errors, so we just collect everything.
+func captureCompletions(t *testing.T, args []string) []string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	printCompletions(args)
+
+	w.Close()
+	os.Stdout = orig
+	out := <-done
+	if out == "" {
+		return nil
+	}
+	// Trim final newline so we don't get a trailing empty entry.
+	out = strings.TrimRight(out, "\n")
+	return strings.Split(out, "\n")
+}
+
+func contains(slice []string, s string) bool {
+	return slices.Contains(slice, s)
+}
+
+// TestPrintCompletions_TopLevelOnEmpty asserts the bare `ezs <TAB>` case —
+// COMP_WORDS is (ezs, "") so we receive a single empty arg. This is the
+// most common completion path; pin it down.
+func TestPrintCompletions_TopLevelOnEmpty(t *testing.T) {
+	got := captureCompletions(t, []string{""})
+	for _, want := range []string{"new", "list", "status", "doctor", "config", "pr", "agent"} {
+		if !contains(got, want) {
+			t.Errorf("expected %q in top-level completions, got %v", want, got)
+		}
+	}
+}
+
+// TestPrintCompletions_TopLevelOnPartial covers `ezs c<TAB>`. Bash filters
+// candidates by prefix via compgen, so we still emit the full top-level list.
+// Before the rewrite, this case fell through and emitted nothing — bash then
+// fell back to filename completion, which was the user-visible bug.
+func TestPrintCompletions_TopLevelOnPartial(t *testing.T) {
+	got := captureCompletions(t, []string{"c"})
+	if !contains(got, "config") {
+		t.Errorf("partial 'c' should still emit full list (compgen filters); got %v", got)
+	}
+	if len(got) < 5 {
+		t.Errorf("expected full top-level list, got only %d entries: %v", len(got), got)
+	}
+}
+
+func TestPrintCompletions_TopLevelIncludesDoctor(t *testing.T) {
+	// doctor was missing from the original list — its only entrypoint was the
+	// dispatch typo path. Regression guard.
+	got := captureCompletions(t, []string{""})
+	if !contains(got, "doctor") {
+		t.Errorf("doctor must be in top-level completions, got %v", got)
+	}
+}
+
+func TestPrintCompletions_TopLevelExcludesAliases(t *testing.T) {
+	// We deliberately keep `ls`/`st`/`ci`/`del`/`rm`/`go`/`rp`/`n`/`cfg` out
+	// of the top-level list to avoid doubling the menu. Aliases still work
+	// at runtime; they just don't surface in completion. Pin this so a
+	// future contributor doesn't "helpfully" add them back.
+	got := captureCompletions(t, []string{""})
+	for _, alias := range []string{"ls", "st", "ci", "del", "rm", "go", "rp", "n", "cfg"} {
+		if contains(got, alias) {
+			t.Errorf("alias %q should not appear in top-level completions: %v", alias, got)
+		}
+	}
+}
+
+func TestPrintCompletions_PRSubcommands(t *testing.T) {
+	got := captureCompletions(t, []string{"pr", ""})
+	for _, want := range []string{"create", "draft", "merge", "stack", "update"} {
+		if !contains(got, want) {
+			t.Errorf("missing pr subcommand %q in %v", want, got)
+		}
+	}
+}
+
+func TestPrintCompletions_ConfigSubcommands(t *testing.T) {
+	got := captureCompletions(t, []string{"config", ""})
+	for _, want := range []string{"set", "show", "export", "import"} {
+		if !contains(got, want) {
+			t.Errorf("missing config subcommand %q in %v", want, got)
+		}
+	}
+}
+
+func TestPrintCompletions_ConfigSetKeys(t *testing.T) {
+	got := captureCompletions(t, []string{"config", "set", ""})
+	// All keys mirrored from configSet's switch in commands/config.go.
+	for _, want := range []string{
+		"worktree_base_dir", "default_base_branch", "github_token",
+		"cd_after_new", "use_worktrees", "init_submodules",
+		"sync_strategy", "agent_command",
+	} {
+		if !contains(got, want) {
+			t.Errorf("missing config key %q in %v", want, got)
+		}
+	}
+}
+
+// TestPrintCompletions_ConfigShowEmitsNothing locks down that `ezs config
+// show <TAB>` doesn't keep handing out config keys — show takes no further
+// args, so completion should stop there. This also guards that we don't
+// accidentally fall through to a generic positional handler.
+func TestPrintCompletions_ConfigShowEmitsNothing(t *testing.T) {
+	got := captureCompletions(t, []string{"config", "show", ""})
+	if len(got) != 0 {
+		t.Errorf("config show <TAB> should emit nothing, got %v", got)
+	}
+}
+
+func TestPrintCompletions_AgentSubcommands(t *testing.T) {
+	got := captureCompletions(t, []string{"agent", ""})
+	for _, want := range []string{"feature", "feat", "prompt"} {
+		if !contains(got, want) {
+			t.Errorf("missing agent subcommand %q in %v", want, got)
+		}
+	}
+}
+
+func TestPrintCompletions_AgentPromptTypes(t *testing.T) {
+	got := captureCompletions(t, []string{"agent", "prompt", ""})
+	for _, want := range []string{"work", "feature"} {
+		if !contains(got, want) {
+			t.Errorf("missing prompt type %q in %v", want, got)
+		}
+	}
+}
+
+// TestPrintCompletions_FlagsForCommand asserts `ezs <cmd> --<TAB>` emits the
+// flag set declared for that command. Spot-check both a long flag and a short
+// flag per command — full coverage is implicit in the table.
+func TestPrintCompletions_FlagsForCommand(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want []string
+	}{
+		{"list", []string{"--all", "-a", "--json", "--help"}},
+		{"status", []string{"--all", "-a", "--branch", "--watch"}},
+		{"sync", []string{"--all", "--squash", "--dry-run", "--continue"}},
+		{"new", []string{"--parent", "--worktree", "--from-remote"}},
+		{"agent", []string{"--cmd", "--stack", "--branch", "--dry-run"}},
+		{"reparent", []string{"--branch", "--parent"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.cmd, func(t *testing.T) {
+			got := captureCompletions(t, []string{tc.cmd, "--"})
+			for _, w := range tc.want {
+				if !contains(got, w) {
+					t.Errorf("flag %q missing for %s; got %v", w, tc.cmd, got)
+				}
+			}
+		})
+	}
+}
+
+// TestPrintCompletions_FlagsForUnknownCommand: a command we don't know about
+// (someone might be typing a typo) should emit nothing for `--<TAB>` rather
+// than fall through to positional logic. Otherwise typos would surface
+// branch names, which is misleading.
+func TestPrintCompletions_FlagsForUnknownCommand(t *testing.T) {
+	got := captureCompletions(t, []string{"xyzzy", "--"})
+	if len(got) != 0 {
+		t.Errorf("unknown command should emit no flag completions, got %v", got)
+	}
+}
+
+// TestPrintCompletions_BranchValueFlagAfterDashB pins down that a previous
+// word of `-b` triggers branch-name completion. We can't assert specific
+// branch names without a real repo — but we can verify the function is
+// driven by the prev-word lookup and not the positional path. The
+// "out-of-repo emits nothing" semantics are best-effort by design, so we
+// only verify *no* unexpected non-branch entries leak through (e.g. flags
+// or subcommands).
+func TestPrintCompletions_BranchValueFlagPathDoesNotLeakSubcommands(t *testing.T) {
+	got := captureCompletions(t, []string{"sync", "-b", ""})
+	for _, leaked := range []string{"create", "draft", "set", "show", "feature", "prompt", "--all"} {
+		if contains(got, leaked) {
+			t.Errorf("`-b` value-of-flag path leaked %q: %v", leaked, got)
+		}
+	}
+}
+
+func TestPrintCompletions_LongBranchFlagPath(t *testing.T) {
+	// `--branch` is the long form of `-b` and must trigger the same path.
+	got := captureCompletions(t, []string{"unstack", "--branch", ""})
+	for _, leaked := range []string{"set", "show", "create"} {
+		if contains(got, leaked) {
+			t.Errorf("`--branch` should not leak unrelated completions: %v (saw %q)", got, leaked)
+		}
+	}
+}
+
+// TestPrintCompletions_AgentDashSCompletesStacks: `agent -s <hash>` is the
+// only command where `-s` takes a stack value (sync/delete have `-s` as a
+// boolean flag). This test pins the command-aware branch in the lookup.
+func TestPrintCompletions_AgentDashSCompletesStacks(t *testing.T) {
+	got := captureCompletions(t, []string{"agent", "-s", ""})
+	for _, leaked := range []string{"feature", "feat", "prompt", "--cmd"} {
+		if contains(got, leaked) {
+			t.Errorf("agent -s <TAB> leaked non-stack completion %q: %v", leaked, got)
+		}
+	}
+}
+
+// TestPrintCompletions_FlagAtCursorBeatsPositional asserts that when the
+// current word starts with `-`, we always emit flags — never branch names
+// or subcommands. This is the "user is mid-flag" hot path.
+func TestPrintCompletions_FlagAtCursorBeatsPositional(t *testing.T) {
+	got := captureCompletions(t, []string{"goto", "-"})
+	// goto is a branch-positional command, but cursor is on a flag — only
+	// flags should come back, never branch names.
+	if !contains(got, "--help") {
+		t.Errorf("goto -<TAB> should emit flags including --help, got %v", got)
+	}
+}
+
+// TestPrintCompletions_ConfigSetValueFlagSuppressed: when the cursor is on a
+// flag inside the value slot of `config set`, we must NOT suggest ezs's own
+// flags. The agent_command value is a shell command line — completing
+// `--<TAB>` to `--help` would silently corrupt it.
+func TestPrintCompletions_ConfigSetValueFlagSuppressed(t *testing.T) {
+	got := captureCompletions(t, []string{"config", "set", "agent_command", "claude", "--"})
+	if len(got) != 0 {
+		t.Errorf("config set value-flag position must emit no completions; got %v", got)
+	}
+}
+
+// TestPrintCompletions_NewExcludedFromBranchPositional: the first positional
+// of `ezs new` is the *new* branch name (does not exist yet). Completing
+// existing branch names there would be misleading. Pin the exclusion.
+func TestPrintCompletions_NewExcludedFromBranchPositional(t *testing.T) {
+	got := captureCompletions(t, []string{"new", ""})
+	// In a non-repo test process there are no branches anyway, but the
+	// value of this test is structural — `new` must not be in
+	// branchPositionalCommands. The fact that it's not present is enforced
+	// indirectly by the table-driven flag test above; here we just make
+	// the intent explicit.
+	if branchPositionalCommands["new"] {
+		t.Error("`new` must NOT be in branchPositionalCommands — its first positional is the new branch name")
+	}
+	_ = got
+}

--- a/cmd/ezs/main.go
+++ b/cmd/ezs/main.go
@@ -412,38 +412,3 @@ if [ -n "$ZSH_VERSION" ]; then
 fi
 `)
 }
-
-var topLevelCommands = []string{
-	"agent", "amend", "commit", "config", "delete", "diff", "down",
-	"goto", "list", "log", "menu", "new", "pr", "push",
-	"reparent", "stack", "status", "sync", "unstack", "up",
-}
-
-var prSubcommands = []string{"create", "draft", "merge", "stack", "update"}
-
-func printCompletions(args []string) {
-	if len(args) == 0 || (len(args) == 1 && args[0] == "") {
-		for _, cmd := range topLevelCommands {
-			fmt.Println(cmd)
-		}
-		return
-	}
-
-	cmd := args[0]
-	switch cmd {
-	case "pr":
-		for _, sub := range prSubcommands {
-			fmt.Println(sub)
-		}
-	case "agent":
-		if len(args) >= 2 && (args[1] == "prompt") {
-			fmt.Println("work")
-			fmt.Println("feature")
-			fmt.Println("feat")
-		} else {
-			fmt.Println("feature")
-			fmt.Println("feat")
-			fmt.Println("prompt")
-		}
-	}
-}

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -1194,7 +1194,12 @@ Options:
       <h4 id="configuration-1">Configuration</h4>
       <pre><code><span class="c-comment"># Set the agent CLI (default: claude)</span>
 <span class="c-cmd">ezs</span> <span class="c-flag">config</span> <span class="c-str">set</span> <span class="c-str">agent_command</span> <span class="c-str">claude</span>
+
+<span class="c-comment"># Pass flags to the agent CLI by quoting the whole value as one shell arg:</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">config</span> <span class="c-str">set</span> <span class="c-str">agent_command</span> <span class="c-str">"claude --dangerously-skip-permissions"</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">config</span> <span class="c-str">set</span> <span class="c-str">agent_command</span> <span class="c-str">"aider --model gpt-4"</span>
 </code></pre>
+      <blockquote><p>Multi-word values must be quoted. The CLI takes <code>&lt;value&gt;</code> as a single positional argument and rejects anything trailing &mdash; this keeps typos like <code>ezs config set worktree_base_dir /tmp/foo --bogus</code> from being silently stored as the literal path.</p></blockquote>
       <h3 id="ezs-commit--ezs-amend"><code>ezs commit</code> / <code>ezs amend</code></h3>
       <p>Wrap <code>git commit</code> / <code>git commit --amend</code> and auto-sync child branches. Aliases: <code>ci</code></p>
       <pre><code><span class="c-cmd">ezs</span> <span class="c-flag">commit</span> <span class="c-str">[git-commit-options]</span> <span class="c-str">[--merge|--rebase]</span>

--- a/itests/cli_flag_validation_test.go
+++ b/itests/cli_flag_validation_test.go
@@ -163,6 +163,36 @@ func TestFlagValidation_ListRejectsUnknownFlag(t *testing.T) {
 	}
 }
 
+// TestFlagValidation_UpHelpRejectsTrailingArg pins down the strict shape of
+// the navigate help short-circuit. The original code looked at args[0]
+// only, so `ezs up --help garbage` printed help and exited 0 — silently
+// dropping the trailing `garbage` token. After the v2 fix the help check
+// requires exactly one help token, so trailing junk is rejected.
+func TestFlagValidation_UpHelpRejectsTrailingArg(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	for _, tc := range []struct {
+		args []string
+	}{
+		{[]string{"up", "--help", "garbage"}},
+		{[]string{"up", "-h", "--bogus"}},
+		{[]string{"down", "--help", "junk"}},
+	} {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			out, err := runEzs(t, env, tc.args...)
+			if err == nil {
+				t.Fatalf("%v with trailing arg must be rejected:\n%s", tc.args, out)
+			}
+			// And we must NOT have printed the help banner (which would
+			// signal the silent-help-then-drop-garbage regression).
+			if strings.Contains(out, "Navigate up the stack") || strings.Contains(out, "Navigate down the stack") {
+				t.Errorf("%v printed help banner despite extra junk:\n%s", tc.args, out)
+			}
+		})
+	}
+}
+
 // TestFlagValidation_HelpStillWorks asserts that the legitimate -h/--help
 // path still short-circuits. After the doctor refactor I want to confirm
 // it didn't accidentally become a hard error.

--- a/itests/cli_flag_validation_test.go
+++ b/itests/cli_flag_validation_test.go
@@ -1,0 +1,290 @@
+package itests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// runEzs executes the cached ezs binary in env.RepoDir with the given args.
+// Returns combined output + the exit error so each test can assert exit
+// status and stderr message together — the two we care about for flag
+// validation.
+func runEzs(t *testing.T, env *TestEnv, args ...string) (string, error) {
+	t.Helper()
+	bin := buildEzs(t)
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = env.RepoDir
+	cmd.Env = append(cmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestFlagValidation_DoctorRejectsUnknownFlag is the integration-level
+// regression for the silent-doctor bug: prior to the pflag refactor,
+// `ezs doctor --bogus` ran a full health check and exited 0, masking
+// typos. End-to-end binary invocation pins that this is fixed both at
+// the command level and through the dispatch path.
+func TestFlagValidation_DoctorRejectsUnknownFlag(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "doctor", "--bogus-flag")
+	if err == nil {
+		t.Fatalf("doctor with unknown flag should fail; output:\n%s", out)
+	}
+	if !strings.Contains(out, "unknown flag") {
+		t.Errorf("expected 'unknown flag' in output:\n%s", out)
+	}
+	// Health check banner ("ezstack doctor") must NOT appear — the parse
+	// error has to short-circuit before any check runs.
+	if strings.Contains(out, "git:") || strings.Contains(out, "fzf:") {
+		t.Errorf("health checks ran despite unknown flag:\n%s", out)
+	}
+}
+
+func TestFlagValidation_DoctorRejectsExtraPositional(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "doctor", "junk")
+	if err == nil {
+		t.Fatalf("doctor with extra positional should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "unexpected") {
+		t.Errorf("expected 'unexpected' in output:\n%s", out)
+	}
+}
+
+// TestFlagValidation_ConfigSetRejectsExtraArg is the most important itest
+// in this file. The pre-fix `ezs config set <key> <val> --bogus` joined the
+// trailing `--bogus` into the value with strings.Join, silently corrupting
+// the user's worktree_base_dir / agent_command / etc. End-to-end test
+// confirms the fix at the binary boundary.
+func TestFlagValidation_ConfigSetRejectsExtraArg(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "set", "sync_strategy", "merge", "--bogus")
+	if err == nil {
+		t.Fatalf("config set with extra arg should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "usage: ezs config set") {
+		t.Errorf("expected usage hint in output:\n%s", out)
+	}
+}
+
+func TestFlagValidation_ConfigShowRejectsExtraArg(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "show", "junk")
+	if err == nil {
+		t.Fatalf("config show with extra arg should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "usage: ezs config show") {
+		t.Errorf("expected usage hint in output:\n%s", out)
+	}
+}
+
+func TestFlagValidation_ConfigShowRejectsBogusFlag(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "show", "--bogus")
+	if err == nil {
+		t.Fatalf("config show with bogus flag should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "usage: ezs config show") {
+		t.Errorf("expected usage hint in output:\n%s", out)
+	}
+}
+
+func TestFlagValidation_ConfigExportRejectsExtraArg(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	dest := env.TmpDir + "/export.json"
+	out, err := runEzs(t, env, "config", "export", dest, "junk")
+	if err == nil {
+		t.Fatalf("config export with extra arg should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "usage: ezs config export") {
+		t.Errorf("expected usage hint in output:\n%s", out)
+	}
+}
+
+// TestFlagValidation_UpRejectsExtraArg pins down the navigation cardinality
+// fix. `ezs up 1 typo` used to silently no-op the `typo`. Now any extra
+// positional must surface.
+func TestFlagValidation_UpRejectsExtraArg(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "up", "1", "extra")
+	if err == nil {
+		t.Fatalf("up 1 extra should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "at most one argument") {
+		t.Errorf("expected cardinality error:\n%s", out)
+	}
+}
+
+func TestFlagValidation_DownRejectsBogusFlag(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "down", "--bogus")
+	if err == nil {
+		t.Fatalf("down --bogus should fail:\n%s", out)
+	}
+	// Could be "unknown flag" (since it starts with "-") or
+	// "invalid step count" depending on which guard catches it. Both are
+	// acceptable rejections; the bad case is silent acceptance.
+	if !strings.Contains(out, "unknown flag") && !strings.Contains(out, "invalid step count") {
+		t.Errorf("expected rejection for `down --bogus`:\n%s", out)
+	}
+}
+
+// TestFlagValidation_ListRejectsUnknownFlag is a positive control: list
+// already used pflag with ContinueOnError pre-fix. This test ensures we
+// haven't accidentally broken the working commands while fixing the
+// silent ones.
+func TestFlagValidation_ListRejectsUnknownFlag(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "list", "--bogus")
+	if err == nil {
+		t.Fatalf("list --bogus should fail:\n%s", out)
+	}
+	if !strings.Contains(out, "unknown flag") {
+		t.Errorf("expected 'unknown flag':\n%s", out)
+	}
+}
+
+// TestFlagValidation_HelpStillWorks asserts that the legitimate -h/--help
+// path still short-circuits. After the doctor refactor I want to confirm
+// it didn't accidentally become a hard error.
+func TestFlagValidation_HelpStillWorks(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	tests := []struct {
+		args   []string
+		banner string
+	}{
+		{[]string{"doctor", "--help"}, "Check ezstack health"},
+		{[]string{"doctor", "-h"}, "Check ezstack health"},
+		{[]string{"config", "--help"}, "Configure ezstack"},
+		{[]string{"up", "--help"}, "Navigate up the stack"},
+		{[]string{"down", "--help"}, "Navigate down the stack"},
+	}
+	for _, tc := range tests {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			out, err := runEzs(t, env, tc.args...)
+			if err != nil {
+				t.Errorf("%v unexpectedly failed: %v\n%s", tc.args, err, out)
+			}
+			if !strings.Contains(out, tc.banner) {
+				t.Errorf("expected banner %q in:\n%s", tc.banner, out)
+			}
+		})
+	}
+}
+
+// TestFlagValidation_LegitimateConfigSetStillWorks is a positive control to
+// make sure the cardinality tightening didn't break the happy path.
+// It also implicitly covers that the value isn't being mutated by the
+// stricter parsing.
+func TestFlagValidation_LegitimateConfigSetStillWorks(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// sync_strategy is an enum field with simple validation — perfect for
+	// asserting end-to-end set+show roundtrip without touching the path
+	// expansion paths used by worktree_base_dir.
+	out, err := runEzs(t, env, "config", "set", "sync_strategy", "merge")
+	if err != nil {
+		t.Fatalf("legitimate config set failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Set sync_strategy = merge") {
+		t.Errorf("expected success line in output:\n%s", out)
+	}
+
+	out, err = runEzs(t, env, "config", "show")
+	if err != nil {
+		t.Fatalf("config show failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "sync_strategy: merge") {
+		t.Errorf("config show didn't reflect set value:\n%s", out)
+	}
+}
+
+// TestFlagValidation_AgentCommandMultiWordRequiresQuoting pins the strict
+// cardinality contract for agent_command. Multi-word shell command lines
+// MUST be quoted: `ezs config set agent_command "claude --flag"`. The old
+// unquoted form silently joined trailing tokens, which made it impossible
+// to distinguish a legitimate flag-bearing command line from a typo like
+// `set worktree_base_dir /tmp/foo --bogus`. We now reject both shapes the
+// same way and put the quoting hint in the error message.
+func TestFlagValidation_AgentCommandMultiWordRequiresQuoting(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "set", "agent_command", "claude", "--dangerously-skip-permissions")
+	if err == nil {
+		t.Fatalf("unquoted multi-word agent_command must be rejected:\n%s", out)
+	}
+	if !strings.Contains(out, "wrap it in quotes") {
+		t.Errorf("error message should hint at quoting:\n%s", out)
+	}
+}
+
+// TestFlagValidation_AgentCommandQuotedWorks documents the supported way
+// to set a multi-word agent_command after the strict-quoting change. The
+// shell collapses the quoted string to a single argv entry, so it lands
+// in the cardinality-3 happy path.
+func TestFlagValidation_AgentCommandQuotedWorks(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "set", "agent_command", "aider --model gpt-4")
+	if err != nil {
+		t.Fatalf("quoted multi-word agent_command should work: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Set agent_command = aider --model gpt-4") {
+		t.Errorf("expected quoted value in output:\n%s", out)
+	}
+
+	out, err = runEzs(t, env, "config", "show")
+	if err != nil {
+		t.Fatalf("config show failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "agent_command: aider --model gpt-4") {
+		t.Errorf("config show should reflect quoted multi-word value:\n%s", out)
+	}
+}
+
+// TestFlagValidation_NonAgentKeyRejectsTrailing is the targeted regression
+// test for the original bug: `config set worktree_base_dir /tmp/foo --bogus`
+// used to silently store the literal string "/tmp/foo --bogus" as the path.
+// The cardinality fix MUST keep rejecting this for non-agent keys.
+func TestFlagValidation_NonAgentKeyRejectsTrailing(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	out, err := runEzs(t, env, "config", "set", "worktree_base_dir", "/tmp/ezs-test", "--bogus")
+	if err == nil {
+		t.Fatalf("worktree_base_dir with trailing --bogus must fail:\n%s", out)
+	}
+	if !strings.Contains(out, "usage: ezs config set") {
+		t.Errorf("expected usage hint:\n%s", out)
+	}
+
+	// And the good path must not have happened — no "Set worktree_base_dir"
+	// success line should appear.
+	if strings.Contains(out, "Set worktree_base_dir") {
+		t.Errorf("partial success leaked through despite usage error:\n%s", out)
+	}
+}

--- a/itests/completions_test.go
+++ b/itests/completions_test.go
@@ -274,6 +274,67 @@ func TestCompletions_NewSurfacesInitSubmodulesFlag(t *testing.T) {
 	}
 }
 
+// TestCompletions_AgentPromptHasOwnFlags pins the per-subcommand flag fix
+// for `agent prompt`. The prompt subcommand declares its own flagset
+// (--shipped/--custom/--repo/--edit/--reset). Pre-fix `agent prompt --<TAB>`
+// fell through to commandFlags["agent"] and suggested --cmd / --stack /
+// --branch — flags from the work/feature flagset that prompt doesn't accept.
+func TestCompletions_AgentPromptHasOwnFlags(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "agent", "prompt", "--")
+	for _, want := range []string{"--shipped", "--custom", "--repo", "--edit", "--reset"} {
+		if !itestContains(got, want) {
+			t.Errorf("agent prompt --<TAB> missing %q; got %v", want, got)
+		}
+	}
+	// Phantom check: agent's main-mode flags (--cmd/--stack/--branch/etc.)
+	// are not accepted by the prompt subcommand's flagset, so completing
+	// them here would lead users into a wrong invocation.
+	for _, phantom := range []string{"--cmd", "--stack", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp"} {
+		if itestContains(got, phantom) {
+			t.Errorf("agent prompt --<TAB> leaked main-mode flag %q; got %v", phantom, got)
+		}
+	}
+}
+
+// TestCompletions_PRTopLevelHasDraftAll pins down that `ezs pr --<TAB>`
+// surfaces `--draft-all`. The flag is documented in pr.go's help text and
+// parsed in pr.go:49 — leaving it out of commandFlags["pr"] silently
+// dropped completion for the only top-level pr flag besides --help.
+func TestCompletions_PRTopLevelHasDraftAll(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "pr", "--")
+	if !itestContains(got, "--draft-all") {
+		t.Errorf("pr --<TAB> missing --draft-all; got %v", got)
+	}
+}
+
+// TestCompletions_PushHasNoPhantoms guards the v2 fix where push had
+// phantom `--all`/`-a`/`--children` entries in the completion table.
+// push.go declares neither — completing them sent users to a runtime
+// "unknown flag" error.
+func TestCompletions_PushHasNoPhantoms(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "push", "--")
+	for _, phantom := range []string{"--all", "-a", "--children"} {
+		if itestContains(got, phantom) {
+			t.Errorf("push --<TAB> emits phantom %q (push.go declares no such flag); got %v", phantom, got)
+		}
+	}
+	// Positive control: real flags must still be there.
+	for _, want := range []string{"--stack", "--branch", "--force", "--verify", "--all-remotes"} {
+		if !itestContains(got, want) {
+			t.Errorf("push --<TAB> dropped real flag %q; got %v", want, got)
+		}
+	}
+}
+
 // TestCompletions_PRSubcommandFlags pins down per-subcommand flag completion.
 // Pre-fix `ezs pr create --<TAB>` emitted only `--help`/`-h` (the bare `pr`
 // flag set) instead of create's actual flag list. Verify a representative
@@ -320,58 +381,134 @@ func TestCompletions_BranchEqualsValueSyntax(t *testing.T) {
 	}
 }
 
-// TestCompletions_FlagTableMatchesHelpOutput is the drift gate. For each
-// command in commandFlags, run `ezs <cmd> --help`, parse the OPTIONS lines,
-// and assert every flag printed by the binary appears in the table. This
-// catches the "command grew a flag, table didn't" failure mode that produced
-// the missing `--init-submodules`/`-s` regression in v1 of this PR.
+// TestCompletions_FlagTableMatchesHelpOutput is the bidirectional drift gate.
+// For each command we exercise BOTH directions:
 //
-// Asymmetric on purpose: extra entries in the table are tolerated (some help
-// text mentions help-only flags), missing entries are not.
+//  1. help ⊆ completion: every flag in `<cmd> --help` OPTIONS must appear in
+//     the completion table. This catches the v1 regression where `new` grew
+//     `--init-submodules` but the completion table forgot it.
+//  2. completion ⊆ help ∪ tolerated: every flag the completion table emits
+//     must either appear in `<cmd> --help` OR be in the per-command
+//     `toleratedExtras` allowlist below. This catches phantom flags — e.g.
+//     `push` previously had `--all`/`-a`/`--children` in the table even
+//     though push.go declares no such flags. Without the reverse check
+//     users tab-complete to a flag and then `push` rejects with
+//     "unknown flag" at runtime.
+//
+// The completion table is fetched live via `ezs --completions <cmd> --`
+// rather than re-listed in this test. That removes the duplicate-source-
+// of-truth problem (the v1 test had its own copy of the table that
+// drifted out of sync with completions.go).
+//
+// toleratedExtras documents flags that ARE registered with pflag but NOT
+// printed in the help OPTIONS section — typically advanced/internal flags.
+// Each entry must point at a real declaration in cmd/ezs/commands/*.go.
 func TestCompletions_FlagTableMatchesHelpOutput(t *testing.T) {
 	env := SetupTestEnv(t)
 	defer env.Cleanup()
 
-	tableFlags := map[string][]string{
-		"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
-		"delete":   {"--force", "-f", "--stack", "-s", "--cascade", "--help", "-h"},
-		"diff":     {"--branch", "-b", "--stat", "--json", "--help", "-h"},
-		"doctor":   {"--help", "-h"},
-		"goto":     {"--search", "--help", "-h"},
-		"list":     {"--all", "-a", "--json", "--debug", "-d", "--help", "-h"},
-		"log":      {"--branch", "-b", "--json", "--help", "-h"},
-		"new":      {"--parent", "-p", "--worktree", "-w", "--template", "--cd", "-c", "--no-cd", "-C", "--init-submodules", "-s", "--no-init-submodules", "-S", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
-		"push":     {"--all", "-a", "--stack", "-s", "--branch", "-b", "--children", "--force", "-f", "--verify", "--all-remotes", "--help", "-h"},
-		"reparent": {"--branch", "-b", "--parent", "-p", "--merge", "--rebase", "--no-rebase", "--help", "-h"},
-		"stack":    {"--branch", "-b", "--parent", "-p", "--base", "-B", "--help", "-h"},
-		"status":   {"--all", "-a", "--branch", "-b", "--debug", "-d", "--json", "--watch", "--help", "-h"},
-		"sync":     {"--stats", "--squash", "--stack", "-s", "--all", "-a", "--current", "-c", "--branch", "-b", "--parent", "-p", "--children", "-C", "--merge", "--rebase", "--no-delete-local", "--dry-run", "--continue", "--no-autostash", "--json", "--help", "-h"},
-		"unstack":  {"--branch", "-b", "--help", "-h"},
+	// Flags declared with pflag but intentionally not printed in --help
+	// OPTIONS. Listing them here keeps the bidirectional check honest
+	// without forcing every advanced flag to be documented in the help
+	// banner. If the underlying command stops registering one of these,
+	// remove the entry; if a new advanced flag is added, add it here.
+	toleratedExtras := map[string]map[string]bool{
+		"agent": {
+			// agent.go:93-96 declares these but the help banner only
+			// surfaces the user-facing subset.
+			"--save-prompt": true,
+			"--no-push":     true,
+			"--preset":      true,
+			"--no-mcp":      true,
+		},
+	}
+
+	// Commands whose flag completion path doesn't reach commandFlags
+	// (handled by a different code branch — config/menu have no flags
+	// other than --help; agent prompt/feature use their own subcommand
+	// table). They're skipped here and covered by their own tests.
+	commands := []string{
+		"agent", "delete", "diff", "doctor", "goto", "list", "log",
+		"new", "pr", "push", "reparent", "stack", "status", "sync",
+		"unstack",
 	}
 
 	bin := buildEzs(t)
-	for cmd, want := range tableFlags {
+	for _, cmd := range commands {
 		t.Run(cmd, func(t *testing.T) {
-			c := exec.Command(bin, cmd, "--help")
-			c.Dir = env.RepoDir
-			c.Env = append(c.Environ(), "EZSTACK_HOME="+env.ConfigDir)
-			out, err := c.CombinedOutput()
+			// Fetch the live completion output for `ezs <cmd> --<TAB>`.
+			compCmd := exec.Command(bin, "--completions", cmd, "--")
+			compCmd.Dir = env.RepoDir
+			compCmd.Env = append(compCmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+			compOut, err := compCmd.CombinedOutput()
 			if err != nil {
-				t.Fatalf("ezs %s --help failed: %v\n%s", cmd, err, out)
+				t.Fatalf("ezs --completions %s -- failed: %v\n%s", cmd, err, compOut)
 			}
-			helpFlags := parseHelpOptionsFlags(string(out))
-			tableSet := map[string]bool{}
-			for _, f := range want {
-				tableSet[f] = true
+			compFlags := splitCompletionLines(compOut)
+
+			// Fetch help OPTIONS for the same command.
+			helpCmd := exec.Command(bin, cmd, "--help")
+			helpCmd.Dir = env.RepoDir
+			helpCmd.Env = append(helpCmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+			helpOut, err := helpCmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ezs %s --help failed: %v\n%s", cmd, err, helpOut)
 			}
+			helpFlags := parseHelpOptionsFlags(string(helpOut))
+
+			compSet := map[string]bool{}
+			for _, f := range compFlags {
+				compSet[f] = true
+			}
+			helpSet := map[string]bool{}
 			for _, f := range helpFlags {
-				if !tableSet[f] {
-					t.Errorf("flag %q in `ezs %s --help` output is missing from completion table; commandFlags[%q] needs updating",
+				helpSet[f] = true
+			}
+
+			// Direction 1 (missing): every help flag must appear in
+			// completion. Catches the "command grew a flag, table didn't"
+			// failure mode.
+			for _, f := range helpFlags {
+				if !compSet[f] {
+					t.Errorf("flag %q in `ezs %s --help` is missing from completion; commandFlags[%q] needs updating",
 						f, cmd, cmd)
 				}
 			}
+
+			// Direction 2 (phantom): every completion flag must appear
+			// in help OR the tolerated-extras allowlist. Catches phantom
+			// entries that don't actually exist in the parser. This is
+			// the check that catches `push` having phantom `--all` /
+			// `-a` / `--children` in the v2 table.
+			for _, f := range compFlags {
+				if helpSet[f] {
+					continue
+				}
+				if toleratedExtras[cmd][f] {
+					continue
+				}
+				t.Errorf("phantom flag %q: completion offers it but `ezs %s --help` doesn't list it and it's not in toleratedExtras[%q] — does the parser actually accept it?",
+					f, cmd, cmd)
+			}
 		})
 	}
+}
+
+// splitCompletionLines splits the stdout of `ezs --completions ...` into
+// non-empty trimmed entries. Used by the drift gate to consume completion
+// candidates without each test rebuilding the same parser.
+func splitCompletionLines(out []byte) []string {
+	body := strings.TrimRight(string(out), "\n")
+	if body == "" {
+		return nil
+	}
+	var flags []string
+	for _, line := range strings.Split(body, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			flags = append(flags, line)
+		}
+	}
+	return flags
 }
 
 // parseHelpOptionsFlags pulls flag tokens out of an ezs `--help` OPTIONS

--- a/itests/completions_test.go
+++ b/itests/completions_test.go
@@ -82,7 +82,8 @@ func TestCompletions_ConfigSetKeys(t *testing.T) {
 	got := runCompletions(t, env, "config", "set", "")
 	for _, want := range []string{
 		"worktree_base_dir", "default_base_branch", "github_token",
-		"cd_after_new", "use_worktrees", "sync_strategy", "agent_command",
+		"cd_after_new", "use_worktrees", "init_submodules",
+		"sync_strategy", "agent_command",
 	} {
 		if !itestContains(got, want) {
 			t.Errorf("config set key %q missing in %v", want, got)
@@ -212,6 +213,247 @@ func TestCompletions_OutsideRepoTopLevelStillWorks(t *testing.T) {
 	if !slices.Contains(lines, "doctor") || !slices.Contains(lines, "config") {
 		t.Errorf("top-level completions missing outside repo: %v", lines)
 	}
+}
+
+// TestCompletions_SyncDashPDoesNotCompleteBranches is the integration-level
+// regression for the false-positive completion bug: `-p`/`--parent` is a
+// boolean for `sync` (means "rebase onto parent"), not a value-bearing flag,
+// so the next slot is the next flag/positional — branches are wrong here.
+// The pre-fix flat branchValueFlags map suggested branches anyway. Pin the
+// negative shape: a real branch exists in the repo, but `sync -p <TAB>` must
+// not surface it.
+func TestCompletions_SyncDashPDoesNotCompleteBranches(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	CreateBranchWithCommit(t, env, "feat-syncp-bug", "main")
+
+	got := runCompletions(t, env, "sync", "-p", "")
+	if itestContains(got, "feat-syncp-bug") {
+		t.Errorf("sync -p <TAB> must NOT emit branches (-p is boolean for sync); got %v", got)
+	}
+
+	// Same for the long form.
+	got = runCompletions(t, env, "sync", "--parent", "")
+	if itestContains(got, "feat-syncp-bug") {
+		t.Errorf("sync --parent <TAB> must NOT emit branches (--parent is boolean for sync); got %v", got)
+	}
+}
+
+// TestCompletions_DeleteStackFlagFallsThroughToPositional documents the
+// reviewer's correctness fix: --stack/-s is boolean for delete (delete.go
+// declares it BoolP). Pre-fix the flat stackValueLongFlags map fired the
+// value-of-flag router and emitted ONLY stack hashes after --stack. Post-
+// fix --stack falls through to delete's positional path which emits BOTH
+// branches and stacks (delete accepts either). Verify a real branch
+// surfaces — a clear signal that the fall-through path is firing rather
+// than the (now-fixed) wrong path.
+func TestCompletions_DeleteStackFlagFallsThroughToPositional(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	CreateBranchWithCommit(t, env, "feat-delstack", "main")
+
+	got := runCompletions(t, env, "delete", "--stack", "")
+	if !itestContains(got, "feat-delstack") {
+		t.Errorf("delete --stack <TAB> should fall through to positional (branches + stacks); got %v", got)
+	}
+}
+
+// TestCompletions_NewSurfacesInitSubmodulesFlag covers the missing-flag
+// regression. `--init-submodules`/`-s` and the negation `--no-init-submodules`/`-S`
+// are real flags on `ezs new` (new.go:64-65) but were missing from the
+// commandFlags table. `ezs new --<TAB>` must surface them.
+func TestCompletions_NewSurfacesInitSubmodulesFlag(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "new", "--")
+	for _, want := range []string{"--init-submodules", "--no-init-submodules"} {
+		if !itestContains(got, want) {
+			t.Errorf("new --<TAB> missing %q (real flag, was missing from table); got %v", want, got)
+		}
+	}
+}
+
+// TestCompletions_PRSubcommandFlags pins down per-subcommand flag completion.
+// Pre-fix `ezs pr create --<TAB>` emitted only `--help`/`-h` (the bare `pr`
+// flag set) instead of create's actual flag list. Verify a representative
+// long flag for each subcommand.
+func TestCompletions_PRSubcommandFlags(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	tests := []struct {
+		sub  string
+		want string
+	}{
+		{"create", "--title"},
+		{"update", "--branch"},
+		{"merge", "--method"},
+		{"draft", "--branch"},
+		{"stack", "--branch"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.sub, func(t *testing.T) {
+			got := runCompletions(t, env, "pr", tc.sub, "--")
+			if !itestContains(got, tc.want) {
+				t.Errorf("pr %s --<TAB> missing %q; got %v", tc.sub, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestCompletions_BranchEqualsValueSyntax covers `--branch=foo<TAB>`. Bash's
+// default COMP_WORDBREAKS splits on `=`, so the args we receive are
+// (..., "--branch", "=", "foo"). The router must look one further back when
+// prev is "=" so it still recognizes the underlying flag and routes to
+// branch completion.
+func TestCompletions_BranchEqualsValueSyntax(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	CreateBranchWithCommit(t, env, "feat-eqsyntax", "main")
+
+	// Cursor on the empty value slot after `--branch=`:
+	// COMP_WORDS = (ezs, sync, --branch, =, "")
+	got := runCompletions(t, env, "sync", "--branch", "=", "")
+	if !itestContains(got, "feat-eqsyntax") {
+		t.Errorf("sync --branch=<TAB> must complete branches; got %v", got)
+	}
+}
+
+// TestCompletions_FlagTableMatchesHelpOutput is the drift gate. For each
+// command in commandFlags, run `ezs <cmd> --help`, parse the OPTIONS lines,
+// and assert every flag printed by the binary appears in the table. This
+// catches the "command grew a flag, table didn't" failure mode that produced
+// the missing `--init-submodules`/`-s` regression in v1 of this PR.
+//
+// Asymmetric on purpose: extra entries in the table are tolerated (some help
+// text mentions help-only flags), missing entries are not.
+func TestCompletions_FlagTableMatchesHelpOutput(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	tableFlags := map[string][]string{
+		"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
+		"delete":   {"--force", "-f", "--stack", "-s", "--cascade", "--help", "-h"},
+		"diff":     {"--branch", "-b", "--stat", "--json", "--help", "-h"},
+		"doctor":   {"--help", "-h"},
+		"goto":     {"--search", "--help", "-h"},
+		"list":     {"--all", "-a", "--json", "--debug", "-d", "--help", "-h"},
+		"log":      {"--branch", "-b", "--json", "--help", "-h"},
+		"new":      {"--parent", "-p", "--worktree", "-w", "--template", "--cd", "-c", "--no-cd", "-C", "--init-submodules", "-s", "--no-init-submodules", "-S", "--from-worktree", "-f", "--from-remote", "-r", "--help", "-h"},
+		"push":     {"--all", "-a", "--stack", "-s", "--branch", "-b", "--children", "--force", "-f", "--verify", "--all-remotes", "--help", "-h"},
+		"reparent": {"--branch", "-b", "--parent", "-p", "--merge", "--rebase", "--no-rebase", "--help", "-h"},
+		"stack":    {"--branch", "-b", "--parent", "-p", "--base", "-B", "--help", "-h"},
+		"status":   {"--all", "-a", "--branch", "-b", "--debug", "-d", "--json", "--watch", "--help", "-h"},
+		"sync":     {"--stats", "--squash", "--stack", "-s", "--all", "-a", "--current", "-c", "--branch", "-b", "--parent", "-p", "--children", "-C", "--merge", "--rebase", "--no-delete-local", "--dry-run", "--continue", "--no-autostash", "--json", "--help", "-h"},
+		"unstack":  {"--branch", "-b", "--help", "-h"},
+	}
+
+	bin := buildEzs(t)
+	for cmd, want := range tableFlags {
+		t.Run(cmd, func(t *testing.T) {
+			c := exec.Command(bin, cmd, "--help")
+			c.Dir = env.RepoDir
+			c.Env = append(c.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+			out, err := c.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ezs %s --help failed: %v\n%s", cmd, err, out)
+			}
+			helpFlags := parseHelpOptionsFlags(string(out))
+			tableSet := map[string]bool{}
+			for _, f := range want {
+				tableSet[f] = true
+			}
+			for _, f := range helpFlags {
+				if !tableSet[f] {
+					t.Errorf("flag %q in `ezs %s --help` output is missing from completion table; commandFlags[%q] needs updating",
+						f, cmd, cmd)
+				}
+			}
+		})
+	}
+}
+
+// parseHelpOptionsFlags pulls flag tokens out of an ezs `--help` OPTIONS
+// section. Each command's help follows the convention:
+//
+//	OPTIONS
+//	    -s, --stack            Sync current stack...
+//	    -a, --all              ...
+//	    --json                 ...
+//
+// We pluck every word matching ^-{1,2}[a-zA-Z][a-zA-Z0-9-]*$ from those
+// lines. Robust to colorized output (we strip ANSI first) and to commands
+// that use either short+long or long-only forms.
+func parseHelpOptionsFlags(help string) []string {
+	help = stripANSI(help)
+	lines := strings.Split(help, "\n")
+	inOptions := false
+	var out []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "OPTIONS") {
+			inOptions = true
+			continue
+		}
+		if inOptions {
+			// A new section heading (uppercase word at column 0) ends OPTIONS.
+			if line != "" && line[0] != ' ' && line[0] != '\t' {
+				inOptions = false
+				continue
+			}
+			for _, tok := range strings.Fields(trimmed) {
+				tok = strings.TrimSuffix(tok, ",")
+				if isFlagToken(tok) {
+					out = append(out, tok)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func isFlagToken(s string) bool {
+	if !strings.HasPrefix(s, "-") {
+		return false
+	}
+	body := strings.TrimLeft(s, "-")
+	if body == "" || body == s {
+		return false
+	}
+	for _, r := range body {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// stripANSI removes ANSI escape sequences so help-output parsing is robust
+// to ui.Bold/ui.Cyan/etc. Implementation is a small state machine matching
+// CSI sequences (`\x1b[ ... m`) which is all the ezs UI helpers emit.
+func stripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			// Skip until terminating letter (per CSI grammar: any byte in
+			// 0x40..0x7E ends the sequence).
+			j := i + 2
+			for j < len(s) {
+				c := s[j]
+				if c >= 0x40 && c <= 0x7E {
+					break
+				}
+				j++
+			}
+			i = j
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }
 
 // TestCompletions_ShellInitContainsCompletionFunction sanity-checks that

--- a/itests/completions_test.go
+++ b/itests/completions_test.go
@@ -239,22 +239,26 @@ func TestCompletions_SyncDashPDoesNotCompleteBranches(t *testing.T) {
 	}
 }
 
-// TestCompletions_DeleteStackFlagFallsThroughToPositional documents the
-// reviewer's correctness fix: --stack/-s is boolean for delete (delete.go
-// declares it BoolP). Pre-fix the flat stackValueLongFlags map fired the
-// value-of-flag router and emitted ONLY stack hashes after --stack. Post-
-// fix --stack falls through to delete's positional path which emits BOTH
-// branches and stacks (delete accepts either). Verify a real branch
-// surfaces — a clear signal that the fall-through path is firing rather
-// than the (now-fixed) wrong path.
-func TestCompletions_DeleteStackFlagFallsThroughToPositional(t *testing.T) {
+// TestCompletions_DeleteStackFlagNarrowsToStacks pins the narrowing: when
+// the user has typed `delete --stack` (or `-s`), the positional must be a
+// stack hash, so branch suggestions are noise and are suppressed. Without
+// the narrowing, a real branch like `feat-delstack` would leak through
+// delete's branchOrStack positional handler.
+func TestCompletions_DeleteStackFlagNarrowsToStacks(t *testing.T) {
 	env := SetupTestEnv(t)
 	defer env.Cleanup()
 	CreateBranchWithCommit(t, env, "feat-delstack", "main")
 
-	got := runCompletions(t, env, "delete", "--stack", "")
-	if !itestContains(got, "feat-delstack") {
-		t.Errorf("delete --stack <TAB> should fall through to positional (branches + stacks); got %v", got)
+	for _, flag := range []string{"--stack", "-s"} {
+		t.Run(flag, func(t *testing.T) {
+			got := runCompletions(t, env, "delete", flag, "")
+			if itestContains(got, "feat-delstack") {
+				t.Errorf("delete %s <TAB> must NOT emit branches (signal is stack-only); got %v", flag, got)
+			}
+			if len(got) == 0 {
+				t.Errorf("delete %s <TAB> should still emit at least one stack identifier; got nothing", flag)
+			}
+		})
 	}
 }
 

--- a/itests/completions_test.go
+++ b/itests/completions_test.go
@@ -1,0 +1,237 @@
+package itests
+
+import (
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// runCompletions exercises `ezs --completions ...` end-to-end. It returns the
+// emitted candidates (one per line) and the error from CombinedOutput. The
+// completion path is invoked from a configured repo so branch/stack lookups
+// can populate.
+func runCompletions(t *testing.T, env *TestEnv, args ...string) []string {
+	t.Helper()
+	bin := buildEzs(t)
+	full := append([]string{"--completions"}, args...)
+	cmd := exec.Command(bin, full...)
+	cmd.Dir = env.RepoDir
+	cmd.Env = append(cmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ezs --completions %v failed: %v\n%s", args, err, out)
+	}
+	body := strings.TrimRight(string(out), "\n")
+	if body == "" {
+		return nil
+	}
+	return strings.Split(body, "\n")
+}
+
+func itestContains(slice []string, s string) bool {
+	return slices.Contains(slice, s)
+}
+
+// TestCompletions_TopLevel covers `ezs <TAB>` end-to-end. Pre-rewrite the
+// output was missing `doctor`; this is the integration-level regression gate.
+func TestCompletions_TopLevel(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "")
+	for _, want := range []string{
+		"new", "list", "status", "sync", "config", "doctor", "pr", "agent",
+		"goto", "delete", "reparent", "stack", "unstack", "up", "down",
+	} {
+		if !itestContains(got, want) {
+			t.Errorf("top-level missing %q in: %v", want, got)
+		}
+	}
+}
+
+func TestCompletions_TopLevelOnPartialPrefix(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// `ezs c<TAB>` — bash filters by prefix via compgen, so we still emit
+	// the full list. Pre-fix this case fell through and returned nothing,
+	// which made bash fall back to filename completion.
+	got := runCompletions(t, env, "c")
+	if !itestContains(got, "config") || !itestContains(got, "commit") {
+		t.Errorf("partial prefix should still emit full list; got %v", got)
+	}
+}
+
+func TestCompletions_ConfigSubcommands(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "config", "")
+	for _, want := range []string{"set", "show", "export", "import"} {
+		if !itestContains(got, want) {
+			t.Errorf("config subcommand %q missing in %v", want, got)
+		}
+	}
+}
+
+func TestCompletions_ConfigSetKeys(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "config", "set", "")
+	for _, want := range []string{
+		"worktree_base_dir", "default_base_branch", "github_token",
+		"cd_after_new", "use_worktrees", "sync_strategy", "agent_command",
+	} {
+		if !itestContains(got, want) {
+			t.Errorf("config set key %q missing in %v", want, got)
+		}
+	}
+}
+
+func TestCompletions_PRSubcommands(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "pr", "")
+	for _, want := range []string{"create", "draft", "merge", "stack", "update"} {
+		if !itestContains(got, want) {
+			t.Errorf("pr subcommand %q missing in %v", want, got)
+		}
+	}
+}
+
+func TestCompletions_AgentSubcommands(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	got := runCompletions(t, env, "agent", "")
+	for _, want := range []string{"feature", "feat", "prompt"} {
+		if !itestContains(got, want) {
+			t.Errorf("agent subcommand %q missing in %v", want, got)
+		}
+	}
+}
+
+// TestCompletions_BranchNamesForGoto creates a real branch and checks that
+// `ezs goto <TAB>` surfaces it. The whole branch-completion path is only
+// useful when the repo has stacks, so the integration test is the
+// definitive coverage — unit tests can't exercise the stack manager
+// load path without spinning up a repo anyway.
+func TestCompletions_BranchNamesForGoto(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "feature-x", "main")
+	CreateBranchWithCommit(t, env, "feature-y", "main")
+
+	got := runCompletions(t, env, "goto", "")
+	for _, want := range []string{"feature-x", "feature-y"} {
+		if !itestContains(got, want) {
+			t.Errorf("goto <TAB> should include %q; got %v", want, got)
+		}
+	}
+}
+
+// TestCompletions_BranchValueFlagPath covers `ezs sync -b <TAB>`. The
+// previous-word router must catch `-b` and switch to branch completion
+// regardless of which command we're in.
+func TestCompletions_BranchValueFlagPath(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "feat-bvf", "main")
+
+	got := runCompletions(t, env, "sync", "-b", "")
+	if !itestContains(got, "feat-bvf") {
+		t.Errorf("sync -b <TAB> should complete branches; got %v", got)
+	}
+}
+
+// TestCompletions_StackHashesForSync verifies that `ezs sync <TAB>` lists
+// stack hashes (sync's positional arg). Each branch creation produces a
+// stack, so we can inspect hashes via the manager and compare.
+func TestCompletions_StackHashesForSync(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "feat-sync-a", "main")
+
+	got := runCompletions(t, env, "sync", "")
+	// Hashes are 7+ hex chars. We don't know the exact value, but at least
+	// one non-flag, non-subcommand token should appear that looks like a
+	// hash. Be liberal: assert non-empty and that none of the tokens is a
+	// known top-level command (which would mean we accidentally fell
+	// through to the wrong path).
+	if len(got) == 0 {
+		t.Errorf("sync <TAB> should emit at least one stack identifier with a stack present")
+	}
+	for _, tok := range got {
+		switch tok {
+		case "create", "draft", "merge", "set", "show", "feature", "prompt":
+			t.Errorf("sync <TAB> leaked unrelated token %q (full output: %v)", tok, got)
+		}
+	}
+}
+
+// TestCompletions_FlagAtCursor: when the cursor is on a `-` token we always
+// emit flags, never branches. This is the hot path when typing a flag.
+func TestCompletions_FlagAtCursor(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	CreateBranchWithCommit(t, env, "branch-flag-test", "main")
+
+	got := runCompletions(t, env, "goto", "-")
+	if itestContains(got, "branch-flag-test") {
+		t.Errorf("goto -<TAB> must not surface branch names; got %v", got)
+	}
+	if !itestContains(got, "--help") {
+		t.Errorf("goto -<TAB> should emit flags; got %v", got)
+	}
+}
+
+// TestCompletions_OutsideRepoTopLevelStillWorks ensures completion of
+// top-level commands works even when the user hasn't cd'd into a repo yet
+// — the most common case during shell startup. Branch/stack completion is
+// allowed to be empty here (best-effort), but command lists must always
+// appear.
+func TestCompletions_OutsideRepoTopLevelStillWorks(t *testing.T) {
+	bin := buildEzs(t)
+
+	tmp := t.TempDir()
+	cmd := exec.Command(bin, "--completions", "")
+	cmd.Dir = tmp
+	cmd.Env = append(cmd.Environ(), "EZSTACK_HOME="+tmp)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--completions failed outside repo: %v\n%s", err, out)
+	}
+	body := strings.TrimRight(string(out), "\n")
+	lines := strings.Split(body, "\n")
+	if !slices.Contains(lines, "doctor") || !slices.Contains(lines, "config") {
+		t.Errorf("top-level completions missing outside repo: %v", lines)
+	}
+}
+
+// TestCompletions_ShellInitContainsCompletionFunction sanity-checks that
+// `ezs --shell-init` still emits the bash completion wiring. If a future
+// refactor drops the wiring, completions silently stop working — this
+// test makes that visible.
+func TestCompletions_ShellInitContainsCompletionFunction(t *testing.T) {
+	bin := buildEzs(t)
+	out, err := exec.Command(bin, "--shell-init").CombinedOutput()
+	if err != nil {
+		t.Fatalf("--shell-init failed: %v\n%s", err, out)
+	}
+	body := string(out)
+	for _, want := range []string{
+		"_ezs_completions",
+		"--completions",
+		"complete -F _ezs_completions ezs",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("--shell-init missing %q:\n%s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Five `ezs` commands silently ignored unknown flags or extra positional args — most dangerously `ezs config set worktree_base_dir /tmp/foo --bogus` used `strings.Join` to absorb `--bogus` into the stored path. Tab completion covered top-level commands and `pr`/`agent` only — `doctor` was missing entirely and there was no completion for branches, stacks, flags, or `config` subcommands.

## Changes

**Flag validation** — every `ezs` subcommand now rejects unknown flags and excess args:

- `doctor`: pflag-based parser.
- `config show / export / import`: exact arg counts.
- `config set`: exact arg count (3). **Multi-word values must now be quoted** — e.g. `ezs config set agent_command "claude --flag"`. The error message embeds a quoted example.
- `up` / `down`: integer-parse-first so `-1` reads as a step count error rather than "unknown flag", then reject any flag-shaped or extra positional arg.

**Tab completion** (new `cmd/ezs/completions.go`):

- Top-level emits the full command list on every one-word prefix (was: only on empty). `ezs c<TAB>` now works.
- `doctor` added to the completion list.
- `config <TAB>` → subcommands; `config set <TAB>` → 8 valid keys.
- `config set <key> --<TAB>` is suppressed (don't pollute a shell command line value with ezs's own flags).
- `goto / reparent / unstack / stack` → branch names.
- `delete` → branches **and** stack hashes (delete accepts either).
- `sync` → stack hashes/names.
- `--branch / -b / --parent / -p <value>` → branches; `--stack <value>` / `agent -s <value>` → stacks.
- `<cmd> --<TAB>` → command's flag set.
- Branch/stack lookup is best-effort: silent on failure so completion still works outside a configured repo.

**Ecosystem audit** — verified VSCode extension (`ezs doctor`, `config export/import`), Tauri UI (`config show`, `config set <k> <v>`, `doctor`), neovim plugin pass-through, and MCP server (`commands.Config`) all work with the strict parser. Stale MCP comment updated.

## Test plan

55 new tests, plus existing suite still passes.

- [x] `gofmt -l` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` green
- [x] Manual smoke test: doctor, config show/set/export, agent_command quoted/unquoted, up/down, tab completion in bash + zsh
- [x] VSCode/Tauri/neovim/MCP caller patterns verified compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)