### PR TITLE
feat(stack): surface orphan branches, steer ezs new → ezs stack

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -12,7 +12,7 @@
 
 [Overview](#overview) · [Installation](#installation) · [Configuration](#configuration) · [Commands](#commands) · [Workflows](#workflows) · [Editor & Desktop Integrations](#editor--desktop-integrations)
 
-**Commands:** [agent](#ezs-agent) · [commit/amend](#ezs-commit--ezs-amend) · [config](#ezs-config) · [delete](#ezs-delete) · [diff](#ezs-diff) · [doctor](#ezs-doctor) · [down/up](#ezs-down--ezs-up) · [goto](#ezs-goto) · [list](#ezs-list) · [log](#ezs-log) · [menu](#ezs-menu) · [new](#ezs-new) · [pr](#ezs-pr) · [push](#ezs-push) · [reparent](#ezs-reparent) · [stack](#ezs-stack) · [status](#ezs-status) · [sync](#ezs-sync) · [unstack](#ezs-unstack) · [upgrade](#ezs-upgrade)
+**Commands:** [agent](#ezs-agent) · [attach](#ezs-attach) · [commit/amend](#ezs-commit--ezs-amend) · [config](#ezs-config) · [delete](#ezs-delete) · [diff](#ezs-diff) · [doctor](#ezs-doctor) · [down/up](#ezs-down--ezs-up) · [goto](#ezs-goto) · [list](#ezs-list) · [log](#ezs-log) · [menu](#ezs-menu) · [new](#ezs-new) · [pr](#ezs-pr) · [push](#ezs-push) · [reparent](#ezs-reparent) · [stack](#ezs-stack) · [status](#ezs-status) · [sync](#ezs-sync) · [unstack](#ezs-unstack) · [upgrade](#ezs-upgrade)
 
 **Extras:** [Hooks](#hooks) · [Exit codes](#exit-codes) · [Discoverability](#discoverability-info---examples-did-you-mean)
 
@@ -637,6 +637,47 @@ ezs config set agent_command "aider --model gpt-4"
 > positional argument and rejects anything trailing — this keeps typos like
 > `ezs config set worktree_base_dir /tmp/foo --bogus` from being silently
 > stored as the literal path `/tmp/foo --bogus`.
+
+---
+
+### `ezs attach`
+
+Bring an existing local branch under ezs management. Idempotent — running it on an already-fully-attached branch is a no-op. Designed so you don't have to know whether your branch is bare, a worktree-but-untracked, or tracked-without-worktree: `ezs attach` converges to whatever "fully managed" looks like for the current repo.
+
+```
+ezs attach [branch] [options]
+
+Options:
+    -p, --parent <branch>     Override detected parent (default: nearest tracked ancestor via merge-base)
+    -w, --worktree <path>     Force a worktree at this path (overrides config)
+    -W, --no-worktree         Register without a worktree (overrides config)
+    -c, --cd / -C, --no-cd    Change to the worktree after attaching (overrides cd_after_new)
+    -s/-S                     Submodule init control, same as `ezs new`
+    -y, --yes                 Skip the "Proceed?" confirm
+```
+
+The auto-detected parent is the closest tracked ancestor by commit-distance, with the configured base branch as a fallback. The chosen parent, target stack, and worktree action are shown as a one-screen plan before any changes — so you confirm intent, not blind to outcome.
+
+With no branch argument, `ezs attach` opens an interactive picker over local branches that aren't in any stack yet. Each row shows the auto-detected parent so you're never selecting blind.
+
+```bash
+# Bring a branch you made with `git checkout -b` into a stack
+ezs attach feature-x
+
+# Override the detected parent
+ezs attach feature-x -p feature-a
+
+# Force a worktree in a no-worktree-mode repo
+ezs attach feature-x -w ~/wt/feature-x
+
+# Force bare attach in a worktree-mode repo
+ezs attach feature-x -W
+
+# Pick from orphan branches interactively
+ezs attach
+```
+
+To pick up a remote branch (PR review, collaborator's branch), use `ezs new origin/<branch>` instead — that's the canonical "remote → local managed" path.
 
 ---
 

--- a/cmd/ezs/commands/attach.go
+++ b/cmd/ezs/commands/attach.go
@@ -1,0 +1,487 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/git"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/helpers"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/ui"
+	"github.com/spf13/pflag"
+)
+
+// Attach brings an existing local branch under ezs management — converging it
+// to whatever "fully managed" looks like for the current repo (worktree mode
+// vs. bare-branch mode). Idempotent: running it on an already-fully-attached
+// branch is an explicit no-op.
+//
+// Replaces the older `ezs new -f` path and gives users one verb that doesn't
+// require them to know whether their branch is bare, worktree-but-untracked,
+// or tracked-without-worktree.
+func Attach(args []string) error {
+	if HasExamplesFlag("attach", args) {
+		return nil
+	}
+	fs := pflag.NewFlagSet("attach", pflag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%sBring an existing branch under ezs management%s
+
+%sUSAGE%s
+    ezs attach [branch] [options]
+
+%sOPTIONS%s
+    -p, --parent <branch>     Override detected parent (default: nearest tracked ancestor)
+    -w, --worktree <path>     Force a worktree at this path (overrides config)
+    -W, --no-worktree         Register without a worktree (overrides config)
+    -c, --cd                  Change to the worktree after attaching
+    -C, --no-cd               Don't change to the worktree (overrides config)
+    -s, --init-submodules     Mirror main worktree's initialized submodules
+    -S, --no-init-submodules  Skip submodule initialization
+    -y, --yes                 Skip the "Proceed?" confirm
+    -h, --help                Show this help message
+
+%sNOTES%s
+    With no branch argument, prompts to pick from local branches that aren't
+    in any stack yet. Run again on the same branch — it's a no-op.
+
+    To pick up a remote branch, use:  ezs new origin/<branch>
+`, ui.Bold, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset)
+	}
+	parent := fs.StringP("parent", "p", "", "Override detected parent")
+	worktree := fs.StringP("worktree", "w", "", "Force worktree at this path")
+	noWorktree := fs.BoolP("no-worktree", "W", false, "Register without a worktree")
+	cdFlag := fs.BoolP("cd", "c", false, "Change to worktree")
+	noCdFlag := fs.BoolP("no-cd", "C", false, "Don't change to worktree")
+	initSubmodulesFlag := fs.BoolP("init-submodules", "s", false, "Mirror submodules")
+	noInitSubmodulesFlag := fs.BoolP("no-init-submodules", "S", false, "Skip submodules")
+	yesFlag := fs.BoolP("yes", "y", false, "Skip confirmation prompt")
+	helpFlag := fs.BoolP("help", "h", false, "Show help")
+
+	if err := fs.Parse(args); err != nil {
+		if err == pflag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+	if *helpFlag {
+		fs.Usage()
+		return nil
+	}
+	if *worktree != "" && *noWorktree {
+		return fmt.Errorf("--worktree and --no-worktree are mutually exclusive")
+	}
+
+	if *yesFlag {
+		ui.YesMode = true
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	g := git.New(cwd)
+	mgr, err := stack.NewManager(cwd)
+	if err != nil {
+		return err
+	}
+
+	// No branch arg → interactive picker. The picker shows the auto-detected
+	// parent for each row so the user is never selecting blind.
+	if fs.NArg() == 0 {
+		return attachInteractive(g, mgr, *parent, *worktree, *noWorktree, *cdFlag, *noCdFlag, *initSubmodulesFlag, *noInitSubmodulesFlag)
+	}
+
+	branchName := fs.Arg(0)
+	if err := git.ValidateBranchName(branchName); err != nil {
+		return err
+	}
+
+	return attachOne(g, mgr, branchName, *parent, *worktree, *noWorktree, *cdFlag, *noCdFlag, *initSubmodulesFlag, *noInitSubmodulesFlag)
+}
+
+// attachOne performs a single-branch attach. Centralizes the state-machine
+// dispatch so both single-arg and batch interactive paths share one
+// implementation.
+func attachOne(g *git.Git, mgr *stack.Manager, branchName, parentOverride, worktreeOverride string, noWorktree, cdFlag, noCdFlag, initSubmodulesFlag, noInitSubmodulesFlag bool) error {
+	if !g.BranchExists(branchName) {
+		return fmt.Errorf("branch %q does not exist locally\n\n  Create it: ezs new %s", branchName, branchName)
+	}
+
+	cfg := mgr.GetConfig()
+	repoDir := mgr.GetRepoDir()
+	baseBranch := cfg.GetBaseBranch(repoDir)
+
+	if mgr.IsMainBranch(branchName) {
+		return fmt.Errorf("branch %q is the base branch and cannot be attached", branchName)
+	}
+
+	tracked := mgr.GetBranch(branchName)
+	actualWorktreePath := findWorktreePathForBranch(g, branchName)
+
+	useWorktrees := cfg.GetUseWorktrees(repoDir)
+	if worktreeOverride != "" {
+		useWorktrees = true
+	}
+	if noWorktree {
+		useWorktrees = false
+	}
+
+	// Already-tracked path: detect mismatch, sync metadata, no-op, or upgrade.
+	if tracked != nil {
+		metaPath := tracked.WorktreePath
+		if metaPath != "" && actualWorktreePath != "" && metaPath != actualWorktreePath {
+			return fmt.Errorf("worktree mismatch for branch %q\n  metadata says: %s\n  git reports:   %s\n  Move with: git worktree move %s %s",
+				branchName, metaPath, actualWorktreePath, actualWorktreePath, metaPath)
+		}
+		if metaPath == "" && actualWorktreePath != "" {
+			if err := mgr.SetBranchWorktreePath(branchName, actualWorktreePath); err != nil {
+				return err
+			}
+			ui.Info(fmt.Sprintf("Synced metadata for %q to existing worktree at %s", branchName, actualWorktreePath))
+			return nil
+		}
+		if (metaPath != "" && actualWorktreePath != "") || (metaPath == "" && actualWorktreePath == "" && !useWorktrees) {
+			s := mgr.GetStackForBranch(branchName)
+			ui.Info(fmt.Sprintf("Branch %q is already attached%s", branchName, formatStackSuffix(s)))
+			return nil
+		}
+		return materializeWorktreeForTracked(g, mgr, tracked, worktreeOverride, cdFlag, noCdFlag, initSubmodulesFlag, noInitSubmodulesFlag)
+	}
+
+	// Untracked path: pick a parent, then register (and optionally materialize).
+	parentBranch := parentOverride
+	parentDetected := false
+	if parentBranch == "" {
+		detected, ok := detectParentBranch(g, mgr, branchName, baseBranch)
+		if !ok {
+			picked, err := pickParentForAttach(mgr, baseBranch)
+			if err != nil {
+				return err
+			}
+			parentBranch = picked
+		} else {
+			parentBranch = detected
+			parentDetected = true
+		}
+	}
+	if parentBranch == branchName {
+		return fmt.Errorf("parent cannot be the branch itself (%q)", branchName)
+	}
+
+	var plannedWorktreePath string
+	worktreeAction := "none"
+	if useWorktrees {
+		if actualWorktreePath != "" {
+			if worktreeOverride != "" && helpers.ExpandPath(worktreeOverride) != actualWorktreePath {
+				return fmt.Errorf("branch %q already has a worktree at %s; refusing to create a second one at %s",
+					branchName, actualWorktreePath, worktreeOverride)
+			}
+			plannedWorktreePath = actualWorktreePath
+			worktreeAction = "use existing"
+		} else if worktreeOverride != "" {
+			plannedWorktreePath = helpers.ExpandPath(worktreeOverride)
+			worktreeAction = "create"
+		} else {
+			worktreeBaseDir := cfg.GetWorktreeBaseDir(repoDir)
+			if worktreeBaseDir == "" {
+				wbd, err := promptWorktreeBaseDir(repoDir, cfg)
+				if err != nil {
+					return err
+				}
+				worktreeBaseDir = wbd
+			}
+			plannedWorktreePath = filepath.Join(worktreeBaseDir, branchName)
+			worktreeAction = "create"
+		}
+	} else if actualWorktreePath != "" {
+		// User explicitly passed -W but a worktree already exists — register it
+		// rather than ignore reality.
+		plannedWorktreePath = actualWorktreePath
+		worktreeAction = "use existing"
+	}
+
+	showAttachPlan(g, mgr, branchName, parentBranch, parentDetected, plannedWorktreePath, worktreeAction, baseBranch)
+	if !ui.YesMode {
+		if !ui.ConfirmTUIWithDefault(fmt.Sprintf("Attach %q?", branchName), true) {
+			ui.Warn("Cancelled")
+			return nil
+		}
+	}
+
+	if worktreeAction == "create" {
+		if err := g.CreateWorktree(branchName, plannedWorktreePath, parentBranch); err != nil {
+			return fmt.Errorf("failed to create worktree: %w", err)
+		}
+		mirrorSubmodulesIfEnabled(g, cfg, repoDir, plannedWorktreePath, initSubmodulesFlag, noInitSubmodulesFlag)
+	}
+
+	branch, err := mgr.AddWorktreeToStack(branchName, plannedWorktreePath, parentBranch)
+	if err != nil {
+		return err
+	}
+
+	ui.Success(fmt.Sprintf("Attached %q under %q", branchName, parentBranch))
+	if plannedWorktreePath != "" {
+		ui.Info(fmt.Sprintf("Worktree: %s", plannedWorktreePath))
+	}
+
+	if s := mgr.GetStackForBranch(branchName); s != nil && len(s.Branches) == 1 {
+		promptStackName(mgr, branch.Name)
+	}
+
+	if plannedWorktreePath != "" && getCdAfterNew(cfg, repoDir, cdFlag, noCdFlag) {
+		EmitCd(plannedWorktreePath)
+	}
+	return nil
+}
+
+// materializeWorktreeForTracked handles the "branch is already tracked but
+// has no worktree, and use_worktrees=true" case — the path that lets users
+// upgrade a no-worktree-mode branch to a worktree-mode branch without
+// re-creating any stack metadata.
+func materializeWorktreeForTracked(g *git.Git, mgr *stack.Manager, tracked *config.Branch, worktreeOverride string, cdFlag, noCdFlag, initSubmodulesFlag, noInitSubmodulesFlag bool) error {
+	cfg := mgr.GetConfig()
+	repoDir := mgr.GetRepoDir()
+
+	worktreePath := worktreeOverride
+	if worktreePath == "" {
+		worktreeBaseDir := cfg.GetWorktreeBaseDir(repoDir)
+		if worktreeBaseDir == "" {
+			wbd, err := promptWorktreeBaseDir(repoDir, cfg)
+			if err != nil {
+				return err
+			}
+			worktreeBaseDir = wbd
+		}
+		worktreePath = filepath.Join(worktreeBaseDir, tracked.Name)
+	}
+	worktreePath = helpers.ExpandPath(worktreePath)
+
+	ui.Info(fmt.Sprintf("Branch %q is tracked but has no worktree.", tracked.Name))
+	ui.Info(fmt.Sprintf("Will create worktree at: %s", worktreePath))
+	if !ui.YesMode && !ui.ConfirmTUIWithDefault("Proceed?", true) {
+		ui.Warn("Cancelled")
+		return nil
+	}
+
+	if err := g.CreateWorktree(tracked.Name, worktreePath, tracked.Parent); err != nil {
+		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+	mirrorSubmodulesIfEnabled(g, cfg, repoDir, worktreePath, initSubmodulesFlag, noInitSubmodulesFlag)
+
+	if err := mgr.SetBranchWorktreePath(tracked.Name, worktreePath); err != nil {
+		return err
+	}
+
+	ui.Success(fmt.Sprintf("Materialized worktree for %q at %s", tracked.Name, worktreePath))
+	if getCdAfterNew(cfg, repoDir, cdFlag, noCdFlag) {
+		EmitCd(worktreePath)
+	}
+	return nil
+}
+
+// detectParentBranch finds the closest tracked ancestor of branchName. Walks
+// every tracked branch (across all stacks) plus the configured base branch
+// and picks the one with the smallest commit-distance from branchName,
+// breaking ties in favor of non-base candidates. If nothing is an ancestor,
+// returns ("", false) so the caller can fall back to a picker.
+func detectParentBranch(g *git.Git, mgr *stack.Manager, branchName, baseBranch string) (string, bool) {
+	var candidates []string
+	seen := make(map[string]bool)
+	add := func(name string) {
+		if name == "" || name == branchName || seen[name] {
+			return
+		}
+		seen[name] = true
+		candidates = append(candidates, name)
+	}
+	for _, b := range mgr.GetAllBranchesInAllStacks() {
+		add(b.Name)
+	}
+	if baseBranch != "" {
+		add(baseBranch)
+	}
+
+	type scored struct {
+		name     string
+		distance int
+		isBase   bool
+	}
+	var ancestors []scored
+	for _, c := range candidates {
+		isAncestor, err := g.IsBranchMerged(c, branchName)
+		if err != nil || !isAncestor {
+			continue
+		}
+		dist, err := g.GetCommitsAhead(branchName, c)
+		if err != nil {
+			continue
+		}
+		ancestors = append(ancestors, scored{c, dist, c == baseBranch})
+	}
+	if len(ancestors) == 0 {
+		if baseBranch != "" {
+			return baseBranch, false
+		}
+		return "", false
+	}
+	sort.SliceStable(ancestors, func(i, j int) bool {
+		if ancestors[i].distance != ancestors[j].distance {
+			return ancestors[i].distance < ancestors[j].distance
+		}
+		if ancestors[i].isBase != ancestors[j].isBase {
+			return !ancestors[i].isBase
+		}
+		return ancestors[i].name < ancestors[j].name
+	})
+	return ancestors[0].name, true
+}
+
+// pickParentForAttach falls back to the parent picker used by `ezs new` so
+// the attach UX matches user expectations when auto-detect can't decide.
+func pickParentForAttach(mgr *stack.Manager, baseBranch string) (string, error) {
+	choices := buildParentChoices(baseBranch, mgr.ListStacks())
+	if len(choices) == 0 {
+		return baseBranch, nil
+	}
+	labels := make([]string, len(choices))
+	for i, c := range choices {
+		labels[i] = c.label
+	}
+	idx, err := ui.SelectOption(labels, "Could not detect parent — select one")
+	if err != nil {
+		return "", err
+	}
+	return choices[idx].branch, nil
+}
+
+// findWorktreePathForBranch returns the path of any existing worktree for the
+// branch, or "" if none exists. The main worktree counts — if the user did a
+// plain `git checkout -b` in the main repo, that's its worktree.
+func findWorktreePathForBranch(g *git.Git, branchName string) string {
+	wts, err := g.ListWorktrees()
+	if err != nil {
+		return ""
+	}
+	for _, wt := range wts {
+		if wt.Branch == branchName {
+			return wt.Path
+		}
+	}
+	return ""
+}
+
+func formatStackSuffix(s *config.Stack) string {
+	if s == nil {
+		return ""
+	}
+	return fmt.Sprintf(" in stack '%s'", s.DisplayName())
+}
+
+// showAttachPlan prints the planned attach action and returns false if the
+// user had any reason to abort before the confirm. Always returns true today;
+// reserved for future "preflight failed" branches.
+func showAttachPlan(g *git.Git, mgr *stack.Manager, branchName, parentBranch string, detected bool, worktreePath, worktreeAction, baseBranch string) bool {
+	commitsAhead, _ := g.GetCommitsAhead(branchName, parentBranch)
+
+	stackLabel := "(new stack)"
+	if s := mgr.FindStackForBranch(parentBranch); s != nil {
+		stackLabel = fmt.Sprintf("'%s' [%s]", s.DisplayName(), s.Hash)
+	}
+
+	parentNote := ""
+	if detected {
+		parentNote = "  (auto-detected)"
+	} else if parentBranch == baseBranch {
+		parentNote = "  (default base)"
+	}
+
+	worktreeNote := "(no worktree)"
+	switch worktreeAction {
+	case "create":
+		worktreeNote = fmt.Sprintf("%s  (will be created)", worktreePath)
+	case "use existing":
+		worktreeNote = fmt.Sprintf("%s  (existing — will be registered)", worktreePath)
+	}
+
+	fmt.Fprintf(os.Stderr, "%s%sPlan:%s\n", ui.Bold, ui.Cyan, ui.Reset)
+	fmt.Fprintf(os.Stderr, "  Branch:   %s  (%d commit(s) ahead of %s)\n", branchName, commitsAhead, parentBranch)
+	fmt.Fprintf(os.Stderr, "  Parent:   %s%s\n", parentBranch, parentNote)
+	fmt.Fprintf(os.Stderr, "  Stack:    %s\n", stackLabel)
+	fmt.Fprintf(os.Stderr, "  Worktree: %s\n", worktreeNote)
+	fmt.Fprintln(os.Stderr)
+	return true
+}
+
+// attachInteractive shows the orphan-branch picker with each row's auto-
+// detected parent. Selecting a row hands off to attachOne — so the
+// confirmation flow there still applies, and the user gets the full plan
+// preview before any changes.
+func attachInteractive(g *git.Git, mgr *stack.Manager, parentOverride, worktreeOverride string, noWorktree, cdFlag, noCdFlag, initSubmodulesFlag, noInitSubmodulesFlag bool) error {
+	candidates, err := CollectUntrackedBranches(g, mgr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%swarning: %v%s\n", ui.Yellow, err, ui.Reset)
+	}
+	if len(candidates) == 0 {
+		ui.Info("No orphan branches found — every local branch is already in a stack.")
+		return nil
+	}
+
+	cfg := mgr.GetConfig()
+	baseBranch := cfg.GetBaseBranch(mgr.GetRepoDir())
+
+	type candRow struct {
+		name       string
+		worktree   string
+		parent     string
+		detected   bool
+		commitsAhd int
+	}
+	rows := make([]candRow, 0, len(candidates))
+	for _, c := range candidates {
+		row := candRow{name: c.Name, worktree: c.WorktreePath}
+		if parentOverride != "" {
+			row.parent = parentOverride
+		} else {
+			p, ok := detectParentBranch(g, mgr, c.Name, baseBranch)
+			row.parent = p
+			row.detected = ok
+		}
+		if row.parent != "" {
+			row.commitsAhd, _ = g.GetCommitsAhead(c.Name, row.parent)
+		}
+		rows = append(rows, row)
+	}
+
+	options := make([]string, len(rows))
+	for i, r := range rows {
+		wt := "[no worktree]"
+		if r.worktree != "" {
+			wt = fmt.Sprintf("(worktree at %s)", r.worktree)
+		}
+		parentNote := ""
+		if r.parent != "" {
+			parentNote = fmt.Sprintf("  → would attach under %s (%d commit(s) ahead)", r.parent, r.commitsAhd)
+			if !r.detected {
+				parentNote += " [fallback]"
+			}
+		}
+		options[i] = fmt.Sprintf("%s %s%s", r.name, wt, parentNote)
+	}
+
+	selected, err := ui.SelectOption(options, "Select branch to attach")
+	if err != nil {
+		return err
+	}
+	row := rows[selected]
+
+	parent := row.parent
+	if parent == "" {
+		parent = baseBranch
+	}
+	return attachOne(g, mgr, row.name, parent, worktreeOverride, noWorktree, cdFlag, noCdFlag, initSubmodulesFlag, noInitSubmodulesFlag)
+}

--- a/cmd/ezs/commands/attach.go
+++ b/cmd/ezs/commands/attach.go
@@ -132,6 +132,15 @@ func attachOne(g *git.Git, mgr *stack.Manager, branchName, parentOverride, workt
 
 	// Already-tracked path: detect mismatch, sync metadata, no-op, or upgrade.
 	if tracked != nil {
+		// `-p` on an already-attached branch is ambiguous — the user almost
+		// certainly wants a reparent, but attach is not the reparent verb.
+		// Silently ignoring it would let stale metadata accumulate; routing
+		// it through reparent would surprise users who think they're running
+		// a no-op. Fail with a clear signpost instead.
+		if parentOverride != "" && parentOverride != tracked.Parent {
+			return fmt.Errorf("branch %q is already attached under %q\n\n  Change parent: ezs reparent %s -p %s",
+				branchName, tracked.Parent, branchName, parentOverride)
+		}
 		metaPath := tracked.WorktreePath
 		if metaPath != "" && actualWorktreePath != "" && metaPath != actualWorktreePath {
 			return fmt.Errorf("worktree mismatch for branch %q\n  metadata says: %s\n  git reports:   %s\n  Move with: git worktree move %s %s",
@@ -171,14 +180,24 @@ func attachOne(g *git.Git, mgr *stack.Manager, branchName, parentOverride, workt
 	if parentBranch == branchName {
 		return fmt.Errorf("parent cannot be the branch itself (%q)", branchName)
 	}
+	// Validate the parent ref before recording it. CreateWorktree won't catch a
+	// typo here: when the branch already exists locally (which is the only path
+	// into attach), `git branch <name> <parent>` short-circuits with "already
+	// exists" and `git worktree add <path> <branch>` ignores the parent
+	// entirely. So an invalid `-p` would land in metadata silently, breaking
+	// every later sync/reparent that walks parent refs.
+	if !g.BranchExists(parentBranch) && mgr.GetBranch(parentBranch) == nil {
+		return fmt.Errorf("parent branch %q does not exist", parentBranch)
+	}
 
 	var plannedWorktreePath string
 	worktreeAction := "none"
 	if useWorktrees {
 		if actualWorktreePath != "" {
-			if worktreeOverride != "" && helpers.ExpandPath(worktreeOverride) != actualWorktreePath {
+			expandedOverride := helpers.ExpandPath(worktreeOverride)
+			if worktreeOverride != "" && expandedOverride != actualWorktreePath {
 				return fmt.Errorf("branch %q already has a worktree at %s; refusing to create a second one at %s",
-					branchName, actualWorktreePath, worktreeOverride)
+					branchName, actualWorktreePath, expandedOverride)
 			}
 			plannedWorktreePath = actualWorktreePath
 			worktreeAction = "use existing"
@@ -382,10 +401,9 @@ func formatStackSuffix(s *config.Stack) string {
 	return fmt.Sprintf(" in stack '%s'", s.DisplayName())
 }
 
-// showAttachPlan prints the planned attach action and returns false if the
-// user had any reason to abort before the confirm. Always returns true today;
-// reserved for future "preflight failed" branches.
-func showAttachPlan(g *git.Git, mgr *stack.Manager, branchName, parentBranch string, detected bool, worktreePath, worktreeAction, baseBranch string) bool {
+// showAttachPlan prints the planned attach action so the user can confirm
+// against the full picture before any mutation runs.
+func showAttachPlan(g *git.Git, mgr *stack.Manager, branchName, parentBranch string, detected bool, worktreePath, worktreeAction, baseBranch string) {
 	commitsAhead, _ := g.GetCommitsAhead(branchName, parentBranch)
 
 	stackLabel := "(new stack)"
@@ -414,7 +432,6 @@ func showAttachPlan(g *git.Git, mgr *stack.Manager, branchName, parentBranch str
 	fmt.Fprintf(os.Stderr, "  Stack:    %s\n", stackLabel)
 	fmt.Fprintf(os.Stderr, "  Worktree: %s\n", worktreeNote)
 	fmt.Fprintln(os.Stderr)
-	return true
 }
 
 // attachInteractive shows the orphan-branch picker with each row's auto-
@@ -435,11 +452,11 @@ func attachInteractive(g *git.Git, mgr *stack.Manager, parentOverride, worktreeO
 	baseBranch := cfg.GetBaseBranch(mgr.GetRepoDir())
 
 	type candRow struct {
-		name       string
-		worktree   string
-		parent     string
-		detected   bool
-		commitsAhd int
+		name         string
+		worktree     string
+		parent       string
+		detected     bool
+		commitsAhead int
 	}
 	rows := make([]candRow, 0, len(candidates))
 	for _, c := range candidates {
@@ -452,7 +469,7 @@ func attachInteractive(g *git.Git, mgr *stack.Manager, parentOverride, worktreeO
 			row.detected = ok
 		}
 		if row.parent != "" {
-			row.commitsAhd, _ = g.GetCommitsAhead(c.Name, row.parent)
+			row.commitsAhead, _ = g.GetCommitsAhead(c.Name, row.parent)
 		}
 		rows = append(rows, row)
 	}
@@ -465,7 +482,7 @@ func attachInteractive(g *git.Git, mgr *stack.Manager, parentOverride, worktreeO
 		}
 		parentNote := ""
 		if r.parent != "" {
-			parentNote = fmt.Sprintf("  → would attach under %s (%d commit(s) ahead)", r.parent, r.commitsAhd)
+			parentNote = fmt.Sprintf("  → would attach under %s (%d commit(s) ahead)", r.parent, r.commitsAhead)
 			if !r.detected {
 				parentNote += " [fallback]"
 			}

--- a/cmd/ezs/commands/list.go
+++ b/cmd/ezs/commands/list.go
@@ -460,6 +460,9 @@ func Status(args []string) error {
 		if err := printOrJSON(stacks, statusMaps); err != nil {
 			return err
 		}
+		if !*jsonFlag {
+			printOrphanBranches(g, mgr)
+		}
 		if !*jsonFlag && ghAvailable {
 			offerFullyMergedStackCleanup(mgr, stacks)
 		}
@@ -522,6 +525,54 @@ func Status(args []string) error {
 	}
 
 	return nil
+}
+
+// printOrphanBranches lists local branches that aren't part of any stack and
+// aren't main/master/baseBranch. Surfaced under `ezs status -a` so users notice
+// branches they made with `git checkout -b` outside of ezs and learn how to
+// adopt them. No-op when there are no orphans.
+func printOrphanBranches(g *git.Git, mgr *stack.Manager) {
+	localBranches, err := g.ListLocalBranches()
+	if err != nil {
+		return
+	}
+
+	worktrees, _ := g.ListWorktrees()
+	wtByBranch := make(map[string]string, len(worktrees))
+	for _, wt := range worktrees {
+		if wt.Branch != "" {
+			wtByBranch[wt.Branch] = wt.Path
+		}
+	}
+
+	type orphan struct {
+		name         string
+		worktreePath string
+	}
+	var orphans []orphan
+	for _, b := range localBranches {
+		if mgr.IsMainBranch(b) {
+			continue
+		}
+		if mgr.GetBranch(b) != nil {
+			continue
+		}
+		orphans = append(orphans, orphan{name: b, worktreePath: wtByBranch[b]})
+	}
+
+	if len(orphans) == 0 {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "%s%sBranches not in any stack:%s\n", ui.Bold, ui.Cyan, ui.Reset)
+	for _, o := range orphans {
+		suffix := "[no worktree]"
+		if o.worktreePath != "" {
+			suffix = fmt.Sprintf("(worktree at %s)", o.worktreePath)
+		}
+		fmt.Fprintf(os.Stderr, "  %s %s%s%s\n", o.name, ui.Gray, suffix, ui.Reset)
+	}
+	fmt.Fprintf(os.Stderr, "%sAdopt one with:%s ezs stack -b <branch> -p <parent>\n\n", ui.Gray, ui.Reset)
 }
 
 // runStatusWatch repeatedly clears the screen and runs status until the user

--- a/cmd/ezs/commands/list.go
+++ b/cmd/ezs/commands/list.go
@@ -532,34 +532,12 @@ func Status(args []string) error {
 // branches they made with `git checkout -b` outside of ezs and learn how to
 // adopt them. No-op when there are no orphans.
 func printOrphanBranches(g *git.Git, mgr *stack.Manager) {
-	localBranches, err := g.ListLocalBranches()
+	orphans, err := CollectUntrackedBranches(g, mgr)
 	if err != nil {
-		return
+		// Status decoration shouldn't fail the command, but the user deserves
+		// a heads-up that the orphan list may be incomplete.
+		fmt.Fprintf(os.Stderr, "%swarning: orphan-branch lookup partial: %v%s\n", ui.Yellow, err, ui.Reset)
 	}
-
-	worktrees, _ := g.ListWorktrees()
-	wtByBranch := make(map[string]string, len(worktrees))
-	for _, wt := range worktrees {
-		if wt.Branch != "" {
-			wtByBranch[wt.Branch] = wt.Path
-		}
-	}
-
-	type orphan struct {
-		name         string
-		worktreePath string
-	}
-	var orphans []orphan
-	for _, b := range localBranches {
-		if mgr.IsMainBranch(b) {
-			continue
-		}
-		if mgr.GetBranch(b) != nil {
-			continue
-		}
-		orphans = append(orphans, orphan{name: b, worktreePath: wtByBranch[b]})
-	}
-
 	if len(orphans) == 0 {
 		return
 	}
@@ -567,12 +545,12 @@ func printOrphanBranches(g *git.Git, mgr *stack.Manager) {
 	fmt.Fprintf(os.Stderr, "%s%sBranches not in any stack:%s\n", ui.Bold, ui.Cyan, ui.Reset)
 	for _, o := range orphans {
 		suffix := "[no worktree]"
-		if o.worktreePath != "" {
-			suffix = fmt.Sprintf("(worktree at %s)", o.worktreePath)
+		if o.WorktreePath != "" {
+			suffix = fmt.Sprintf("(worktree at %s)", o.WorktreePath)
 		}
-		fmt.Fprintf(os.Stderr, "  %s %s%s%s\n", o.name, ui.Gray, suffix, ui.Reset)
+		fmt.Fprintf(os.Stderr, "  %s %s%s%s\n", o.Name, ui.Gray, suffix, ui.Reset)
 	}
-	fmt.Fprintf(os.Stderr, "%sAdopt one with:%s ezs stack -b <branch> -p <parent>\n\n", ui.Gray, ui.Reset)
+	fmt.Fprintf(os.Stderr, "%sAdopt one with:%s ezs attach <branch>\n\n", ui.Gray, ui.Reset)
 }
 
 // runStatusWatch repeatedly clears the screen and runs status until the user

--- a/cmd/ezs/commands/new.go
+++ b/cmd/ezs/commands/new.go
@@ -304,6 +304,22 @@ func New(args []string) error {
 		return err
 	}
 
+	// If the branch already exists locally, ezs new would either silently
+	// adopt it (worktree mode tolerates "branch already exists") or fail
+	// opaquely (no-worktree mode). Both are surprising. Steer the user to
+	// `ezs stack`, which is the supported path for bringing a pre-existing
+	// branch into a stack.
+	if g.BranchExists(branchName) {
+		hintParent := parentBranch
+		if hintParent == "" {
+			hintParent = "<parent>"
+		}
+		return fmt.Errorf("branch %q already exists locally\n\n"+
+			"  Add it to a stack:    ezs stack -b %s -p %s\n"+
+			"  Or pick a new name:   ezs new %s-v2",
+			branchName, branchName, hintParent, branchName)
+	}
+
 	// Create the manager first to get repo-specific config
 	mgr, err := stack.NewManager(cwd)
 	if err != nil {

--- a/cmd/ezs/commands/new.go
+++ b/cmd/ezs/commands/new.go
@@ -307,17 +307,14 @@ func New(args []string) error {
 	// If the branch already exists locally, ezs new would either silently
 	// adopt it (worktree mode tolerates "branch already exists") or fail
 	// opaquely (no-worktree mode). Both are surprising. Steer the user to
-	// `ezs stack`, which is the supported path for bringing a pre-existing
-	// branch into a stack.
+	// `ezs attach`, which is the supported path for bringing a pre-existing
+	// branch under ezs management — it auto-detects the parent and
+	// converges the branch to the repo's "fully managed" state.
 	if g.BranchExists(branchName) {
-		hintParent := parentBranch
-		if hintParent == "" {
-			hintParent = "<parent>"
-		}
 		return fmt.Errorf("branch %q already exists locally\n\n"+
-			"  Add it to a stack:    ezs stack -b %s -p %s\n"+
-			"  Or pick a new name:   ezs new %s-v2",
-			branchName, branchName, hintParent, branchName)
+			"  Bring it into ezstack:  ezs attach %s\n"+
+			"  Or pick a new name:     ezs new %s-v2",
+			branchName, branchName, branchName)
 	}
 
 	// Create the manager first to get repo-specific config

--- a/cmd/ezs/commands/stack.go
+++ b/cmd/ezs/commands/stack.go
@@ -123,7 +123,7 @@ func Stack(args []string) error {
 
 		if choice == 0 {
 			// Add to existing stack: pick branch first, then parent
-			branchName, err = selectUntrackedBranch(mgr)
+			branchName, err = selectUntrackedBranch(g, mgr)
 			if err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func Stack(args []string) error {
 			if err != nil {
 				return err
 			}
-			branchName, err = selectUntrackedBranch(mgr, parentName)
+			branchName, err = selectUntrackedBranch(g, mgr, parentName)
 			if err != nil {
 				return err
 			}
@@ -149,7 +149,7 @@ func Stack(args []string) error {
 			if err != nil {
 				return err
 			}
-			branchName, err = selectUntrackedBranch(mgr, parentName)
+			branchName, err = selectUntrackedBranch(g, mgr, parentName)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ func Stack(args []string) error {
 		}
 	} else {
 		if branchName == "" {
-			branchName, err = selectUntrackedBranch(mgr)
+			branchName, err = selectUntrackedBranch(g, mgr)
 			if err != nil {
 				return err
 			}
@@ -483,31 +483,73 @@ func selectBaseBranch(mgr *stack.Manager, g *git.Git, branchName, baseBranch str
 	return branchNames[selected], nil
 }
 
-// selectUntrackedBranch shows a selection UI for untracked worktrees.
-// excludeBranches are filtered out of the list (e.g. the base branch itself).
-func selectUntrackedBranch(mgr *stack.Manager, excludeBranches ...string) (string, error) {
-	unregistered, err := mgr.GetUnregisteredWorktrees()
-	if err != nil {
-		return "", err
-	}
+// UntrackedBranch represents a local branch eligible to be attached to a stack.
+// WorktreePath is empty for bare branches (no worktree).
+type UntrackedBranch struct {
+	Name         string
+	WorktreePath string
+}
 
+// CollectUntrackedBranches returns local branches that aren't tracked in any
+// stack and aren't the base branch — both unregistered worktrees and bare
+// local branches. Order: worktrees first (in git's listing order), then bare
+// branches (in git's listing order).
+func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ...string) []UntrackedBranch {
 	exclude := make(map[string]bool, len(excludeBranches))
 	for _, b := range excludeBranches {
 		exclude[b] = true
 	}
 
-	var options []string
-	var branchNames []string
-	for _, wt := range unregistered {
-		if exclude[wt.Branch] {
-			continue
+	seen := make(map[string]bool)
+	var out []UntrackedBranch
+
+	if unregistered, err := mgr.GetUnregisteredWorktrees(); err == nil {
+		for _, wt := range unregistered {
+			if exclude[wt.Branch] || seen[wt.Branch] {
+				continue
+			}
+			seen[wt.Branch] = true
+			out = append(out, UntrackedBranch{Name: wt.Branch, WorktreePath: wt.Path})
 		}
-		options = append(options, fmt.Sprintf("%s (%s)", wt.Branch, wt.Path))
-		branchNames = append(branchNames, wt.Branch)
 	}
 
-	if len(options) == 0 {
-		return "", fmt.Errorf("no untracked branches found. All worktrees are already in stacks")
+	if localBranches, err := g.ListLocalBranches(); err == nil {
+		for _, lb := range localBranches {
+			if exclude[lb] || seen[lb] {
+				continue
+			}
+			if mgr.IsMainBranch(lb) {
+				continue
+			}
+			if mgr.GetBranch(lb) != nil {
+				continue
+			}
+			seen[lb] = true
+			out = append(out, UntrackedBranch{Name: lb})
+		}
+	}
+
+	return out
+}
+
+// selectUntrackedBranch shows a selection UI for branches not in any stack.
+// Includes both unregistered worktrees and bare local branches (no worktree),
+// so users can attach a branch they made with `git checkout -b` without first
+// having to materialize a worktree manually.
+// excludeBranches are filtered out of the list (e.g. the base branch itself).
+func selectUntrackedBranch(g *git.Git, mgr *stack.Manager, excludeBranches ...string) (string, error) {
+	candidates := CollectUntrackedBranches(g, mgr, excludeBranches...)
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no untracked branches found. All branches are already in stacks")
+	}
+
+	options := make([]string, len(candidates))
+	for i, c := range candidates {
+		if c.WorktreePath != "" {
+			options[i] = fmt.Sprintf("%s (%s)", c.Name, c.WorktreePath)
+		} else {
+			options[i] = fmt.Sprintf("%s [no worktree]", c.Name)
+		}
 	}
 
 	selected, err := ui.SelectOption(options, "Select branch to add to stack")
@@ -515,7 +557,7 @@ func selectUntrackedBranch(mgr *stack.Manager, excludeBranches ...string) (strin
 		return "", err
 	}
 
-	return branchNames[selected], nil
+	return candidates[selected].Name, nil
 }
 
 // selectRemotePR shows a selection UI for choosing a remote PR as the base of a new stack.

--- a/cmd/ezs/commands/stack.go
+++ b/cmd/ezs/commands/stack.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -494,18 +495,40 @@ type UntrackedBranch struct {
 // stack and aren't the base branch — both unregistered worktrees and bare
 // local branches. Order: worktrees first (in git's listing order), then bare
 // branches (in git's listing order).
-func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ...string) []UntrackedBranch {
+//
+// On partial source failure, returns whatever could be collected plus a
+// non-nil error joining the failures so callers can decide whether to log
+// a warning or proceed silently. Most callers can pass `_` for the error.
+func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ...string) ([]UntrackedBranch, error) {
 	exclude := make(map[string]bool, len(excludeBranches))
 	for _, b := range excludeBranches {
 		exclude[b] = true
 	}
 
+	// Stack roots (e.g. a "develop" branch that anchors a stack) are real
+	// local branches that aren't in any stack's Branches list, so without
+	// this filter they'd leak into the orphan list with a misleading
+	// "ezs attach <root>" hint.
+	stackRoots := make(map[string]bool)
+	for _, s := range mgr.ListStacks() {
+		if s.Root != "" {
+			stackRoots[s.Root] = true
+		}
+	}
+
 	seen := make(map[string]bool)
 	var out []UntrackedBranch
+	var errs []error
 
-	if unregistered, err := mgr.GetUnregisteredWorktrees(); err == nil {
+	unregistered, err := mgr.GetUnregisteredWorktrees()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list unregistered worktrees: %w", err))
+	} else {
 		for _, wt := range unregistered {
 			if exclude[wt.Branch] || seen[wt.Branch] {
+				continue
+			}
+			if stackRoots[wt.Branch] {
 				continue
 			}
 			seen[wt.Branch] = true
@@ -513,12 +536,18 @@ func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ..
 		}
 	}
 
-	if localBranches, err := g.ListLocalBranches(); err == nil {
+	localBranches, err := g.ListLocalBranches()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list local branches: %w", err))
+	} else {
 		for _, lb := range localBranches {
 			if exclude[lb] || seen[lb] {
 				continue
 			}
 			if mgr.IsMainBranch(lb) {
+				continue
+			}
+			if stackRoots[lb] {
 				continue
 			}
 			if mgr.GetBranch(lb) != nil {
@@ -529,7 +558,7 @@ func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ..
 		}
 	}
 
-	return out
+	return out, errors.Join(errs...)
 }
 
 // selectUntrackedBranch shows a selection UI for branches not in any stack.
@@ -538,7 +567,10 @@ func CollectUntrackedBranches(g *git.Git, mgr *stack.Manager, excludeBranches ..
 // having to materialize a worktree manually.
 // excludeBranches are filtered out of the list (e.g. the base branch itself).
 func selectUntrackedBranch(g *git.Git, mgr *stack.Manager, excludeBranches ...string) (string, error) {
-	candidates := CollectUntrackedBranches(g, mgr, excludeBranches...)
+	candidates, err := CollectUntrackedBranches(g, mgr, excludeBranches...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%swarning: %v%s\n", ui.Yellow, err, ui.Reset)
+	}
 	if len(candidates) == 0 {
 		return "", fmt.Errorf("no untracked branches found. All branches are already in stacks")
 	}

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -13,7 +13,7 @@ import (
 // matching on the long names, and listing both forms doubles the menu without
 // helping anyone.
 var topLevelCommands = []string{
-	"agent", "amend", "commit", "config", "delete", "diff", "doctor", "down",
+	"agent", "amend", "attach", "commit", "config", "delete", "diff", "doctor", "down",
 	"goto", "list", "log", "menu", "new", "pr", "push",
 	"reparent", "stack", "status", "sync", "unstack", "up", "upgrade",
 }
@@ -56,6 +56,7 @@ var configKeys = []string{
 var commandFlags = map[string][]string{
 	"agent":    {"--cmd", "--stack", "-s", "--branch", "-b", "--dry-run", "--save-prompt", "--no-push", "--preset", "--no-mcp", "--help", "-h"},
 	"amend":    {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
+	"attach":   {"--parent", "-p", "--worktree", "-w", "--no-worktree", "-W", "--cd", "-c", "--no-cd", "-C", "--init-submodules", "-s", "--no-init-submodules", "-S", "--yes", "-y", "--help", "-h"},
 	"commit":   {"--merge", "--rebase", "--push", "--push-children", "--no-push", "--help", "-h"},
 	"config":   {"--help", "-h"},
 	"delete":   {"--force", "-f", "--stack", "-s", "--cascade", "--help", "-h"},

--- a/cmd/ezs/main.go
+++ b/cmd/ezs/main.go
@@ -29,6 +29,7 @@ var knownCommands = map[string]bool{
 	"reparent": true, "rp": true,
 	"stack":   true,
 	"unstack": true,
+	"attach":  true,
 	"commit":  true, "ci": true,
 	"amend":   true,
 	"diff":    true,
@@ -229,6 +230,8 @@ func main() {
 		err = commands.Stack(args)
 	case "unstack":
 		err = commands.Unstack(args)
+	case "attach":
+		err = commands.Attach(args)
 	case "commit", "ci":
 		err = commands.Commit(args)
 	case "amend":
@@ -337,6 +340,7 @@ func printUsage() {
 %sCOMMANDS%s
     agent         Launch AI agent with stack context
     amend         Amend last commit and auto-sync children
+    attach        Bring an existing branch under ezs management
     commit, ci    Commit and auto-sync child branches
     config        Configure ezstack
     delete, del, rm  Delete a branch and its worktree
@@ -395,7 +399,7 @@ func printShellInit() {
 # Add this to your shell config: eval "$(ezs --shell-init)"
 ezs() {
     case "${1:-}" in
-        goto|go|new|n|delete|del|rm|sync|up|down|menu)
+        goto|go|new|n|attach|delete|del|rm|sync|up|down|menu)
             # These commands may output "cd <path>" which we need to eval
             eval "$(EZS_SHELL_WRAPPER=1 command ezs "$@")"
             ;;

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -610,6 +610,7 @@
         <li><a href="#stacking-on-a-remote-pr" class="toc-h3">Stacking on a Remote PR</a></li>
         <li><a href="#commands">Commands</a></li>
         <li><a href="#ezs-agent" class="toc-h3">ezs agent</a></li>
+        <li><a href="#ezs-attach" class="toc-h3">ezs attach</a></li>
         <li><a href="#ezs-commit--ezs-amend" class="toc-h3">ezs commit / ezs amend</a></li>
         <li><a href="#ezs-config" class="toc-h3">ezs config</a></li>
         <li><a href="#ezs-delete" class="toc-h3">ezs delete</a></li>
@@ -1221,6 +1222,36 @@ Options:
       <code>ezs config set worktree_base_dir /tmp/foo --bogus</code> from being silently
       stored as the literal path <code>/tmp/foo --bogus</code>.</p>
       </blockquote>
+      <h3 id="ezs-attach"><code>ezs attach</code></h3>
+      <p>Bring an existing local branch under ezs management. Idempotent — running it on an already-fully-attached branch is a no-op. Designed so you don't have to know whether your branch is bare, a worktree-but-untracked, or tracked-without-worktree: <code>ezs attach</code> converges to whatever &quot;fully managed&quot; looks like for the current repo.</p>
+      <pre><code><span class="c-cmd">ezs</span> <span class="c-flag">attach</span> <span class="c-str">[branch]</span> <span class="c-str">[options]</span>
+
+Options:
+    <span class="c-flag">-p,</span> <span class="c-flag">--parent</span> <span class="c-str">&lt;branch&gt;</span>     <span class="c-dim">Override detected parent (default: nearest tracked ancestor via merge-base)</span>
+    <span class="c-flag">-w,</span> <span class="c-flag">--worktree</span> <span class="c-str">&lt;path&gt;</span>     <span class="c-dim">Force a worktree at this path (overrides config)</span>
+    <span class="c-flag">-W,</span> <span class="c-flag">--no-worktree</span>         <span class="c-dim">Register without a worktree (overrides config)</span>
+    <span class="c-flag">-c,</span> <span class="c-flag">--cd</span> <span class="c-str">/</span> <span class="c-flag">-C,</span> <span class="c-flag">--no-cd</span>    <span class="c-dim">Change to the worktree after attaching (overrides cd_after_new)</span>
+    <span class="c-flag">-s/-S</span>                     <span class="c-dim">Submodule init control, same as `ezs new`</span>
+    <span class="c-flag">-y,</span> <span class="c-flag">--yes</span>                 <span class="c-dim">Skip the &#34;Proceed?&#34; confirm</span>
+</code></pre>
+      <p>The auto-detected parent is the closest tracked ancestor by commit-distance, with the configured base branch as a fallback. The chosen parent, target stack, and worktree action are shown as a one-screen plan before any changes — so you confirm intent, not blind to outcome.</p>
+      <p>With no branch argument, <code>ezs attach</code> opens an interactive picker over local branches that aren't in any stack yet. Each row shows the auto-detected parent so you're never selecting blind.</p>
+      <pre><code><span class="c-comment"># Bring a branch you made with `git checkout -b` into a stack</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">attach</span> <span class="c-str">feature-x</span>
+
+<span class="c-comment"># Override the detected parent</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">attach</span> <span class="c-str">feature-x</span> <span class="c-flag">-p</span> <span class="c-str">feature-a</span>
+
+<span class="c-comment"># Force a worktree in a no-worktree-mode repo</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">attach</span> <span class="c-str">feature-x</span> <span class="c-flag">-w</span> <span class="c-str">~/wt/feature-x</span>
+
+<span class="c-comment"># Force bare attach in a worktree-mode repo</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">attach</span> <span class="c-str">feature-x</span> <span class="c-flag">-W</span>
+
+<span class="c-comment"># Pick from orphan branches interactively</span>
+<span class="c-cmd">ezs</span> <span class="c-flag">attach</span>
+</code></pre>
+      <p>To pick up a remote branch (PR review, collaborator's branch), use <code>ezs new origin/&lt;branch&gt;</code> instead — that's the canonical &quot;remote → local managed&quot; path.</p>
       <h3 id="ezs-commit--ezs-amend"><code>ezs commit</code> / <code>ezs amend</code></h3>
       <p>Wrap <code>git commit</code> / <code>git commit --amend</code> and auto-sync child branches. Aliases: <code>ci</code></p>
       <pre><code><span class="c-cmd">ezs</span> <span class="c-flag">commit</span> <span class="c-str">[git-commit-options]</span> <span class="c-str">[--merge|--rebase]</span>

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1506,6 +1506,35 @@ func (m *Manager) MarkBranchMerged(branchName string) error {
 	return nil
 }
 
+// SetBranchWorktreePath records or clears the worktree path for an
+// already-tracked branch. Used by `ezs attach` to upgrade a tracked-without-
+// worktree branch to a tracked-with-worktree branch (or, with path="",
+// to record that a previously-known worktree was removed). Returns an error
+// if the branch is not tracked in any stack — callers should check that
+// first.
+func (m *Manager) SetBranchWorktreePath(branchName, path string) error {
+	if m.GetBranch(branchName) == nil {
+		return fmt.Errorf("branch '%s' is not tracked in any stack", branchName)
+	}
+
+	cache := m.stackConfig.Cache
+	bc := cache.GetBranchCache(branchName)
+	if bc == nil {
+		bc = &config.BranchCache{}
+	}
+	bc.WorktreePath = path
+	cache.SetBranchCache(branchName, bc)
+
+	for _, stack := range m.stackConfig.Stacks {
+		if stack.HasBranch(branchName) {
+			stack.PopulateBranchesWithCache(cache)
+			break
+		}
+	}
+
+	return m.stackConfig.Save(m.repoDir)
+}
+
 // MarkBranchRemote marks a branch as belonging to another contributor.
 // Remote branches are not rebased during sync. Optionally sets PR URL.
 // If remote is non-empty, it specifies the git remote to push to (for fork PRs).

--- a/itests/attach_orphan_test.go
+++ b/itests/attach_orphan_test.go
@@ -60,7 +60,10 @@ func TestNewBranch_ExistingBranchErrors(t *testing.T) {
 	gitBareBranch(t, env.RepoDir, "feature-x", "main")
 
 	chdirForTest(t, env.RepoDir)
-	err := commands.New([]string{"feature-x", "-p", "main"})
+	// Flags before positional so we don't depend on whether the flag parser
+	// accepts interleaving — the BranchExists check fires regardless, but
+	// argument order shouldn't be load-bearing for the test signal.
+	err := commands.New([]string{"-p", "main", "feature-x"})
 	if err == nil {
 		t.Fatalf("expected error when branch already exists; got nil")
 	}
@@ -68,8 +71,8 @@ func TestNewBranch_ExistingBranchErrors(t *testing.T) {
 	if !strings.Contains(msg, "already exists") {
 		t.Errorf("error should mention branch already exists; got: %s", msg)
 	}
-	if !strings.Contains(msg, "ezs stack") {
-		t.Errorf("error should signpost `ezs stack`; got: %s", msg)
+	if !strings.Contains(msg, "ezs attach") {
+		t.Errorf("error should signpost `ezs attach`; got: %s", msg)
 	}
 }
 
@@ -94,7 +97,10 @@ func TestCollectUntrackedBranches_IncludesBareBranches(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	got := commands.CollectUntrackedBranches(g, mgr)
+	got, err := commands.CollectUntrackedBranches(g, mgr)
+	if err != nil {
+		t.Fatalf("CollectUntrackedBranches: %v", err)
+	}
 
 	var sawBare, sawTracked bool
 	for _, c := range got {
@@ -147,10 +153,42 @@ func TestStatus_OrphanSection(t *testing.T) {
 	if !strings.Contains(out, "manual-branch") {
 		t.Errorf("orphan branch missing from status output; got:\n%s", out)
 	}
-	if !strings.Contains(out, "ezs stack") {
+	if !strings.Contains(out, "ezs attach") {
 		t.Errorf("adoption hint missing from status output; got:\n%s", out)
 	}
-	if strings.Contains(out, "tracked-feature\n") && strings.Contains(out, "Branches not in any stack:\n  tracked-feature") {
-		t.Errorf("tracked branch leaked into orphan list; got:\n%s", out)
+
+	// Scope the leak check to the orphan section itself (between the header
+	// and the "Adopt one with:" footer). Otherwise we'd false-negative when
+	// the tracked branch shows up earlier in unrelated stack output, or
+	// false-positive only when it happens to land first under the header.
+	orphanSection := extractOrphanSection(out)
+	if orphanSection == "" {
+		t.Fatalf("could not locate orphan section in output:\n%s", out)
 	}
+	if !strings.Contains(orphanSection, "manual-branch") {
+		t.Errorf("manual-branch missing from orphan section:\n%s", orphanSection)
+	}
+	if strings.Contains(orphanSection, "tracked-feature") {
+		t.Errorf("tracked branch leaked into orphan section:\n%s", orphanSection)
+	}
+}
+
+// extractOrphanSection returns the body of the "Branches not in any stack"
+// section — everything between that header and the "Adopt one with:" footer.
+// Returns "" if the section isn't present. Strips ANSI color codes so
+// substring matches are robust to ui.Bold/ui.Cyan/etc. Reuses the stripANSI
+// helper from completions_test.go.
+func extractOrphanSection(out string) string {
+	plain := stripANSI(out)
+	const header = "Branches not in any stack:"
+	const footer = "Adopt one with:"
+	hi := strings.Index(plain, header)
+	if hi < 0 {
+		return ""
+	}
+	body := plain[hi+len(header):]
+	if fi := strings.Index(body, footer); fi >= 0 {
+		body = body[:fi]
+	}
+	return body
 }

--- a/itests/attach_orphan_test.go
+++ b/itests/attach_orphan_test.go
@@ -1,0 +1,156 @@
+package itests
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/cmd/ezs/commands"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/git"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+)
+
+// captureStderr replaces os.Stderr with a pipe for the duration of fn and
+// returns everything written to it. Used by tests that assert against
+// human-facing output (orphan list, error messages, etc.).
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// gitBareBranch creates a local branch via plain git (no ezs metadata, no
+// worktree). Mirrors what a user does with `git checkout -b` outside of ezs.
+func gitBareBranch(t *testing.T, repoDir, name, base string) {
+	t.Helper()
+	if err := exec.Command("git", "-C", repoDir, "branch", name, base).Run(); err != nil {
+		t.Fatalf("git branch %s %s: %v", name, base, err)
+	}
+}
+
+// TestNewBranch_ExistingBranchErrors locks down the discoverability fix:
+// running `ezs new <name>` on an already-existing local branch must error
+// out instead of accidentally adopting the branch (worktree mode) or
+// failing opaquely (no-worktree mode).
+func TestNewBranch_ExistingBranchErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	err := commands.New([]string{"feature-x", "-p", "main"})
+	if err == nil {
+		t.Fatalf("expected error when branch already exists; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "already exists") {
+		t.Errorf("error should mention branch already exists; got: %s", msg)
+	}
+	if !strings.Contains(msg, "ezs stack") {
+		t.Errorf("error should signpost `ezs stack`; got: %s", msg)
+	}
+}
+
+// TestCollectUntrackedBranches_IncludesBareBranches verifies that the picker
+// surface (CollectUntrackedBranches) sees branches with no worktree, not just
+// unregistered worktrees.
+func TestCollectUntrackedBranches_IncludesBareBranches(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Tracked branch (worktree) — should NOT appear.
+	CreateBranch(t, env, "tracked-feature", "main")
+	// Bare branch — should appear.
+	gitBareBranch(t, env.RepoDir, "bare-feature", "main")
+
+	g := git.New(env.RepoDir)
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	got := commands.CollectUntrackedBranches(g, mgr)
+
+	var sawBare, sawTracked bool
+	for _, c := range got {
+		if c.Name == "bare-feature" {
+			sawBare = true
+			if c.WorktreePath != "" {
+				t.Errorf("bare-feature WorktreePath = %q, want empty", c.WorktreePath)
+			}
+		}
+		if c.Name == "tracked-feature" {
+			sawTracked = true
+		}
+	}
+	if !sawBare {
+		t.Errorf("bare-feature missing from CollectUntrackedBranches result: %+v", got)
+	}
+	if sawTracked {
+		t.Errorf("tracked-feature should be filtered out (it's in a stack); got: %+v", got)
+	}
+}
+
+// TestStatus_OrphanSection verifies that `ezs status -a` surfaces local
+// branches that exist in git but aren't part of any stack, with the
+// adoption hint pointing at `ezs stack`.
+func TestStatus_OrphanSection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// One real stack so Status doesn't bail on "no stacks found".
+	CreateBranch(t, env, "tracked-feature", "main")
+	// Orphan that should surface.
+	gitBareBranch(t, env.RepoDir, "manual-branch", "main")
+
+	chdirForTest(t, env.RepoDir)
+
+	var statusErr error
+	out := captureStderr(t, func() {
+		statusErr = commands.Status([]string{"-a"})
+	})
+	if statusErr != nil {
+		t.Fatalf("Status(-a): %v", statusErr)
+	}
+
+	if !strings.Contains(out, "Branches not in any stack") {
+		t.Errorf("orphan header missing from status output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "manual-branch") {
+		t.Errorf("orphan branch missing from status output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "ezs stack") {
+		t.Errorf("adoption hint missing from status output; got:\n%s", out)
+	}
+	if strings.Contains(out, "tracked-feature\n") && strings.Contains(out, "Branches not in any stack:\n  tracked-feature") {
+		t.Errorf("tracked branch leaked into orphan list; got:\n%s", out)
+	}
+}

--- a/itests/attach_orphan_test.go
+++ b/itests/attach_orphan_test.go
@@ -124,7 +124,7 @@ func TestCollectUntrackedBranches_IncludesBareBranches(t *testing.T) {
 
 // TestStatus_OrphanSection verifies that `ezs status -a` surfaces local
 // branches that exist in git but aren't part of any stack, with the
-// adoption hint pointing at `ezs stack`.
+// adoption hint pointing at `ezs attach`.
 func TestStatus_OrphanSection(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("worktree semantics")

--- a/itests/attach_test.go
+++ b/itests/attach_test.go
@@ -54,15 +54,6 @@ func setRepoUseWorktrees(t *testing.T, env *TestEnv, useWorktrees bool) {
 	}
 }
 
-// commitOnBranch runs git commands to create a commit on a bare branch
-// without checking it out — used to simulate a user who created a branch via
-// `git checkout -b`, made commits, then went back to main without ezs ever
-// seeing the branch.
-func commitOnBranchInWorktree(t *testing.T, worktreeDir, filename, content string) {
-	t.Helper()
-	GitCommit(t, worktreeDir, filename, content, "commit on "+filepath.Base(worktreeDir))
-}
-
 // TestAttach_BareBranchInWorktreeMode covers the headline case: user has a
 // bare local branch (no ezs metadata, no worktree), repo is in worktree
 // mode. `ezs attach` should infer the parent, create the worktree, and
@@ -394,6 +385,76 @@ func TestAttach_TrackedNoWorktreeMaterializesOnSecondRun(t *testing.T) {
 	// Stack identity is preserved — attach only filled in the worktree path.
 	if got := mgr.GetStackForBranch("feature-x").Hash; got != stackHashBefore {
 		t.Errorf("stack hash changed: before=%q after=%q", stackHashBefore, got)
+	}
+}
+
+// TestAttach_AlreadyAttachedWithMismatchedParentErrors verifies that running
+// `ezs attach -p other` on a branch that's already attached under a different
+// parent fails with a signpost to `ezs reparent`. Without this, the override
+// would be silently ignored and stale metadata would creep in.
+func TestAttach_AlreadyAttachedWithMismatchedParentErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	// Set up: feature-a tracked under main, feature-x bare branch, attach it
+	// once so it's tracked under main.
+	CreateBranchWithCommit(t, env, "feature-a", "main")
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("first Attach: %v", err)
+	}
+
+	// Now attempt to attach again with a *different* parent.
+	err := commands.Attach([]string{"feature-x", "-p", "feature-a"})
+	if err == nil {
+		t.Fatalf("expected error when -p disagrees with current parent; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "already attached") {
+		t.Errorf("error should mention already attached; got: %s", msg)
+	}
+	if !strings.Contains(msg, "ezs reparent") {
+		t.Errorf("error should signpost `ezs reparent`; got: %s", msg)
+	}
+
+	// Re-running with the *same* parent should still be a no-op.
+	if err := commands.Attach([]string{"feature-x", "-p", "main"}); err != nil {
+		t.Errorf("attach with matching -p should be a no-op; got: %v", err)
+	}
+}
+
+// TestAttach_NonexistentParentErrors covers the parent-validation gap: when
+// the user passes `-p typo`, attach must reject up front rather than write
+// the typo into stack metadata. CreateWorktree silently ignores the parent
+// arg for already-existing branches, so without an explicit check the bad
+// parent would land in config and trip every later sync that walks parent
+// refs.
+func TestAttach_NonexistentParentErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	err := commands.Attach([]string{"feature-x", "-p", "definitely-not-a-branch"})
+	if err == nil {
+		t.Fatalf("expected error for nonexistent parent; got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should mention 'does not exist'; got: %s", err.Error())
+	}
+	mgr, _ := stack.NewManager(env.RepoDir)
+	if mgr.GetBranch("feature-x") != nil {
+		t.Errorf("feature-x should NOT have been registered with a bogus parent")
 	}
 }
 

--- a/itests/attach_test.go
+++ b/itests/attach_test.go
@@ -1,0 +1,424 @@
+package itests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/cmd/ezs/commands"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/git"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/ui"
+)
+
+// runGit runs `git -C <dir> <args...>` and returns combined output. Used by
+// tests that need to set up branch/worktree state directly via git, bypassing
+// the stack manager — i.e., simulating a user who used plain git.
+func runGit(dir string, args ...string) (string, error) {
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	return string(out), err
+}
+
+// withYesMode sets ui.YesMode and returns a restore func. Mirrors the pattern
+// in delete_cascade_test.go — every Attach test needs this because the
+// command always runs a "Proceed?" confirm.
+func withYesMode(t *testing.T) func() {
+	t.Helper()
+	prev := ui.YesMode
+	ui.YesMode = true
+	return func() { ui.YesMode = prev }
+}
+
+// setRepoUseWorktrees flips the per-repo use_worktrees flag so a single test
+// can exercise both modes without booting a second repo.
+func setRepoUseWorktrees(t *testing.T, env *TestEnv, useWorktrees bool) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	rc := cfg.GetRepoConfig(env.RepoDir)
+	if rc == nil {
+		rc = &config.RepoConfig{WorktreeBaseDir: env.WorktreeDir}
+	}
+	v := useWorktrees
+	rc.UseWorktrees = &v
+	cfg.SetRepoConfig(env.RepoDir, rc)
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("cfg.Save: %v", err)
+	}
+}
+
+// commitOnBranch runs git commands to create a commit on a bare branch
+// without checking it out — used to simulate a user who created a branch via
+// `git checkout -b`, made commits, then went back to main without ezs ever
+// seeing the branch.
+func commitOnBranchInWorktree(t *testing.T, worktreeDir, filename, content string) {
+	t.Helper()
+	GitCommit(t, worktreeDir, filename, content, "commit on "+filepath.Base(worktreeDir))
+}
+
+// TestAttach_BareBranchInWorktreeMode covers the headline case: user has a
+// bare local branch (no ezs metadata, no worktree), repo is in worktree
+// mode. `ezs attach` should infer the parent, create the worktree, and
+// register the branch in the right stack.
+func TestAttach_BareBranchInWorktreeMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x not registered in any stack after attach")
+	}
+	if branch.Parent != "main" {
+		t.Errorf("parent = %q, want %q (auto-detected from merge-base)", branch.Parent, "main")
+	}
+	expected := filepath.Join(env.WorktreeDir, "feature-x")
+	if branch.WorktreePath != expected {
+		t.Errorf("worktree path = %q, want %q", branch.WorktreePath, expected)
+	}
+	if _, err := os.Stat(expected); err != nil {
+		t.Errorf("worktree was not materialized at %s: %v", expected, err)
+	}
+}
+
+// TestAttach_Idempotent verifies the design's central promise: running
+// `ezs attach` twice on the same branch is safe and a no-op the second time.
+func TestAttach_Idempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("first Attach: %v", err)
+	}
+	// Snapshot stack state.
+	mgrA, _ := stack.NewManager(env.RepoDir)
+	stacksBefore := len(mgrA.ListStacks())
+	branchBefore := mgrA.GetBranch("feature-x")
+
+	out := captureStderr(t, func() {
+		if err := commands.Attach([]string{"feature-x"}); err != nil {
+			t.Fatalf("second Attach: %v", err)
+		}
+	})
+	if !strings.Contains(out, "already attached") {
+		t.Errorf("second attach should print 'already attached' info; got:\n%s", out)
+	}
+
+	mgrB, _ := stack.NewManager(env.RepoDir)
+	if got := len(mgrB.ListStacks()); got != stacksBefore {
+		t.Errorf("stack count changed: before=%d, after=%d", stacksBefore, got)
+	}
+	branchAfter := mgrB.GetBranch("feature-x")
+	if branchAfter == nil {
+		t.Fatalf("branch missing after second attach")
+	}
+	if branchBefore.Parent != branchAfter.Parent || branchBefore.WorktreePath != branchAfter.WorktreePath {
+		t.Errorf("attach mutated state on no-op: before=%+v after=%+v", branchBefore, branchAfter)
+	}
+}
+
+// TestAttach_ParentDetectionPrefersClosestAncestor verifies the design's
+// "closest tracked ancestor" rule: a branch forked off feature-a (which is
+// itself a child of main) must attach under feature-a, not main.
+func TestAttach_ParentDetectionPrefersClosestAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	// Set up a real stack: main → feature-a (with one commit).
+	CreateBranchWithCommit(t, env, "feature-a", "main")
+
+	// Create feature-x off feature-a using plain git, so ezs doesn't know about it.
+	featureAPath := filepath.Join(env.WorktreeDir, "feature-a")
+	gitBareBranch(t, featureAPath, "feature-x", "feature-a")
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x not registered")
+	}
+	if branch.Parent != "feature-a" {
+		t.Errorf("parent = %q, want %q (closest tracked ancestor)", branch.Parent, "feature-a")
+	}
+	// Should land in the same stack as feature-a, not a new one.
+	stackOfFeatureX := mgr.GetStackForBranch("feature-x")
+	stackOfFeatureA := mgr.GetStackForBranch("feature-a")
+	if stackOfFeatureX == nil || stackOfFeatureA == nil {
+		t.Fatalf("missing stack: x=%v a=%v", stackOfFeatureX, stackOfFeatureA)
+	}
+	if stackOfFeatureX.Hash != stackOfFeatureA.Hash {
+		t.Errorf("feature-x landed in stack %q, expected the same stack as feature-a (%q)",
+			stackOfFeatureX.Hash, stackOfFeatureA.Hash)
+	}
+}
+
+// TestAttach_ParentOverride: -p flag bypasses auto-detection.
+func TestAttach_ParentOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	CreateBranchWithCommit(t, env, "feature-a", "main")
+	gitBareBranch(t, env.RepoDir, "feature-x", "main") // forked from main
+
+	chdirForTest(t, env.RepoDir)
+	// Force feature-x under feature-a even though merge-base would say main.
+	if err := commands.Attach([]string{"feature-x", "-p", "feature-a"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil || branch.Parent != "feature-a" {
+		t.Errorf("parent override didn't take: branch=%+v", branch)
+	}
+}
+
+// TestAttach_ExistingWorktreeIsRegisteredNotRecreated covers the "user did
+// `git worktree add` manually, ezs doesn't know" case. Attach should pick
+// up the existing worktree path rather than try to create a second one.
+func TestAttach_ExistingWorktreeIsRegisteredNotRecreated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	manualPath := filepath.Join(env.TmpDir, "manual-feature-x")
+	g := git.New(env.RepoDir)
+	if _, err := runGit(env.RepoDir, "branch", "feature-x", "main"); err != nil {
+		t.Fatalf("git branch: %v", err)
+	}
+	if _, err := runGit(env.RepoDir, "worktree", "add", manualPath, "feature-x"); err != nil {
+		t.Fatalf("git worktree add: %v", err)
+	}
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x not registered")
+	}
+	if branch.WorktreePath != manualPath {
+		t.Errorf("worktree path = %q, want existing path %q", branch.WorktreePath, manualPath)
+	}
+
+	// Sanity: there is exactly one worktree for feature-x in git's view —
+	// attach must not have spun up a duplicate at the default location.
+	wts, err := g.ListWorktrees()
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	count := 0
+	for _, w := range wts {
+		if w.Branch == "feature-x" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one worktree for feature-x; got %d (%+v)", count, wts)
+	}
+}
+
+// TestAttach_NoWorktreeFlagRespected: -W forces bare attach in worktree-mode repo.
+func TestAttach_NoWorktreeFlagRespected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x", "-W"}); err != nil {
+		t.Fatalf("Attach -W: %v", err)
+	}
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x not registered")
+	}
+	if branch.WorktreePath != "" {
+		t.Errorf("expected bare attach, but got worktree at %q", branch.WorktreePath)
+	}
+	if _, err := os.Stat(filepath.Join(env.WorktreeDir, "feature-x")); err == nil {
+		t.Errorf("worktree dir was created despite -W")
+	}
+}
+
+// TestAttach_NonexistentBranchErrors: clear error and signpost to ezs new
+// when the branch doesn't actually exist.
+func TestAttach_NonexistentBranchErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	chdirForTest(t, env.RepoDir)
+	err := commands.Attach([]string{"feature-x"})
+	if err == nil {
+		t.Fatalf("expected error for missing branch")
+	}
+	if !strings.Contains(err.Error(), "does not exist") || !strings.Contains(err.Error(), "ezs new") {
+		t.Errorf("error should signpost `ezs new`; got: %s", err.Error())
+	}
+}
+
+// TestAttach_BareBranchInBranchMode covers the no-worktree-config path:
+// repo configured for branch mode should attach as bare (no worktree
+// materialized) and remain a no-op on a second run.
+func TestAttach_BareBranchInBranchMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	setRepoUseWorktrees(t, env, false)
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x not registered")
+	}
+	if branch.WorktreePath != "" {
+		t.Errorf("expected bare attach in branch-mode repo, got worktree at %q", branch.WorktreePath)
+	}
+
+	// Second run is a no-op.
+	out := captureStderr(t, func() {
+		if err := commands.Attach([]string{"feature-x"}); err != nil {
+			t.Fatalf("second Attach: %v", err)
+		}
+	})
+	if !strings.Contains(out, "already attached") {
+		t.Errorf("second attach in branch mode should be a no-op; got:\n%s", out)
+	}
+}
+
+// TestAttach_TrackedNoWorktreeMaterializesOnSecondRun: simulates the
+// "switch the repo from no-worktree mode to worktree mode, then run
+// `ezs attach` to upgrade existing branches" flow. Tracked branch with no
+// worktree + use_worktrees=true => attach materializes the worktree and
+// updates the cache, leaving the stack tree unchanged.
+func TestAttach_TrackedNoWorktreeMaterializesOnSecondRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	// Create the branch in branch-mode (no worktree).
+	setRepoUseWorktrees(t, env, false)
+	mgr0, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := mgr0.CreateBranchNoWorktree("feature-x", "main", ""); err != nil {
+		t.Fatalf("CreateBranchNoWorktree: %v", err)
+	}
+	stackHashBefore := mgr0.GetStackForBranch("feature-x").Hash
+
+	// Flip to worktree mode and attach to materialize.
+	setRepoUseWorktrees(t, env, true)
+
+	chdirForTest(t, env.RepoDir)
+	if err := commands.Attach([]string{"feature-x"}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	mgr, _ := stack.NewManager(env.RepoDir)
+	branch := mgr.GetBranch("feature-x")
+	if branch == nil {
+		t.Fatalf("feature-x missing after attach")
+	}
+	expected := filepath.Join(env.WorktreeDir, "feature-x")
+	if branch.WorktreePath != expected {
+		t.Errorf("worktree path = %q, want %q", branch.WorktreePath, expected)
+	}
+	if _, err := os.Stat(expected); err != nil {
+		t.Errorf("worktree was not materialized at %s: %v", expected, err)
+	}
+	// Stack identity is preserved — attach only filled in the worktree path.
+	if got := mgr.GetStackForBranch("feature-x").Hash; got != stackHashBefore {
+		t.Errorf("stack hash changed: before=%q after=%q", stackHashBefore, got)
+	}
+}
+
+// TestAttach_PlanIsShownBeforeChanges: the plan preview is part of the UX
+// promise — the user must be able to see what's about to happen. Captured
+// stderr should include the Plan/Branch/Parent/Stack/Worktree banner.
+func TestAttach_PlanIsShownBeforeChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	defer withYesMode(t)()
+
+	gitBareBranch(t, env.RepoDir, "feature-x", "main")
+	chdirForTest(t, env.RepoDir)
+
+	out := captureStderr(t, func() {
+		if err := commands.Attach([]string{"feature-x"}); err != nil {
+			t.Fatalf("Attach: %v", err)
+		}
+	})
+	for _, want := range []string{"Plan:", "Branch:", "Parent:", "Stack:", "Worktree:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q; got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Surfaces orphan branches and adds a single verb — `ezs attach` — to bring them under ezs management. Replaces the older "ezs new on existing branch" path (which silently adopted in worktree mode and failed opaquely in no-worktree mode) and the "ezs stack -b <name> -p <parent>" path (which required the user to figure out the parent themselves).

### `ezs attach`

One verb that converges any local branch (bare, worktree-but-untracked, or tracked-without-worktree) to whatever "fully managed" looks like for the repo.

- Auto-detects parent as the closest tracked ancestor by commit-distance, falling back to the configured base branch.
- Shows a plan banner (`Branch:`, `Parent:`, `Stack:`, `Worktree:`) before any mutation; `-y` skips the confirm.
- Idempotent — running on an already-fully-attached branch reports "already attached" and exits without mutating state.
- Materializes a worktree for tracked-without-worktree branches when the repo is in worktree mode (covers the "branch-mode → worktree-mode" upgrade flow).
- Picker (`ezs attach` with no args) shows each candidate's auto-detected parent so selection is informed.

### Discoverability gaps closed

- **`ezs new <name>` on an existing branch hard-errors** with a signpost to `ezs attach <name>`. Replaces today's inconsistent behavior (silent adopt vs opaque failure).
- **`ezs stack` interactive picker now lists bare local branches**, not just unregistered worktrees. Backed by exported `CollectUntrackedBranches` so the surface is testable without driving fzf.
- **`ezs status -a` shows a "Branches not in any stack" section** with each orphan's worktree state and a one-line `ezs attach` hint.

### Bug fix bundled in

- `CollectUntrackedBranches` was leaking custom-base stack roots (e.g. a `develop` branch anchoring a stack) into the orphan list with a misleading "attach develop" hint. Now filtered.

## Test plan

- [x] `make ci` passes (fmt-check + vet + race tests, full suite)
- [x] New itests in `itests/attach_test.go`:
  - `TestAttach_BareBranchInWorktreeMode` — headline path: bare branch, worktree mode, parent auto-detected, worktree materialized
  - `TestAttach_Idempotent` — second run is a no-op on stack count and branch state
  - `TestAttach_ParentDetectionPrefersClosestAncestor` — closest tracked ancestor wins over the base branch
  - `TestAttach_ParentOverride` — `-p` bypasses auto-detection
  - `TestAttach_ExistingWorktreeIsRegisteredNotRecreated` — manual `git worktree add` is registered, not duplicated
  - `TestAttach_NoWorktreeFlagRespected` — `-W` forces bare attach
  - `TestAttach_NonexistentBranchErrors` — clear error with `ezs new` signpost
  - `TestAttach_BareBranchInBranchMode` — branch-mode repo: bare attach + idempotent
  - `TestAttach_TrackedNoWorktreeMaterializesOnSecondRun` — branch-mode → worktree-mode upgrade path
  - `TestAttach_PlanIsShownBeforeChanges` — plan banner is part of the UX promise
- [x] Existing itests in `itests/attach_orphan_test.go`:
  - `TestNewBranch_ExistingBranchErrors` — pre-existing branch errors with `ezs attach` hint
  - `TestCollectUntrackedBranches_IncludesBareBranches` — bare branches surface in picker; tracked branches don't leak
  - `TestStatus_OrphanSection` — `ezs status -a` prints orphan section with adoption hint, scoped to the orphan section so tracked branches elsewhere don't trip the leak check

🤖 Generated with [Claude Code](https://claude.com/claude-code)