### PR TITLE
fix: audit-driven bug + drift fixes (CLI/MCP/VS Code/Tauri/Nvim/docs)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -548,7 +548,7 @@ When the configured agent CLI is `claude`, `ezs agent` automatically:
    falling back to `@latest` for untagged dev builds.
 2. **Registers `ezs-mcp` with Claude Code at user scope** (equivalent to
    running `claude mcp add ezstack --scope user -- ezs-mcp` yourself), so
-   the full 21-tool ezstack surface is available to the agent from the
+   the full 25-tool ezstack surface is available to the agent from the
    first message.
 3. **Swaps the shipped prompt for a short MCP stub** that tells the agent
    to prefer MCP tools over shelling out to `ezs`. The large

--- a/cmd/ezs-mcp/helpers_test.go
+++ b/cmd/ezs-mcp/helpers_test.go
@@ -163,6 +163,91 @@ func TestCaptureCommand_PropagatesError(t *testing.T) {
 	}
 }
 
+// TestCaptureCommand_RestoresGlobalsOnPanic is the regression test for the
+// MCP-bricked-by-panic bug: prior to wrapping restoration in defer, a
+// panic inside fn() left os.Stdout/os.Stderr pinned to the (now-closed)
+// captureCommand pipes. Subsequent tool calls then wrote into EBADF and
+// the MCP server couldn't recover. We assert (a) the panic propagates,
+// (b) stdout/stderr are restored, (c) a follow-up captureCommand still
+// works end-to-end (the harshest signal that pipe lifecycle is clean).
+func TestCaptureCommand_RestoresGlobalsOnPanic(t *testing.T) {
+	origOut, origErr := os.Stdout, os.Stderr
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic to propagate, got none")
+			}
+			if got, ok := r.(string); !ok || got != "boom from fn" {
+				t.Errorf("recovered %v, want %q", r, "boom from fn")
+			}
+		}()
+		_, _, _ = captureCommand(func([]string) error {
+			fmt.Fprint(os.Stdout, "partial output before panic")
+			panic("boom from fn")
+		}, nil)
+	}()
+
+	// Stdout/stderr must be back to the test process's originals so any
+	// further test logging (or subsequent captureCommand calls) goes to
+	// the right place.
+	if os.Stdout != origOut {
+		t.Error("os.Stdout was not restored after fn panicked")
+	}
+	if os.Stderr != origErr {
+		t.Error("os.Stderr was not restored after fn panicked")
+	}
+
+	// Round-trip a normal call. If the previous panic leaked a goroutine
+	// or left a half-closed pipe behind, this either deadlocks or returns
+	// stale output. Either way: red.
+	stdout, stderr, err := captureCommand(func([]string) error {
+		fmt.Fprint(os.Stdout, "normal-out")
+		fmt.Fprint(os.Stderr, "normal-err")
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("captureCommand after recovered panic: %v", err)
+	}
+	if stdout != "normal-out" {
+		t.Errorf("stdout = %q, want %q (panicked call may have leaked into the next pipe)", stdout, "normal-out")
+	}
+	if stderr != "normal-err" {
+		t.Errorf("stderr = %q, want %q", stderr, "normal-err")
+	}
+}
+
+// TestCaptureCommand_RestoresGlobalsOnRuntimePanic is the same contract as
+// the explicit panic test above but for an *implicit* runtime panic
+// (nil-pointer deref). This catches the case where someone "fixes" the
+// panic-restoration by wrapping fn() in a recover() — that would prevent
+// runtime panics from propagating, which would mask real bugs.
+func TestCaptureCommand_RestoresGlobalsOnRuntimePanic(t *testing.T) {
+	origOut, origErr := os.Stdout, os.Stderr
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected runtime panic to propagate")
+			}
+		}()
+		_, _, _ = captureCommand(func([]string) error {
+			var p *int
+			_ = *p // boom
+			return nil
+		}, nil)
+	}()
+
+	if os.Stdout != origOut || os.Stderr != origErr {
+		t.Error("os.Stdout/Stderr not restored after runtime panic")
+	}
+
+	if _, _, err := captureCommand(func([]string) error { return nil }, nil); err != nil {
+		t.Fatalf("follow-up captureCommand failed: %v", err)
+	}
+}
+
 // TestCaptureCommand_LargeOutput is the regression test for the pipe-buffer
 // deadlock fix: without concurrent drainers, a command writing more than the
 // ~64KB pipe buffer would block forever on the write side. 256KB is well

--- a/cmd/ezs-mcp/helpers_test.go
+++ b/cmd/ezs-mcp/helpers_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -344,3 +347,48 @@ func TestToolMu_SerializesHandlers(t *testing.T) {
 		t.Errorf("toolMu did not serialize: peak concurrency = %d, want 1", peak)
 	}
 }
+
+// TestEzsMcpVersionOutputFormat pins the exact format of `ezs-mcp --version`
+// stdout. The VS Code extension's activation gate parses it with a regex
+// anchored on the literal "version " keyword
+// (vscode-extension/src/ezsCli.ts::parseVersionSemver). Drift in this format
+// — say, swapping order to "version ezstack-mcp 4.7.6" or printing only
+// "4.7.6\n" without the keyword — silently breaks the extension's min-CLI
+// check, which then never warns even on incompatible CLIs.
+//
+// We build the binary once via `go build` and exec it. This is closer to a
+// real user invocation than calling main() directly: it catches changes to
+// the flag parser, the cmd/ezs-mcp init order, or any wrapper that might be
+// added around the print site in the future.
+func TestEzsMcpVersionOutputFormat(t *testing.T) {
+	// Build into a temp dir; t.TempDir is cleaned up by the test framework.
+	bin := filepath.Join(t.TempDir(), "ezs-mcp")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v: %s", err, out)
+	}
+
+	out, err := exec.Command(bin, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ezs-mcp --version: %v: %s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+
+	// The exact format the extension matches against. We assert two parts:
+	//   1. Starts with "ezstack-mcp version " — anchors the regex.
+	//   2. Followed by a semver triple (the version package's actual value).
+	// We don't assert the literal version because that drifts every release.
+	const wantPrefix = "ezstack-mcp version "
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("ezs-mcp --version output = %q, expected to start with %q. The VS Code extension's parseVersionSemver regex is anchored on the literal 'version ' keyword and will silently fail to match if the prefix changes.", got, wantPrefix)
+	}
+	tail := strings.TrimPrefix(got, wantPrefix)
+	if !semverTripleRe.MatchString(tail) {
+		t.Errorf("ezs-mcp --version trailing = %q, expected a semver triple (X.Y.Z[-suffix][+meta]). Drift here would break the extension's min-CLI gate.", tail)
+	}
+}
+
+// semverTripleRe is the same anchored shape parseVersionSemver uses
+// (lenient on prerelease/build-metadata suffixes).
+var semverTripleRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+([-+].*)?$`)

--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -36,7 +36,12 @@ func main() {
 		os.Exit(2)
 	}
 	if *showVersion {
-		fmt.Println(version.Version)
+		// Match the ezs CLI's "ezstack version X.Y.Z" output format so the
+		// VS Code extension's regex (anchored on the literal "version "
+		// keyword) recognizes both binaries identically. Pre-fix this
+		// printed only the bare semver, which silently failed the
+		// extension's min-CLI gate when it was pointed at ezs-mcp.
+		fmt.Printf("ezstack-mcp version %s\n", version.Version)
 		return
 	}
 	// --upgrade-tag / --upgrade-force are meaningless without --upgrade or

--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -152,19 +152,24 @@ func captureCommand(fn func([]string) error, args []string) (stdout, stderr stri
 	go func() { defer wg.Done(); io.Copy(&outBuf, rOut) }()
 	go func() { defer wg.Done(); io.Copy(&errBuf, rErr) }()
 
+	// Restore stdout/stderr and unblock the drain goroutines even if fn panics —
+	// otherwise os.Stdout/Stderr stay pinned to closed pipes and subsequent
+	// tool calls write into EBADF, silently bricking the MCP server.
 	os.Stdout = wOut
 	os.Stderr = wErr
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		wOut.Close()
+		wErr.Close()
+		wg.Wait()
+		rOut.Close()
+		rErr.Close()
+		stdout = strings.TrimSpace(outBuf.String())
+		stderr = strings.TrimSpace(errBuf.String())
+	}()
 	cmdErr = fn(args)
-	wOut.Close()
-	wErr.Close()
-	os.Stdout = origStdout
-	os.Stderr = origStderr
-
-	wg.Wait()
-	rOut.Close()
-	rErr.Close()
-
-	return strings.TrimSpace(outBuf.String()), strings.TrimSpace(errBuf.String()), cmdErr
+	return
 }
 
 // runCommand is a convenience wrapper: prefers JSON stdout, falls back to ANSI-stripped stderr.
@@ -478,7 +483,7 @@ func registerTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("ezstack_pr_merge",
-			mcp.WithDescription("Merge the pull request for a branch. Use branch to target a specific branch when not on a stack branch."),
+			mcp.WithDescription("Merge the pull request for a branch. Use branch to target a specific branch when not on a stack branch. Side effect: after a successful merge the CLI auto-syncs the local stack (equivalent to `ezs sync -s`) so any rebased descendant branches land cleanly — this runs non-interactively under MCP YesMode."),
 			mcp.WithString("branch", mcp.Description("Branch whose PR to merge (defaults to current branch)")),
 			mcp.WithString("method", mcp.Description("Merge method: merge, squash, rebase (default: squash)")),
 			mcp.WithDestructiveHintAnnotation(true),

--- a/cmd/ezs/commands/commit.go
+++ b/cmd/ezs/commands/commit.go
@@ -360,9 +360,7 @@ func pushChildBranches(g *git.Git, synced []stack.RebaseResult, force bool) {
 		if remote == config.RemoteNoPush {
 			continue
 		}
-		// RemoteBranchExists only checks origin; for non-origin remotes we
-		// skip the existence check and let git decide.
-		if remote == "origin" && !g.RemoteBranchExists(r.Branch) {
+		if !g.RemoteHasBranch(remote, r.Branch) {
 			continue
 		}
 		if err := g.PushBranch(r.Branch, force, remote); err != nil {

--- a/cmd/ezs/commands/list.go
+++ b/cmd/ezs/commands/list.go
@@ -154,7 +154,10 @@ type statusStackJSON struct {
 	Branches     []statusBranchJSON `json:"branches"`
 }
 
-// statusBranchJSON extends branchJSON with PR and CI status fields
+// statusBranchJSON extends branchJSON with PR and CI status fields.
+// Additions/Deletions live on the embedded branchJSON — do not redeclare
+// them here, or Go's JSON encoder will silently shadow the inner copy and
+// any caller that sets only the inner field will see zeros in the output.
 type statusBranchJSON struct {
 	branchJSON
 	PRState     string `json:"pr_state,omitempty"`
@@ -162,8 +165,6 @@ type statusBranchJSON struct {
 	CISummary   string `json:"ci_summary,omitempty"`
 	Mergeable   string `json:"mergeable,omitempty"`
 	ReviewState string `json:"review_state,omitempty"`
-	Additions   int    `json:"additions"`
-	Deletions   int    `json:"deletions"`
 }
 
 // printStacksJSON outputs stacks as JSON to stdout
@@ -256,8 +257,8 @@ func printStacksStatusJSON(stacks []*config.Stack, currentBranch string, statusM
 					sbj.CISummary = bs.CISummary
 					sbj.Mergeable = bs.Mergeable
 					sbj.ReviewState = bs.ReviewState
-					sbj.Additions = bs.Additions
-					sbj.Deletions = bs.Deletions
+					sbj.branchJSON.Additions = bs.Additions
+					sbj.branchJSON.Deletions = bs.Deletions
 				}
 			}
 			sj.Branches = append(sj.Branches, sbj)

--- a/cmd/ezs/commands/list.go
+++ b/cmd/ezs/commands/list.go
@@ -393,6 +393,10 @@ func Status(args []string) error {
 
 	stacks := mgr.ListStacks()
 	if len(stacks) == 0 {
+		if *jsonFlag {
+			fmt.Fprintln(os.Stdout, "[]")
+			return nil
+		}
 		ui.Info("No stacks found. Create one with: ezs new <branch-name>")
 		return nil
 	}

--- a/cmd/ezs/commands/pr.go
+++ b/cmd/ezs/commands/pr.go
@@ -476,8 +476,15 @@ func prCreate(args []string) error {
 		return fmt.Errorf("no commits to create PR from. This branch has no commits ahead of '%s'.\nPlease make at least one commit first", branch.Parent)
 	}
 
-	if !mgr.IsMainBranch(branch.Parent) && !g.RemoteBranchExists(branch.Parent) {
-		ui.Warn(fmt.Sprintf("Parent branch '%s' has not been pushed to remote.", branch.Parent))
+	// The PR base branch must exist on whichever remote hosts the parent.
+	// For tracked parents that's the parent's own EffectiveRemote (fork or
+	// origin); for an untracked parent (rare), fall back to origin.
+	parentRemote := "origin"
+	if parentBranch := mgr.GetBranch(branch.Parent); parentBranch != nil {
+		parentRemote = parentBranch.EffectiveRemote()
+	}
+	if !mgr.IsMainBranch(branch.Parent) && !g.RemoteHasBranch(parentRemote, branch.Parent) {
+		ui.Warn(fmt.Sprintf("Parent branch '%s' has not been pushed to %s.", branch.Parent, parentRemote))
 		ui.Warn("The PR base branch won't exist on GitHub until it is pushed.")
 		if !ui.ConfirmTUI("Continue anyway?") {
 			ui.Warn("Cancelled")
@@ -593,7 +600,8 @@ func prCreate(args []string) error {
 		ui.Warn(fmt.Sprintf("Could not fetch from remote: %v", err))
 	}
 
-	hasDiverged, localAhead, remoteBehind, err := g.HasDivergedFromOrigin(branch.Name)
+	branchRemote := branch.EffectiveRemote()
+	hasDiverged, localAhead, remoteBehind, err := g.HasDivergedFromRemote(branch.Name, branchRemote)
 	if err != nil {
 		ui.Warn(fmt.Sprintf("Could not check remote branch status: %v", err))
 	}
@@ -615,17 +623,17 @@ func prCreate(args []string) error {
 			ui.Warn("Cancelled - cannot create PR without pushing")
 			return nil
 		}
-		if err := g.PushBranch(branch.Name, true, branch.EffectiveRemote()); err != nil {
+		if err := g.PushForceBranch(branch.Name, branchRemote); err != nil {
 			return fmt.Errorf("failed to force push: %w", err)
 		}
-	} else if g.RemoteBranchExists(branch.Name) {
+	} else if g.RemoteHasBranch(branchRemote, branch.Name) {
 		// Remote exists and local is ahead or in sync - regular push should work
-		if err := g.PushBranch(branch.Name, false, branch.EffectiveRemote()); err != nil {
+		if err := g.PushBranch(branch.Name, false, branchRemote); err != nil {
 			return fmt.Errorf("failed to push: %w", err)
 		}
 	} else {
 		// Remote doesn't exist - set upstream
-		if err := g.PushBranchSetUpstream(branch.Name, branch.EffectiveRemote()); err != nil {
+		if err := g.PushBranchSetUpstream(branch.Name, branchRemote); err != nil {
 			return fmt.Errorf("failed to push: %w", err)
 		}
 	}
@@ -771,13 +779,17 @@ func prUpdate(args []string) error {
 		}
 	}
 
-	// Check if remote branch exists and detect divergence
-	hasDiverged, localAhead, remoteAhead, divergeErr := g.HasDivergedFromOrigin(branch.Name)
+	// Check if remote branch exists and detect divergence against the
+	// branch's effective remote (not always origin — fork PRs target the
+	// contributor's fork).
+	branchRemote := branch.EffectiveRemote()
+	hasDiverged, localAhead, remoteAhead, divergeErr := g.HasDivergedFromRemote(branch.Name, branchRemote)
 	if divergeErr != nil {
 		ui.Warn(fmt.Sprintf("Could not check remote status: %v", divergeErr))
 	}
 
-	remoteBranchExists := g.RemoteBranchExists(branch.Name)
+	remoteBranchExists := g.RemoteHasBranch(branchRemote, branch.Name)
+	remoteRef := branchRemote + "/" + branch.Name
 
 	// Determine push type and get commits to show
 	var needsForcePush bool
@@ -791,14 +803,14 @@ func prUpdate(args []string) error {
 		// History has diverged (amended commits, rebase, etc.) - needs force push
 		needsForcePush = true
 		// Show commits that will be pushed
-		commits, _ = g.GetCommitsBetween("origin/"+branch.Name, branch.Name)
+		commits, _ = g.GetCommitsBetween(remoteRef, branch.Name)
 		if len(commits) == 0 {
 			// If no new commits, show all local commits (amended case)
 			commits, _ = g.GetCommitsBetween(branch.Parent, branch.Name)
 		}
 	} else if localAhead > 0 {
 		// Simple case - local is ahead, regular push works
-		commits, _ = g.GetCommitsBetween("origin/"+branch.Name, branch.Name)
+		commits, _ = g.GetCommitsBetween(remoteRef, branch.Name)
 	} else if divergeErr != nil {
 		// Status check failed — attempt force push rather than silently skipping
 		needsForcePush = true
@@ -841,7 +853,7 @@ func prUpdate(args []string) error {
 	}
 
 	ui.Info("Pushing changes...")
-	if err := g.PushBranch(branch.Name, needsForcePush, branch.EffectiveRemote()); err != nil {
+	if err := g.PushBranch(branch.Name, needsForcePush, branchRemote); err != nil {
 		return fmt.Errorf("failed to push: %w", err)
 	}
 

--- a/cmd/ezs/commands/pr.go
+++ b/cmd/ezs/commands/pr.go
@@ -336,8 +336,8 @@ func prCreateAllDraft(currentStack *config.Stack, draft, force bool) error {
 			ui.Warn(fmt.Sprintf("Skipping %s: push not allowed (fork does not allow maintainer push)", b.Name))
 			continue
 		}
-		// Push the branch first
-		if err := g.RunInteractive("push", "-u", b.EffectiveRemote(), b.Name); err != nil {
+		// Push the branch first to its effective remote (fork-aware).
+		if err := g.PushBranchSetUpstream(b.Name, b.EffectiveRemote()); err != nil {
 			ui.Warn(fmt.Sprintf("Failed to push %s: %v", b.Name, err))
 			failed++
 			continue

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -1114,7 +1114,7 @@ Options:
       falling back to <code>@latest</code> for untagged dev builds.</li>
       <li><strong>Registers <code>ezs-mcp</code> with Claude Code at user scope</strong> (equivalent to
       running <code>claude mcp add ezstack --scope user -- ezs-mcp</code> yourself), so
-      the full 21-tool ezstack surface is available to the agent from the
+      the full 25-tool ezstack surface is available to the agent from the
       first message.</li>
       <li><strong>Swaps the shipped prompt for a short MCP stub</strong> that tells the agent
       to prefer MCP tools over shelling out to <code>ezs</code>. The large

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -201,6 +201,11 @@
               <td><span class="mode-label mode-label-work">read-only</span></td>
               <td>Full ezstack configuration for the active repo.</td>
             </tr>
+            <tr>
+              <td><code>ezstack_doctor</code></td>
+              <td><span class="mode-label mode-label-work">read-only</span></td>
+              <td>Run ezstack diagnostics and report environment / config / git state.</td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -325,6 +330,11 @@
               <td><code>ezstack_pr_stack</code></td>
               <td>&mdash;</td>
               <td>Update every PR description in the stack with navigation links. <code>branch</code>.</td>
+            </tr>
+            <tr>
+              <td><code>ezstack_pr_draft_all</code></td>
+              <td>&mdash;</td>
+              <td>Open draft PRs for every branch in the current stack that does not yet have one.</td>
             </tr>
           </tbody>
         </table>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,6 +242,16 @@ func (bc *BranchCache) ClearPRFields() {
 type CacheConfig struct {
 	Branches map[string]*BranchCache `json:"branches"`
 	repoDir  string
+
+	// origBranches captures Branches as it existed on disk at load time, so
+	// CacheConfig.Save can do a three-way merge against any concurrent
+	// peer-process changes instead of wholesale-replacing the on-disk map.
+	// Same semantics as StackConfig.origSnapshot.Branches. nil for caches
+	// that were not loaded from disk (e.g. tests building CacheConfig
+	// in-memory) — Save treats nil as "no changes from us are unmergeable
+	// with theirs", which is equivalent to the pre-fix behavior in that
+	// edge case.
+	origBranches map[string]*BranchCache
 }
 
 // Branch represents a single branch in a stack, constructed from the tree and cache at runtime.
@@ -844,7 +854,19 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
-// Save saves the configuration to ~/.ezstack/config.json
+// Save persists the configuration to ~/.ezstack/config.json under the same
+// per-process lock model used by StackConfig.Save: acquire flock, reload
+// the on-disk file, merge our changes against any concurrent peer's
+// changes, then atomicWriteFile.
+//
+// Without this, two parallel `ezs config set …` runs (or any path that
+// auto-saves the global config) silently lost the earlier writer's update.
+// The merge is map-level (per-repo): if peer added or modified another
+// repo's RepoConfig while we were holding `c` in memory, their entry
+// survives. Same-repo concurrent edits resolve last-writer-wins because
+// `c.Repos` doesn't carry a load-time snapshot — that's a documented
+// limitation, not a regression: pre-PR, every save was last-writer-wins
+// across the whole file.
 func (c *Config) Save() error {
 	configDir, err := ConfigDir()
 	if err != nil {
@@ -855,12 +877,73 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(c, "", "  ")
+	configPath := filepath.Join(configDir, "config.json")
+
+	lock, lockErr := acquireFileLock(configPath + ".lock")
+	if lockErr != nil {
+		return lockErr
+	}
+	defer lock.release()
+
+	// Reload disk state under the lock so we can merge against it. If the
+	// file doesn't exist (first save), there's nothing to merge.
+	merged := c
+	if data, readErr := os.ReadFile(configPath); readErr == nil {
+		var disk Config
+		if err := json.Unmarshal(data, &disk); err == nil {
+			merged = mergeGlobalConfig(&disk, c)
+		}
+	} else if !os.IsNotExist(readErr) {
+		return readErr
+	}
+
+	data, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return atomicWriteFile(filepath.Join(configDir, "config.json"), data, 0644)
+	if err := atomicWriteFile(configPath, data, 0644); err != nil {
+		return err
+	}
+
+	// Mirror merged result back into the receiver so any subsequent
+	// in-process Save() picks up peer additions instead of clobbering them.
+	*c = *merged
+	return nil
+}
+
+// mergeGlobalConfig combines the in-memory config (`mine`) with the disk
+// state read under the lock (`theirs`). Scalar fields prefer mine
+// (last-writer-wins, preserving the pre-fix behavior); the Repos map is
+// merged so a peer's addition of a different repo's config survives our
+// save.
+func mergeGlobalConfig(theirs, mine *Config) *Config {
+	if mine == nil {
+		return theirs
+	}
+	if theirs == nil {
+		return mine
+	}
+	out := &Config{
+		DefaultBaseBranch: mine.DefaultBaseBranch,
+		GitHubToken:       mine.GitHubToken,
+		Repos:             make(map[string]*RepoConfig),
+	}
+	// Preserve scalar last-writer-wins for fields we directly set.
+	if out.DefaultBaseBranch == "" && theirs.DefaultBaseBranch != "" {
+		// Don't fight a peer who set a default we never had.
+		out.DefaultBaseBranch = theirs.DefaultBaseBranch
+	}
+	if out.GitHubToken == "" && theirs.GitHubToken != "" {
+		out.GitHubToken = theirs.GitHubToken
+	}
+	for path, rc := range theirs.Repos {
+		out.Repos[path] = rc
+	}
+	for path, rc := range mine.Repos {
+		out.Repos[path] = rc
+	}
+	return out
 }
 
 // LoadStackConfig loads stack metadata and branch cache for a specific repo from $HOME/.ezstack/stacks.json
@@ -921,9 +1004,37 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to migrate stacks.json: %w", err)
 		}
-		if err := atomicWriteFile(stackPath, data, 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to persist migration: %v\n", err)
+		// Persist the migrated form under the same lock model used by Save
+		// so two processes opening an old config concurrently can't both
+		// write at once. The migration is idempotent (re-running it on
+		// already-migrated data is a no-op), so worst-case both processes
+		// write the same bytes; the lock is purely a "no torn writes"
+		// guarantee.
+		if lock, lockErr := acquireFileLock(stackPath + ".lock"); lockErr == nil {
+			// Re-read disk under the lock — if a peer migrated first, prefer
+			// their result (still our target version) rather than rewriting.
+			if cur, readErr := os.ReadFile(stackPath); readErr == nil {
+				var curVer struct {
+					Version int `json:"version"`
+				}
+				if json.Unmarshal(cur, &curVer) == nil && curVer.Version >= currentStackConfigVersion {
+					data = cur
+					lock.release()
+					goto migrated
+				}
+			}
+			if err := atomicWriteFile(stackPath, data, 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to persist migration: %v\n", err)
+			}
+			lock.release()
+		} else {
+			// Fall back to the unlocked write so a busted lock subsystem
+			// (permission, fs limit) doesn't block all use of ezs.
+			if err := atomicWriteFile(stackPath, data, 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to persist migration: %v\n", err)
+			}
 		}
+	migrated:
 	}
 
 	var file stackConfigFile
@@ -952,8 +1063,9 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 	sc := &StackConfig{
 		Stacks: rd.Stacks,
 		Cache: &CacheConfig{
-			Branches: rd.Branches,
-			repoDir:  repoDir,
+			Branches:     rd.Branches,
+			origBranches: snapshotBranches(rd.Branches),
+			repoDir:      repoDir,
 		},
 		repoDir:      repoDir,
 		origSnapshot: snapshotRepoData(rd),
@@ -967,6 +1079,24 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 	}
 
 	return sc, nil
+}
+
+// snapshotBranches deep-copies a map of *BranchCache pointers via a JSON
+// round-trip. Used by CacheConfig load paths to capture the on-disk state
+// for a later three-way merge in Save. Returns an empty (non-nil) map on
+// nil input.
+func snapshotBranches(branches map[string]*BranchCache) map[string]*BranchCache {
+	out := make(map[string]*BranchCache, len(branches))
+	if len(branches) == 0 {
+		return out
+	}
+	if buf, err := json.Marshal(branches); err == nil {
+		_ = json.Unmarshal(buf, &out)
+	}
+	if out == nil {
+		out = make(map[string]*BranchCache)
+	}
+	return out
 }
 
 // snapshotRepoData deep-copies a repoData via a JSON round-trip so that
@@ -1024,6 +1154,99 @@ var MergeConflictHook func(kind, key string) = func(kind, key string) {
 	)
 }
 
+// mergeBranches performs a three-way merge over branch-cache maps using
+// the same semantics as mergeRepoData (mine wins on us-modified, theirs
+// fills in on we-didn't-touch, deletions and additions from either side
+// survive). Same-target concurrent edits fire MergeConflictHook with kind
+// "branch".
+func mergeBranches(orig, mine, theirs map[string]*BranchCache) map[string]*BranchCache {
+	if orig == nil {
+		orig = map[string]*BranchCache{}
+	}
+	if theirs == nil {
+		theirs = map[string]*BranchCache{}
+	}
+	merged := make(map[string]*BranchCache)
+	notify := func(key string) {
+		if MergeConflictHook != nil {
+			MergeConflictHook("branch", key)
+		}
+	}
+	seen := make(map[string]bool, len(mine))
+	for name, mineB := range mine {
+		seen[name] = true
+		origB, hadOrig := orig[name]
+		if hadOrig && jsonEqual(origB, mineB) {
+			if theirB, hasTheirs := theirs[name]; hasTheirs {
+				merged[name] = theirB
+			}
+			continue
+		}
+		if hadOrig {
+			if theirB, hasTheirs := theirs[name]; hasTheirs &&
+				!jsonEqual(theirB, origB) && !jsonEqual(theirB, mineB) {
+				notify(name)
+			}
+		}
+		merged[name] = mineB
+	}
+	for name, theirB := range theirs {
+		if seen[name] {
+			continue
+		}
+		if _, wasOrig := orig[name]; wasOrig {
+			continue // we deleted it
+		}
+		merged[name] = theirB
+	}
+	return merged
+}
+
+// mergeStacks performs a three-way merge over stack maps using the same
+// semantics as mergeBranches (kind="stack" for the conflict hook).
+func mergeStacks(orig, mine, theirs map[string]*Stack) map[string]*Stack {
+	if orig == nil {
+		orig = map[string]*Stack{}
+	}
+	if theirs == nil {
+		theirs = map[string]*Stack{}
+	}
+	merged := make(map[string]*Stack)
+	notify := func(key string) {
+		if MergeConflictHook != nil {
+			MergeConflictHook("stack", key)
+		}
+	}
+	seen := make(map[string]bool, len(mine))
+	for hash, mineS := range mine {
+		seen[hash] = true
+		origS, hadOrig := orig[hash]
+		if hadOrig && jsonEqual(origS, mineS) {
+			if theirS, hasTheirs := theirs[hash]; hasTheirs {
+				merged[hash] = theirS
+			}
+			continue
+		}
+		if hadOrig {
+			if theirS, hasTheirs := theirs[hash]; hasTheirs &&
+				!jsonEqual(theirS, origS) && !jsonEqual(theirS, mineS) {
+				notify(hash)
+			}
+		}
+		merged[hash] = mineS
+	}
+	for hash, theirS := range theirs {
+		if seen[hash] {
+			continue
+		}
+		if _, wasOrig := orig[hash]; wasOrig {
+			continue // we deleted it
+		}
+		merged[hash] = theirS
+	}
+	return merged
+}
+
 // mergeRepoData performs a three-way merge between the disk state at load
 // time (orig), the in-memory state we want to write (mine), and the disk
 // state right now (theirs, which may include another process's changes).
@@ -1040,6 +1263,12 @@ var MergeConflictHook func(kind, key string) = func(kind, key string) {
 // resolve last-writer-wins, but we fire MergeConflictHook so the loss
 // isn't silent. The common case (two processes touching different stacks
 // of the same repo) remains lossless.
+//
+// IMPORTANT: when adding a new field to repoData, also extend this
+// function. TestMergeRepoData_AllFieldsCovered (config_test.go) uses
+// reflection to fail loudly if a new repoData field is left unmerged —
+// without that guard the new field's peer-process updates would be
+// silently overwritten on every Save.
 func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 	if orig == nil {
 		orig = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
@@ -1047,81 +1276,22 @@ func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 	if theirs == nil {
 		theirs = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
 	}
-	merged := &repoData{
-		Stacks:   make(map[string]*Stack),
-		Branches: make(map[string]*BranchCache),
+	if mine == nil {
+		mine = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
 	}
-
-	notify := func(kind, key string) {
-		if MergeConflictHook != nil {
-			MergeConflictHook(kind, key)
-		}
+	return &repoData{
+		Stacks:   mergeStacks(orig.Stacks, mine.Stacks, theirs.Stacks),
+		Branches: mergeBranches(orig.Branches, mine.Branches, theirs.Branches),
 	}
-
-	// Stacks
-	seenStacks := make(map[string]bool, len(mine.Stacks))
-	for hash, mineS := range mine.Stacks {
-		seenStacks[hash] = true
-		origS, hadOrig := orig.Stacks[hash]
-		if hadOrig && jsonEqual(origS, mineS) {
-			if theirS, hasTheirs := theirs.Stacks[hash]; hasTheirs {
-				merged.Stacks[hash] = theirS
-			}
-			continue
-		}
-		// We modified (or added) — but if theirs *also* drifted from orig
-		// in some way other than matching mine, that's a same-target
-		// concurrent edit. Last-writer-wins (mine) is what the rest of
-		// ezstack expects, but the hook surfaces it so the user knows.
-		if hadOrig {
-			if theirS, hasTheirs := theirs.Stacks[hash]; hasTheirs &&
-				!jsonEqual(theirS, origS) && !jsonEqual(theirS, mineS) {
-				notify("stack", hash)
-			}
-		}
-		merged.Stacks[hash] = mineS
-	}
-	for hash, theirS := range theirs.Stacks {
-		if seenStacks[hash] {
-			continue
-		}
-		if _, wasOrig := orig.Stacks[hash]; wasOrig {
-			continue // we deleted it
-		}
-		merged.Stacks[hash] = theirS
-	}
-
-	// Branches (cache entries) — same shape
-	seenBranches := make(map[string]bool, len(mine.Branches))
-	for name, mineB := range mine.Branches {
-		seenBranches[name] = true
-		origB, hadOrig := orig.Branches[name]
-		if hadOrig && jsonEqual(origB, mineB) {
-			if theirB, hasTheirs := theirs.Branches[name]; hasTheirs {
-				merged.Branches[name] = theirB
-			}
-			continue
-		}
-		if hadOrig {
-			if theirB, hasTheirs := theirs.Branches[name]; hasTheirs &&
-				!jsonEqual(theirB, origB) && !jsonEqual(theirB, mineB) {
-				notify("branch", name)
-			}
-		}
-		merged.Branches[name] = mineB
-	}
-	for name, theirB := range theirs.Branches {
-		if seenBranches[name] {
-			continue
-		}
-		if _, wasOrig := orig.Branches[name]; wasOrig {
-			continue
-		}
-		merged.Branches[name] = theirB
-	}
-
-	return merged
 }
+
+// mergedRepoDataFieldCount returns the number of repoData fields that
+// mergeRepoData currently knows how to merge. Updated whenever the
+// function gains a new field. TestMergeRepoData_AllFieldsCovered
+// cross-checks this against reflect.TypeOf((*repoData)(nil)).Elem().NumField()
+// so that adding a field to repoData without extending mergeRepoData
+// becomes a hard test failure rather than a latent data-loss bug.
+const mergedRepoDataFieldCount = 2
 
 // IsFullyMerged returns true if every branch in the stack is marked as merged
 func (s *Stack) IsFullyMerged(cache *CacheConfig) bool {
@@ -1249,8 +1419,9 @@ func LoadCacheConfig(repoDir string) (*CacheConfig, error) {
 		if err := json.Unmarshal(data, &file); err == nil && file.Repos != nil {
 			if rd, ok := file.Repos[repoDir]; ok && rd != nil && rd.Branches != nil {
 				return &CacheConfig{
-					Branches: rd.Branches,
-					repoDir:  repoDir,
+					Branches:     rd.Branches,
+					origBranches: snapshotBranches(rd.Branches),
+					repoDir:      repoDir,
 				}, nil
 			}
 		}
@@ -1388,8 +1559,16 @@ func MutateBranchCache(repoDir, branchName string, fn func(current *BranchCache)
 	return atomicWriteFile(stackPath, newData, 0644)
 }
 
-// Save writes the cache data back to the combined stacks.json file.
-// This loads the current stacks.json, updates the branches for this repo, and writes it back atomically.
+// Save writes the cache data back to the combined stacks.json file under
+// the per-process file lock and a three-way merge against any concurrent
+// peer-process changes to the branch cache. Without the merge, a parallel
+// `ezs sync` (which writes via StackConfig.Save / MutateBranchCache) could
+// add a new branch entry between our load and save, and our wholesale-
+// replace of `rd.Branches` would silently delete it.
+//
+// Prefer MutateBranchCache for narrow updates — it scopes the RMW window to
+// a single branch under the same lock and avoids carrying stale state. This
+// path remains for callers that need to rewrite multiple entries together.
 func (cc *CacheConfig) Save(repoDir string) error {
 	configDir, err := ConfigDir()
 	if err != nil {
@@ -1432,14 +1611,25 @@ func (cc *CacheConfig) Save(repoDir string) error {
 	}
 
 	file.Version = currentStackConfigVersion
-	rd.Branches = cc.Branches
+	// Three-way merge against the disk's branches: orig is what we read at
+	// load time, mine is the in-memory map we want to write, theirs is the
+	// branches map currently on disk under this lock. Same semantics as
+	// StackConfig.Save's mergeRepoData call.
+	rd.Branches = mergeBranches(cc.origBranches, cc.Branches, rd.Branches)
 
 	newData, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return atomicWriteFile(stackPath, newData, 0644)
+	if err := atomicWriteFile(stackPath, newData, 0644); err != nil {
+		return err
+	}
+
+	// Refresh snapshot so a subsequent Save in the same process treats this
+	// as the new common ancestor.
+	cc.origBranches = snapshotBranches(rd.Branches)
+	return nil
 }
 
 // GetBranches returns a flat list of branches from the tree structure

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,14 +33,21 @@ func PRNumberFromURL(url string) int {
 	return n
 }
 
-var v *viper.Viper
-
-func init() {
-	v = viper.New()
+// newViper builds a fresh Viper instance with the EZSTACK_-prefixed env
+// binding and built-in defaults. We do NOT share a package-level Viper
+// across calls: Viper's Set*/ReadInConfig path mutates internal maps
+// without synchronization, so concurrent Load() in the same process
+// (e.g. ezs-mcp serving parallel tool calls, or any other goroutine
+// driver) would race the global singleton. A per-call instance is
+// cheap (a few map allocations) and makes Load() safe to call from
+// multiple goroutines.
+func newViper() *viper.Viper {
+	v := viper.New()
 	v.SetEnvPrefix("EZSTACK")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 	v.SetDefault("default_base_branch", "main")
+	return v
 }
 
 // Config holds the global configuration for ezstack
@@ -814,6 +821,7 @@ func Load() (*Config, error) {
 
 	configPath := filepath.Join(configDir, "config.json")
 
+	v := newViper()
 	v.SetConfigFile(configPath)
 	v.SetConfigType("json")
 	if err := v.ReadInConfig(); err != nil {
@@ -1027,9 +1035,20 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 				fmt.Fprintf(os.Stderr, "Warning: failed to persist migration: %v\n", err)
 			}
 			lock.release()
+		} else if errors.Is(lockErr, ErrLockTimeout) {
+			// Peer is actively holding the lock and is also migrating
+			// (because they read the same old-version file we did).
+			// Migration is idempotent, so our in-memory `data` is already
+			// the correct target form — skip the persist step. The peer's
+			// write will land; the next Load will pick up the persisted
+			// copy. Racing with an unlocked atomicWriteFile here would
+			// resurrect exactly the torn-write bug the lock prevents.
+			fmt.Fprintf(os.Stderr, "ezs: stacks.json migration: peer process is migrating; skipping our persist step (their write will land)\n")
 		} else {
-			// Fall back to the unlocked write so a busted lock subsystem
-			// (permission, fs limit) doesn't block all use of ezs.
+			// Lock subsystem itself is broken (permission denied, FS limit,
+			// missing parent dir). Fall back to an unlocked write so a
+			// genuinely busted lock backend doesn't block all use of ezs.
+			// Only this branch races; the timeout branch above does not.
 			if err := atomicWriteFile(stackPath, data, 0644); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to persist migration: %v\n", err)
 			}
@@ -1085,13 +1104,26 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 // round-trip. Used by CacheConfig load paths to capture the on-disk state
 // for a later three-way merge in Save. Returns an empty (non-nil) map on
 // nil input.
+//
+// Errors from Marshal/Unmarshal are surfaced via stderr (and the returned
+// map ends up empty). Both fields involved are JSON-tagged so this should
+// never fail in practice — but if it does, the silent path used to leave
+// `out` partially populated, which then made the three-way merge see a
+// stale "orig" and could drop concurrent peer updates. Loud failure is
+// vastly preferable to silent data loss.
 func snapshotBranches(branches map[string]*BranchCache) map[string]*BranchCache {
 	out := make(map[string]*BranchCache, len(branches))
 	if len(branches) == 0 {
 		return out
 	}
-	if buf, err := json.Marshal(branches); err == nil {
-		_ = json.Unmarshal(buf, &out)
+	buf, err := json.Marshal(branches)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ezstack: snapshotBranches: marshal failed (%v); merge will see empty orig — peer updates may be lost\n", err)
+		return out
+	}
+	if err := json.Unmarshal(buf, &out); err != nil {
+		fmt.Fprintf(os.Stderr, "ezstack: snapshotBranches: unmarshal failed (%v); merge will see empty orig — peer updates may be lost\n", err)
+		return make(map[string]*BranchCache)
 	}
 	if out == nil {
 		out = make(map[string]*BranchCache)
@@ -1103,6 +1135,10 @@ func snapshotBranches(branches map[string]*BranchCache) map[string]*BranchCache 
 // later mutations to the live `*Stack` / `*BranchCache` pointers don't
 // affect the captured snapshot. Returns an empty (non-nil) repoData on
 // nil input so callers can compare without a nil check.
+//
+// As with snapshotBranches, Marshal/Unmarshal errors are surfaced via
+// stderr instead of silently swallowed. A round-trip failure here makes
+// the three-way merge see a stale orig and can drop a peer's update.
 func snapshotRepoData(rd *repoData) *repoData {
 	out := &repoData{
 		Stacks:   make(map[string]*Stack),
@@ -1111,8 +1147,17 @@ func snapshotRepoData(rd *repoData) *repoData {
 	if rd == nil {
 		return out
 	}
-	if buf, err := json.Marshal(rd); err == nil {
-		_ = json.Unmarshal(buf, out)
+	buf, err := json.Marshal(rd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ezstack: snapshotRepoData: marshal failed (%v); merge will see empty orig — peer updates may be lost\n", err)
+		return out
+	}
+	if err := json.Unmarshal(buf, out); err != nil {
+		fmt.Fprintf(os.Stderr, "ezstack: snapshotRepoData: unmarshal failed (%v); merge will see empty orig — peer updates may be lost\n", err)
+		return &repoData{
+			Stacks:   make(map[string]*Stack),
+			Branches: make(map[string]*BranchCache),
+		}
 	}
 	if out.Stacks == nil {
 		out.Stacks = make(map[string]*Stack)
@@ -1292,6 +1337,16 @@ func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 // so that adding a field to repoData without extending mergeRepoData
 // becomes a hard test failure rather than a latent data-loss bug.
 const mergedRepoDataFieldCount = 2
+
+// mergedGlobalConfigFieldCount is the same tripwire for the top-level
+// Config struct. mergeGlobalConfig handles three fields today:
+// DefaultBaseBranch (scalar, peer-fill-if-empty), GitHubToken (same), and
+// Repos (per-repo map merge). If a future contributor adds a fourth field
+// — say "Telemetry" or "Notifications" — and forgets to extend
+// mergeGlobalConfig, two parallel `ezs config set` calls (or any peer
+// process) would silently drop one writer's update of the new field. The
+// reflection test in config_audit_test.go catches that at build time.
+const mergedGlobalConfigFieldCount = 3
 
 // IsFullyMerged returns true if every branch in the stack is marked as merged
 func (s *Stack) IsFullyMerged(cache *CacheConfig) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -164,6 +165,12 @@ type StackConfig struct {
 	Stacks  map[string]*Stack `json:"stacks"`
 	Cache   *CacheConfig      `json:"-"` // loaded alongside stacks, not serialized separately
 	repoDir string            // internal, not serialized - used for saving
+
+	// origSnapshot captures this repo's data as it existed on disk at load
+	// time. Save() uses it as the common ancestor for a three-way merge so
+	// that concurrent modifications by another ezstack process don't get
+	// silently overwritten. nil for fresh configs.
+	origSnapshot *repoData
 }
 
 // Stack represents a chain of stacked branches as a tree
@@ -316,7 +323,10 @@ type legacyConfig struct {
 }
 
 // atomicWriteFile writes data to a file atomically by writing to a temp file
-// in the same directory, fsyncing it, and then renaming over the destination.
+// in the same directory, fsyncing it, renaming over the destination, and then
+// fsyncing the parent directory so the rename itself is durable on filesystems
+// where rename ordering vs. data persistence isn't otherwise guaranteed
+// (APFS, ZFS, NFS).
 //
 // fsync before rename is what makes "atomic" actually durable: without it, a
 // crash between rename and the OS flushing dirty pages can leave the renamed
@@ -355,7 +365,22 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
+	syncDir(dir)
 	return nil
+}
+
+// syncDir fsyncs a directory so that a recent rename inside it is durable.
+// Best-effort: errors are ignored because (a) Windows rejects directory fsync
+// with EINVAL and (b) some filesystems return ENOTSUP. The atomic rename has
+// already happened; missing the directory sync is a small durability hit, not
+// a correctness bug.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	_ = d.Sync()
+	d.Close()
 }
 
 // migrateStackConfig migrates stacks.json data from srcVersion to dstVersion.
@@ -930,7 +955,8 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 			Branches: rd.Branches,
 			repoDir:  repoDir,
 		},
-		repoDir: repoDir,
+		repoDir:      repoDir,
+		origSnapshot: snapshotRepoData(rd),
 	}
 
 	for hash, stack := range sc.Stacks {
@@ -941,6 +967,119 @@ func LoadStackConfig(repoDir string) (*StackConfig, error) {
 	}
 
 	return sc, nil
+}
+
+// snapshotRepoData deep-copies a repoData via a JSON round-trip so that
+// later mutations to the live `*Stack` / `*BranchCache` pointers don't
+// affect the captured snapshot. Returns an empty (non-nil) repoData on
+// nil input so callers can compare without a nil check.
+func snapshotRepoData(rd *repoData) *repoData {
+	out := &repoData{
+		Stacks:   make(map[string]*Stack),
+		Branches: make(map[string]*BranchCache),
+	}
+	if rd == nil {
+		return out
+	}
+	if buf, err := json.Marshal(rd); err == nil {
+		_ = json.Unmarshal(buf, out)
+	}
+	if out.Stacks == nil {
+		out.Stacks = make(map[string]*Stack)
+	}
+	if out.Branches == nil {
+		out.Branches = make(map[string]*BranchCache)
+	}
+	return out
+}
+
+// jsonEqual compares two values by their JSON serialization. Returns false
+// if either side fails to marshal — we prefer "treat as different" over
+// "treat as equal" for safety.
+func jsonEqual(a, b any) bool {
+	aJSON, errA := json.Marshal(a)
+	bJSON, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(aJSON, bJSON)
+}
+
+// mergeRepoData performs a three-way merge between the disk state at load
+// time (orig), the in-memory state we want to write (mine), and the disk
+// state right now (theirs, which may include another process's changes).
+//
+// Per stack/branch:
+//   - If we modified it (mine != orig) → take mine
+//   - If we didn't touch it (mine == orig) → take theirs (preserves another
+//     process's concurrent updates, including deletions)
+//   - If we added (in mine, not in orig) → take mine
+//   - If we deleted (in orig, not in mine) → omit (deletion wins)
+//   - If theirs added (in theirs, not in orig, not in mine) → take theirs
+//
+// Concurrent modifications to the *same* stack from two processes resolve
+// last-writer-wins, which matches the existing semantics — but the common
+// case (two processes touching different stacks of the same repo) is now
+// safe.
+func mergeRepoData(orig, mine, theirs *repoData) *repoData {
+	if orig == nil {
+		orig = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+	}
+	if theirs == nil {
+		theirs = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+	}
+	merged := &repoData{
+		Stacks:   make(map[string]*Stack),
+		Branches: make(map[string]*BranchCache),
+	}
+
+	// Stacks
+	seenStacks := make(map[string]bool, len(mine.Stacks))
+	for hash, mineS := range mine.Stacks {
+		seenStacks[hash] = true
+		origS, hadOrig := orig.Stacks[hash]
+		if hadOrig && jsonEqual(origS, mineS) {
+			if theirS, hasTheirs := theirs.Stacks[hash]; hasTheirs {
+				merged.Stacks[hash] = theirS
+			}
+			continue
+		}
+		merged.Stacks[hash] = mineS
+	}
+	for hash, theirS := range theirs.Stacks {
+		if seenStacks[hash] {
+			continue
+		}
+		if _, wasOrig := orig.Stacks[hash]; wasOrig {
+			continue // we deleted it
+		}
+		merged.Stacks[hash] = theirS
+	}
+
+	// Branches (cache entries) — same shape
+	seenBranches := make(map[string]bool, len(mine.Branches))
+	for name, mineB := range mine.Branches {
+		seenBranches[name] = true
+		origB, hadOrig := orig.Branches[name]
+		if hadOrig && jsonEqual(origB, mineB) {
+			if theirB, hasTheirs := theirs.Branches[name]; hasTheirs {
+				merged.Branches[name] = theirB
+			}
+			continue
+		}
+		merged.Branches[name] = mineB
+	}
+	for name, theirB := range theirs.Branches {
+		if seenBranches[name] {
+			continue
+		}
+		if _, wasOrig := orig.Branches[name]; wasOrig {
+			continue
+		}
+		merged.Branches[name] = theirB
+	}
+
+	return merged
 }
 
 // IsFullyMerged returns true if every branch in the stack is marked as merged
@@ -1025,18 +1164,32 @@ func (sc *StackConfig) Save(repoDir string) error {
 		branches = sc.Cache.Branches
 	}
 
-	file.Version = currentStackConfigVersion
-	file.Repos[targetRepo] = &repoData{
+	mine := &repoData{
 		Stacks:   sc.Stacks,
 		Branches: branches,
 	}
+
+	// Three-way merge against any concurrent on-disk changes since we loaded.
+	// Without this, two parallel ezs invocations on different stacks of the
+	// same repo silently lose one process's writes.
+	merged := mergeRepoData(sc.origSnapshot, mine, file.Repos[targetRepo])
+
+	file.Version = currentStackConfigVersion
+	file.Repos[targetRepo] = merged
 
 	newData, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return atomicWriteFile(stackPath, newData, 0644)
+	if err := atomicWriteFile(stackPath, newData, 0644); err != nil {
+		return err
+	}
+
+	// Refresh our snapshot so a subsequent Save in the same process treats the
+	// just-written data as the new common ancestor for any further changes.
+	sc.origSnapshot = snapshotRepoData(merged)
+	return nil
 }
 
 // LoadCacheConfig loads cached branch metadata. This now delegates to the combined stacks file.
@@ -1347,13 +1500,21 @@ func (s *Stack) RemoveBranch(branchName string) {
 	s.removeBranchFromTree(s.Tree, branchName)
 }
 
-// removeBranchFromTree recursively finds and removes the branch
+// removeBranchFromTree recursively finds and removes the branch.
+// When the removed branch has children, they are reparented one level up.
+// If a child has the same name as a sibling already at the parent level
+// (rare but possible after a rename or import), we merge that child's
+// subtree into the existing sibling rather than overwriting it — losing
+// the existing subtree would silently drop branches from config.
 func (s *Stack) removeBranchFromTree(tree BranchTree, branchName string) bool {
 	for name, children := range tree {
 		if name == branchName {
-			// Move children up to this branch's parent (which is the current tree)
 			for childName, childTree := range children {
-				tree[childName] = childTree
+				if existing, collides := tree[childName]; collides {
+					mergeBranchTrees(existing, childTree)
+				} else {
+					tree[childName] = childTree
+				}
 			}
 			delete(tree, branchName)
 			return true
@@ -1363,6 +1524,19 @@ func (s *Stack) removeBranchFromTree(tree BranchTree, branchName string) bool {
 		}
 	}
 	return false
+}
+
+// mergeBranchTrees recursively merges src into dst, preserving any
+// non-overlapping subtrees on both sides. When the same name appears in
+// both, descend and merge.
+func mergeBranchTrees(dst, src BranchTree) {
+	for name, srcChildren := range src {
+		if dstChildren, ok := dst[name]; ok {
+			mergeBranchTrees(dstChildren, srcChildren)
+		} else {
+			dst[name] = srcChildren
+		}
+	}
 }
 
 // ReparentBranch moves a branch to be under a new parent

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1005,6 +1005,25 @@ func jsonEqual(a, b any) bool {
 	return bytes.Equal(aJSON, bJSON)
 }
 
+// MergeConflictHook is invoked once per (kind, key) where the three-way
+// merge encountered a same-target concurrent edit (mine != orig AND
+// theirs != orig AND theirs != mine). Kind is "stack" or "branch". The
+// merge resolves last-writer-wins (mine), but the hook gives the caller a
+// chance to log or surface the fact that a peer's update is being
+// overwritten.
+//
+// Default writes a one-line warning to stderr. Tests override it to
+// capture the call. Set to a no-op func to silence (callers that want
+// silence: don't use nil — that path is reserved for "default behavior").
+var MergeConflictHook func(kind, key string) = func(kind, key string) {
+	fmt.Fprintf(os.Stderr,
+		"ezs: warning: concurrent edit to %s %q detected during save; "+
+			"another ezs process modified the same %s in between our load and save. "+
+			"Their changes were overwritten (last-writer-wins).\n",
+		kind, key, kind,
+	)
+}
+
 // mergeRepoData performs a three-way merge between the disk state at load
 // time (orig), the in-memory state we want to write (mine), and the disk
 // state right now (theirs, which may include another process's changes).
@@ -1017,10 +1036,10 @@ func jsonEqual(a, b any) bool {
 //   - If we deleted (in orig, not in mine) → omit (deletion wins)
 //   - If theirs added (in theirs, not in orig, not in mine) → take theirs
 //
-// Concurrent modifications to the *same* stack from two processes resolve
-// last-writer-wins, which matches the existing semantics — but the common
-// case (two processes touching different stacks of the same repo) is now
-// safe.
+// Concurrent modifications to the *same* stack/branch from two processes
+// resolve last-writer-wins, but we fire MergeConflictHook so the loss
+// isn't silent. The common case (two processes touching different stacks
+// of the same repo) remains lossless.
 func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 	if orig == nil {
 		orig = &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
@@ -1033,6 +1052,12 @@ func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 		Branches: make(map[string]*BranchCache),
 	}
 
+	notify := func(kind, key string) {
+		if MergeConflictHook != nil {
+			MergeConflictHook(kind, key)
+		}
+	}
+
 	// Stacks
 	seenStacks := make(map[string]bool, len(mine.Stacks))
 	for hash, mineS := range mine.Stacks {
@@ -1043,6 +1068,16 @@ func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 				merged.Stacks[hash] = theirS
 			}
 			continue
+		}
+		// We modified (or added) — but if theirs *also* drifted from orig
+		// in some way other than matching mine, that's a same-target
+		// concurrent edit. Last-writer-wins (mine) is what the rest of
+		// ezstack expects, but the hook surfaces it so the user knows.
+		if hadOrig {
+			if theirS, hasTheirs := theirs.Stacks[hash]; hasTheirs &&
+				!jsonEqual(theirS, origS) && !jsonEqual(theirS, mineS) {
+				notify("stack", hash)
+			}
 		}
 		merged.Stacks[hash] = mineS
 	}
@@ -1066,6 +1101,12 @@ func mergeRepoData(orig, mine, theirs *repoData) *repoData {
 				merged.Branches[name] = theirB
 			}
 			continue
+		}
+		if hadOrig {
+			if theirB, hasTheirs := theirs.Branches[name]; hasTheirs &&
+				!jsonEqual(theirB, origB) && !jsonEqual(theirB, mineB) {
+				notify("branch", name)
+			}
 		}
 		merged.Branches[name] = mineB
 	}

--- a/internal/config/config_audit_test.go
+++ b/internal/config/config_audit_test.go
@@ -1,0 +1,301 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// TestMergeRepoData_AllFieldsCovered is a "tripwire" guard. The
+// mergeRepoData function knows how to three-way-merge each field of
+// repoData. If a future contributor adds a new field (Settings,
+// Metadata, anything) without extending mergeRepoData, the new field's
+// peer-process updates would be silently overwritten on every Save.
+//
+// We use reflection to count the actual struct fields and compare
+// against mergedRepoDataFieldCount, which the function explicitly
+// declares it merges. The constant must be incremented in lockstep with
+// any new field — and the merge logic itself must be extended in
+// mergeRepoData. This test ensures the latter happens by failing the
+// build until both are done.
+func TestMergeRepoData_AllFieldsCovered(t *testing.T) {
+	got := reflect.TypeOf(repoData{}).NumField()
+	if got != mergedRepoDataFieldCount {
+		t.Fatalf(
+			"repoData has %d fields but mergeRepoData claims to merge %d. "+
+				"A new field was added to repoData without extending "+
+				"mergeRepoData — the new field's concurrent peer-process "+
+				"updates would be silently lost. "+
+				"Update mergeRepoData to merge the new field, then bump "+
+				"mergedRepoDataFieldCount in config.go.",
+			got, mergedRepoDataFieldCount,
+		)
+	}
+}
+
+// TestConfig_ConcurrentSave_DifferentRepos_NoLostUpdates pins the
+// global config equivalent of TestStackConfig_ConcurrentSave_SameRepo:
+// two `ezs config set` runs from different terminals should both
+// survive when they target *different* repos. Pre-fix, Config.Save did
+// a naked Load → mutate → write with no lock or merge — A's read of
+// disk happened before B's write, A's write clobbered B's repo entry.
+func TestConfig_ConcurrentSave_DifferentRepos_NoLostUpdates(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	// Seed an empty config so both goroutines load a real file.
+	seed := &Config{Repos: map[string]*RepoConfig{}}
+	if err := seed.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	const N = 8
+	var wg sync.WaitGroup
+	wg.Add(N)
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			cfg, err := Load()
+			if err != nil {
+				errs <- err
+				return
+			}
+			repo := filepath.Join("/test/repo/", string(rune('A'+i)))
+			cfg.SetRepoConfig(repo, &RepoConfig{
+				WorktreeBaseDir:   "/wt/" + string(rune('A'+i)),
+				DefaultBaseBranch: "main",
+			})
+			if err := cfg.Save(); err != nil {
+				errs <- err
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Errorf("save error: %v", e)
+	}
+
+	final, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < N; i++ {
+		repo := filepath.Join("/test/repo/", string(rune('A'+i)))
+		rc := final.GetRepoConfig(repo)
+		if rc == nil {
+			t.Errorf("repo %s lost — Config.Save races dropped a peer's update", repo)
+			continue
+		}
+		want := "/wt/" + string(rune('A'+i))
+		if rc.WorktreeBaseDir != want {
+			t.Errorf("repo %s: WorktreeBaseDir = %q, want %q", repo, rc.WorktreeBaseDir, want)
+		}
+	}
+}
+
+// TestConfig_Save_PreservesPeerAddedRepos verifies the merge: process A
+// loads, process B loads, both add to the Repos map for *different*
+// keys, both Save. Final disk state must contain BOTH entries. Pre-fix,
+// whichever wrote second would carry only its own Repos map (its
+// in-memory copy, captured before B's write landed) and silently delete
+// the peer's entry.
+func TestConfig_Save_PreservesPeerAddedRepos(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	// A and B each load before either has saved.
+	a, _ := Load()
+	b, _ := Load()
+
+	a.SetRepoConfig("/repo/a", &RepoConfig{WorktreeBaseDir: "/wt/a"})
+	b.SetRepoConfig("/repo/b", &RepoConfig{WorktreeBaseDir: "/wt/b"})
+
+	// A saves first, then B. With the merge, B's save reloads A's data
+	// under the lock and preserves it. Without the merge, B writes only
+	// /repo/b and silently deletes /repo/a.
+	if err := a.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	final, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.GetRepoConfig("/repo/a") == nil {
+		t.Error("/repo/a lost after B's save — peer addition was clobbered")
+	}
+	if final.GetRepoConfig("/repo/b") == nil {
+		t.Error("/repo/b lost after B's save — own write didn't land")
+	}
+}
+
+// TestConfig_Save_LockDoesNotBlockSingleProcess covers the basic shape:
+// repeated saves from the same process succeed back-to-back. A
+// regression that forgot to release the lock would deadlock on the
+// second save.
+func TestConfig_Save_LockDoesNotBlockSingleProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	cfg, _ := Load()
+	cfg.DefaultBaseBranch = "main"
+	for i := 0; i < 5; i++ {
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("save #%d: %v", i, err)
+		}
+	}
+}
+
+// TestCacheConfig_Save_MergesPeerAddedBranches: the audit's H8 — pre-
+// fix, CacheConfig.Save did `rd.Branches = cc.Branches`, wholesale
+// replacing the disk's branches map. A peer that added a different
+// branch entry between our load and save would have its addition
+// silently dropped. The fix uses a three-way merge keyed on the
+// origBranches snapshot captured at load time.
+func TestCacheConfig_Save_MergesPeerAddedBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	const repo = "/test/repo"
+
+	// Seed an entry so LoadCacheConfig has something to snapshot.
+	if err := MutateBranchCache(repo, "seed", func(_ *BranchCache) (*BranchCache, error) {
+		return &BranchCache{WorktreePath: "/wt/seed"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := LoadCacheConfig(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// While we hold cc in memory (without yet saving), a peer adds a
+	// totally separate branch via the canonical narrow-update path.
+	if err := MutateBranchCache(repo, "peer-only", func(_ *BranchCache) (*BranchCache, error) {
+		return &BranchCache{WorktreePath: "/wt/peer", PRUrl: "https://example.com/pull/99"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// We modify our own branch and Save. The peer's "peer-only" entry
+	// must survive — that's the production-grade promise.
+	cc.SetBranchCache("ours", &BranchCache{WorktreePath: "/wt/ours"})
+	if err := cc.Save(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	final, err := LoadCacheConfig(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.GetBranchCache("seed") == nil {
+		t.Error("seed entry lost — original branches map was clobbered")
+	}
+	if final.GetBranchCache("ours") == nil {
+		t.Error("ours not persisted — own write didn't land")
+	}
+	if final.GetBranchCache("peer-only") == nil {
+		t.Error("peer-only lost — peer addition was clobbered (the H8 regression)")
+	}
+}
+
+// TestCacheConfig_Save_DeleteSurvivesPeerAdd: when we explicitly drop a
+// branch from cc.Branches but a peer added a *different* branch in the
+// same window, our deletion still applies (we know we deleted because
+// origBranches has it and Branches doesn't) and the peer's add still
+// survives.
+func TestCacheConfig_Save_DeleteSurvivesPeerAdd(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	const repo = "/test/repo"
+	if err := MutateBranchCache(repo, "to-delete", func(_ *BranchCache) (*BranchCache, error) {
+		return &BranchCache{WorktreePath: "/wt/to-delete"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, _ := LoadCacheConfig(repo)
+	delete(cc.Branches, "to-delete")
+
+	if err := MutateBranchCache(repo, "peer-only", func(_ *BranchCache) (*BranchCache, error) {
+		return &BranchCache{WorktreePath: "/wt/peer"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cc.Save(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	final, _ := LoadCacheConfig(repo)
+	if final.GetBranchCache("to-delete") != nil {
+		t.Error("to-delete still present — our explicit deletion was lost")
+	}
+	if final.GetBranchCache("peer-only") == nil {
+		t.Error("peer-only lost — peer addition clobbered alongside our delete")
+	}
+}
+
+// TestLoadStackConfig_MigrationDoesNotRaceWithConcurrentLoads: two
+// processes opening an old-version stacks.json simultaneously must not
+// produce a torn write. Both will compute the same migrated bytes, but
+// without the lock the writes could interleave at the OS layer (atomic
+// rename only buys us "atomic at the rename boundary", not "no
+// duplicated effort"). Verify that after N concurrent loads, the file
+// version is current and the content is parseable.
+func TestLoadStackConfig_MigrationDoesNotRaceWithConcurrentLoads(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	// Seed a v1 stacks.json (oldest format the migration chain handles).
+	v1 := stackConfigFile{Version: 1, Repos: map[string]*repoData{
+		"/repo": {Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}},
+	}}
+	data, _ := json.MarshalIndent(v1, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "stacks.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	const N = 16
+	var wg sync.WaitGroup
+	wg.Add(N)
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := LoadStackConfig("/repo"); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Errorf("concurrent migration load: %v", e)
+	}
+
+	// Verify final disk state is valid and at the current version.
+	finalData, err := os.ReadFile(filepath.Join(tmpDir, "stacks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var f stackConfigFile
+	if err := json.Unmarshal(finalData, &f); err != nil {
+		t.Fatalf("post-migration file does not parse: %v\n%s", err, finalData)
+	}
+	if f.Version != currentStackConfigVersion {
+		t.Errorf("file version = %d, want %d (migration didn't complete)", f.Version, currentStackConfigVersion)
+	}
+}

--- a/internal/config/config_audit_test.go
+++ b/internal/config/config_audit_test.go
@@ -1,12 +1,16 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestMergeRepoData_AllFieldsCovered is a "tripwire" guard. The
@@ -32,6 +36,27 @@ func TestMergeRepoData_AllFieldsCovered(t *testing.T) {
 				"Update mergeRepoData to merge the new field, then bump "+
 				"mergedRepoDataFieldCount in config.go.",
 			got, mergedRepoDataFieldCount,
+		)
+	}
+}
+
+// TestMergeGlobalConfig_AllFieldsCovered is the same tripwire for the
+// top-level Config struct. The original PR added a tripwire for repoData
+// only; if a future contributor adds (say) a Telemetry or Notifications
+// field to Config and forgets to extend mergeGlobalConfig, two parallel
+// `ezs config set` runs would silently drop one writer's update. Failing
+// the build is cheaper than discovering this in production.
+func TestMergeGlobalConfig_AllFieldsCovered(t *testing.T) {
+	got := reflect.TypeOf(Config{}).NumField()
+	if got != mergedGlobalConfigFieldCount {
+		t.Fatalf(
+			"Config has %d fields but mergeGlobalConfig claims to merge %d. "+
+				"A new field was added to Config without extending "+
+				"mergeGlobalConfig — concurrent peer-process updates of "+
+				"the new field would be silently dropped. "+
+				"Update mergeGlobalConfig and bump "+
+				"mergedGlobalConfigFieldCount in config.go.",
+			got, mergedGlobalConfigFieldCount,
 		)
 	}
 }
@@ -297,5 +322,90 @@ func TestLoadStackConfig_MigrationDoesNotRaceWithConcurrentLoads(t *testing.T) {
 	}
 	if f.Version != currentStackConfigVersion {
 		t.Errorf("file version = %d, want %d (migration didn't complete)", f.Version, currentStackConfigVersion)
+	}
+}
+
+// TestLoadStackConfig_MigrationLockTimeout_DoesNotRaceUnlockedWrite pins the
+// fix for a subtle bug: the original migration code fell back to an UNLOCKED
+// atomicWriteFile on any acquireFileLock error, including the
+// "timed out waiting for peer" case. That defeated the migration lock — two
+// processes could time each other out and both write concurrently.
+//
+// The fix distinguishes ErrLockTimeout (peer holds it; skip our persist;
+// migration is idempotent so peer's write will land) from "lock subsystem
+// broken" (open errors, etc.; fall back to unlocked write because the lock
+// is unusable anyway). This test simulates the timeout case by holding the
+// lock from a parallel goroutine for longer than LockTimeout, then verifies:
+//
+//  1. LoadStackConfig still returns success (no error propagated to caller)
+//  2. The disk file is NOT touched by us during the window where the peer
+//     holds it (no torn write). The peer's eventual release+write produces
+//     the only on-disk persistence.
+//
+// We use a short LockTimeout (50ms) and LockPollInterval (5ms) so the test
+// completes in well under a second.
+func TestLoadStackConfig_MigrationLockTimeout_DoesNotRaceUnlockedWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("EZSTACK_HOME", tmpDir)
+
+	// Seed a v1 stacks.json that needs migration.
+	v1 := stackConfigFile{Version: 1, Repos: map[string]*repoData{
+		"/repo": {Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}},
+	}}
+	data, _ := json.MarshalIndent(v1, "", "  ")
+	stackPath := filepath.Join(tmpDir, "stacks.json")
+	if err := os.WriteFile(stackPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture original lock-tunable values and restore on exit.
+	origTimeout, origPoll := LockTimeout, LockPollInterval
+	defer func() { LockTimeout, LockPollInterval = origTimeout, origPoll }()
+	LockTimeout = 100 * time.Millisecond
+	LockPollInterval = 5 * time.Millisecond
+
+	// Hold the lock from a peer goroutine. Use the actual acquire helper so
+	// tryAcquireFileLockOnce sees the lock as held by another fd.
+	peerLock, err := acquireFileLock(stackPath + ".lock")
+	if err != nil {
+		t.Fatalf("peer acquire: %v", err)
+	}
+
+	// Read disk content NOW so we can compare after the migration attempt.
+	preData, _ := os.ReadFile(stackPath)
+
+	// Capture stderr to verify the user-facing notice fires.
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := LoadStackConfig("/repo")
+		done <- err
+	}()
+
+	loadErr := <-done
+	os.Stderr = origStderr
+	w.Close()
+	stderrBytes, _ := io.ReadAll(r)
+	stderrStr := string(stderrBytes)
+
+	// Release the peer lock so test cleanup is clean.
+	peerLock.release()
+
+	if loadErr != nil {
+		t.Fatalf("LoadStackConfig returned error during peer-held migration: %v", loadErr)
+	}
+
+	// Disk file MUST NOT have been written to during our timeout window —
+	// peer still holds the lock and migration hasn't completed yet.
+	postData, _ := os.ReadFile(stackPath)
+	if !bytes.Equal(preData, postData) {
+		t.Errorf("disk file was modified during peer-held migration window — unlocked-fallback regression. before=%d bytes, after=%d bytes", len(preData), len(postData))
+	}
+
+	if !strings.Contains(stderrStr, "peer process is migrating") {
+		t.Errorf("expected user-facing 'peer process is migrating' notice on stderr; got: %q", stderrStr)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -373,6 +373,136 @@ func TestStackConfig_ConcurrentSave_NoLostUpdates(t *testing.T) {
 	}
 }
 
+// TestStackConfig_ConcurrentSave_SameRepo_NoLostUpdates covers the harder
+// race that the existing flock alone could not prevent: two processes
+// touching *different stacks of the same repo*. Before the three-way merge
+// in Save(), the second writer would replace the first writer's stack
+// updates because the in-memory snapshot was stale.
+func TestStackConfig_ConcurrentSave_SameRepo_NoLostUpdates(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "stack-same-repo-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	originalHome := os.Getenv("EZSTACK_HOME")
+	defer os.Setenv("EZSTACK_HOME", originalHome)
+	os.Setenv("EZSTACK_HOME", tmpDir)
+
+	const repo = "/test/sharedRepo"
+
+	// Two writers add disjoint stacks to the same repo's section. With the
+	// pre-merge code, late writers' Save() would clobber early writers' new
+	// stacks because the in-memory map didn't include them.
+	const iters = 20
+	done := make(chan error, 2)
+	worker := func(prefix string) {
+		for i := 0; i < iters; i++ {
+			sc, err := LoadStackConfig(repo)
+			if err != nil {
+				done <- err
+				return
+			}
+			name := prefix + "-" + string(rune('a'+i))
+			hash := GenerateStackHash(name)
+			sc.Stacks[hash] = &Stack{
+				Hash: hash,
+				Root: "main",
+				Tree: BranchTree{name: BranchTree{}},
+			}
+			if err := sc.Save(repo); err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- nil
+	}
+	go worker("alpha")
+	go worker("beta")
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("worker error: %v", err)
+		}
+	}
+
+	final, _ := LoadStackConfig(repo)
+	if len(final.Stacks) != iters*2 {
+		t.Errorf("repo has %d stacks, want %d — concurrent same-repo save lost updates", len(final.Stacks), iters*2)
+	}
+}
+
+// TestMergeRepoData_ThreeWayMerge spot-checks the merge logic in isolation
+// since same-repo concurrency relies on it being correct for additions,
+// modifications, deletions, and "we didn't touch it" cases.
+func TestMergeRepoData_ThreeWayMerge(t *testing.T) {
+	mkStack := func(hash, root string) *Stack {
+		return &Stack{Hash: hash, Root: root, Tree: BranchTree{}}
+	}
+
+	t.Run("we add a stack — keep it", func(t *testing.T) {
+		orig := &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+		mine := &repoData{Stacks: map[string]*Stack{"aaa": mkStack("aaa", "main")}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(orig, mine, theirs)
+		if _, ok := got.Stacks["aaa"]; !ok {
+			t.Fatal("our addition was dropped")
+		}
+	})
+
+	t.Run("they added a stack we never saw — keep theirs", func(t *testing.T) {
+		orig := &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+		mine := &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{"bbb": mkStack("bbb", "main")}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(orig, mine, theirs)
+		if _, ok := got.Stacks["bbb"]; !ok {
+			t.Fatal("their addition was overwritten by our empty state")
+		}
+	})
+
+	t.Run("we modified, they unchanged — keep ours", func(t *testing.T) {
+		orig := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		modified := mkStack("x", "develop")
+		mine := &repoData{Stacks: map[string]*Stack{"x": modified}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(orig, mine, theirs)
+		if got.Stacks["x"].Root != "develop" {
+			t.Fatalf("our modification was lost; got root=%q", got.Stacks["x"].Root)
+		}
+	})
+
+	t.Run("we unchanged, they modified — keep theirs", func(t *testing.T) {
+		orig := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		mine := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "develop")}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(orig, mine, theirs)
+		if got.Stacks["x"].Root != "develop" {
+			t.Fatalf("theirs modification was clobbered by our untouched copy; got root=%q", got.Stacks["x"].Root)
+		}
+	})
+
+	t.Run("we deleted, they unchanged — stays deleted", func(t *testing.T) {
+		orig := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		mine := &repoData{Stacks: map[string]*Stack{}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(orig, mine, theirs)
+		if _, ok := got.Stacks["x"]; ok {
+			t.Fatal("our deletion was reverted by their unchanged copy")
+		}
+	})
+
+	t.Run("nil orig is treated as empty (fresh config)", func(t *testing.T) {
+		mine := &repoData{Stacks: map[string]*Stack{"x": mkStack("x", "main")}, Branches: map[string]*BranchCache{}}
+		theirs := &repoData{Stacks: map[string]*Stack{"y": mkStack("y", "main")}, Branches: map[string]*BranchCache{}}
+		got := mergeRepoData(nil, mine, theirs)
+		if _, ok := got.Stacks["x"]; !ok {
+			t.Fatal("our addition was lost when orig was nil")
+		}
+		if _, ok := got.Stacks["y"]; !ok {
+			t.Fatal("their addition was lost when orig was nil")
+		}
+	})
+}
+
 func TestStackConfig_LoadSave(t *testing.T) {
 	// Create a temp directory for config
 	tmpDir, err := os.MkdirTemp("", "stack-config-test-*")
@@ -1293,5 +1423,42 @@ func TestMutateBranchCache_PreservesNonPRFields(t *testing.T) {
 	}
 	if bc.WorktreePath != "/wt/feature" || !bc.IsRemote || bc.Remote != "fork" {
 		t.Errorf("non-PR fields touched: %+v", bc)
+	}
+}
+
+// TestRemoveBranchFromTree_PreservesSiblingSubtree covers the case where the
+// branch we remove has a child whose name collides with an existing sibling
+// at the parent level. Without the merge, the existing sibling's subtree
+// would be silently overwritten and any branches under it dropped.
+func TestRemoveBranchFromTree_PreservesSiblingSubtree(t *testing.T) {
+	s := &Stack{
+		Hash: "abc1234",
+		Root: "main",
+		Tree: BranchTree{
+			"feat-A": BranchTree{
+				"feat-shared": BranchTree{
+					"feat-A-grandchild": BranchTree{},
+				},
+			},
+			"feat-shared": BranchTree{
+				"feat-shared-grandchild": BranchTree{},
+			},
+		},
+	}
+
+	s.RemoveBranch("feat-A")
+
+	shared, ok := s.Tree["feat-shared"]
+	if !ok {
+		t.Fatal("feat-shared was removed entirely; expected the merged subtree to survive")
+	}
+	if _, ok := shared["feat-shared-grandchild"]; !ok {
+		t.Error("original feat-shared-grandchild was lost; the existing subtree was clobbered")
+	}
+	if _, ok := shared["feat-A-grandchild"]; !ok {
+		t.Error("feat-A-grandchild was not reparented under feat-shared")
+	}
+	if _, ok := s.Tree["feat-A"]; ok {
+		t.Error("feat-A is still in the tree")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -501,6 +501,133 @@ func TestMergeRepoData_ThreeWayMerge(t *testing.T) {
 			t.Fatal("their addition was lost when orig was nil")
 		}
 	})
+
+	t.Run("same-stack concurrent edit fires MergeConflictHook", func(t *testing.T) {
+		// Both we and they modified stack "x" relative to orig in *different*
+		// ways. Last-writer-wins is documented behavior, but the hook must
+		// fire so the loss isn't silent.
+		var got []string
+		prev := MergeConflictHook
+		MergeConflictHook = func(kind, key string) { got = append(got, kind+":"+key) }
+		defer func() { MergeConflictHook = prev }()
+
+		orig := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "main")},
+			Branches: map[string]*BranchCache{},
+		}
+		mine := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "develop")},
+			Branches: map[string]*BranchCache{},
+		}
+		theirs := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "release")},
+			Branches: map[string]*BranchCache{},
+		}
+		merged := mergeRepoData(orig, mine, theirs)
+		if merged.Stacks["x"].Root != "develop" {
+			t.Errorf("last-writer-wins broke: got root=%q, want %q", merged.Stacks["x"].Root, "develop")
+		}
+		if len(got) != 1 || got[0] != "stack:x" {
+			t.Errorf("hook calls = %v, want exactly [\"stack:x\"]", got)
+		}
+	})
+
+	t.Run("different-stack concurrent edits do NOT fire hook", func(t *testing.T) {
+		// We modify x; they modify y. Neither overwrote the other — no
+		// conflict, no hook. False positives here would noisify every save.
+		var got []string
+		prev := MergeConflictHook
+		MergeConflictHook = func(kind, key string) { got = append(got, kind+":"+key) }
+		defer func() { MergeConflictHook = prev }()
+
+		orig := &repoData{
+			Stacks: map[string]*Stack{
+				"x": mkStack("x", "main"),
+				"y": mkStack("y", "main"),
+			},
+			Branches: map[string]*BranchCache{},
+		}
+		mine := &repoData{
+			Stacks: map[string]*Stack{
+				"x": mkStack("x", "develop"),
+				"y": mkStack("y", "main"), // unchanged
+			},
+			Branches: map[string]*BranchCache{},
+		}
+		theirs := &repoData{
+			Stacks: map[string]*Stack{
+				"x": mkStack("x", "main"), // unchanged
+				"y": mkStack("y", "release"),
+			},
+			Branches: map[string]*BranchCache{},
+		}
+		merged := mergeRepoData(orig, mine, theirs)
+		if merged.Stacks["x"].Root != "develop" || merged.Stacks["y"].Root != "release" {
+			t.Errorf("merge failed to preserve disjoint edits: %+v", merged.Stacks)
+		}
+		if len(got) != 0 {
+			t.Errorf("hook fired on disjoint edits: %v", got)
+		}
+	})
+
+	t.Run("identical concurrent edit does NOT fire hook", func(t *testing.T) {
+		// We and they made the *same* change. There's no information loss
+		// — the hook should not fire.
+		var got []string
+		prev := MergeConflictHook
+		MergeConflictHook = func(kind, key string) { got = append(got, kind+":"+key) }
+		defer func() { MergeConflictHook = prev }()
+
+		orig := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "main")},
+			Branches: map[string]*BranchCache{},
+		}
+		mine := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "develop")},
+			Branches: map[string]*BranchCache{},
+		}
+		theirs := &repoData{
+			Stacks:   map[string]*Stack{"x": mkStack("x", "develop")},
+			Branches: map[string]*BranchCache{},
+		}
+		_ = mergeRepoData(orig, mine, theirs)
+		if len(got) != 0 {
+			t.Errorf("hook fired on identical edits: %v", got)
+		}
+	})
+
+	t.Run("same-branch concurrent edit fires hook with kind=branch", func(t *testing.T) {
+		var got []string
+		prev := MergeConflictHook
+		MergeConflictHook = func(kind, key string) { got = append(got, kind+":"+key) }
+		defer func() { MergeConflictHook = prev }()
+
+		orig := &repoData{
+			Stacks: map[string]*Stack{},
+			Branches: map[string]*BranchCache{
+				"feat": {PRUrl: "u0", PRState: "OPEN"},
+			},
+		}
+		mine := &repoData{
+			Stacks: map[string]*Stack{},
+			Branches: map[string]*BranchCache{
+				"feat": {PRUrl: "u-mine", PRState: "OPEN"},
+			},
+		}
+		theirs := &repoData{
+			Stacks: map[string]*Stack{},
+			Branches: map[string]*BranchCache{
+				"feat": {PRUrl: "u-theirs", PRState: "OPEN"},
+			},
+		}
+		merged := mergeRepoData(orig, mine, theirs)
+		if merged.Branches["feat"].PRUrl != "u-mine" {
+			t.Errorf("last-writer-wins broke for branch: %+v", merged.Branches["feat"])
+		}
+		if len(got) != 1 || got[0] != "branch:feat" {
+			t.Errorf("hook calls = %v, want exactly [\"branch:feat\"]", got)
+		}
+	})
 }
 
 func TestStackConfig_LoadSave(t *testing.T) {

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// errLockHeld is the sentinel returned by tryAcquireFileLockOnce when the
+// lock file exists but another process is holding it. Anything else from
+// the platform helper is treated as a real failure (open() error, fd
+// exhaustion, ENOENT on the parent dir, etc.) and surfaced verbatim.
+var errLockHeld = errors.New("lock held by another process")
+
+// LockWaitNotice is the duration we'll silently wait for the lock before
+// printing a "waiting" message to stderr. Tunable for tests.
+var LockWaitNotice = 2 * time.Second
+
+// LockTimeout is the absolute ceiling on how long acquireFileLock will
+// wait before giving up. Without this, a wedged ezstack process (debugger,
+// SIGSTOP, NFS hang) would hang every future invocation forever. Tunable
+// for tests.
+var LockTimeout = 60 * time.Second
+
+// LockPollInterval is the gap between non-blocking acquisition attempts
+// while waiting. 50ms keeps CPU well under 1% even if many clients are
+// queued, and bounds the wakeup latency when the holder releases.
+var LockPollInterval = 50 * time.Millisecond
+
+// acquireFileLock opens (creating if necessary) the lock file at path and
+// acquires an exclusive lock on it. The first attempt is non-blocking; if
+// another process holds the lock, we poll every LockPollInterval until we
+// succeed or LockTimeout elapses, printing a one-time notice after
+// LockWaitNotice so an interactive caller can tell whether ezs is hung
+// vs. waiting on a peer.
+//
+// On timeout the returned error names the lock path and points the user at
+// the recovery action (kill the stale ezs / delete the lock file). This
+// is deliberately a hard failure rather than fallback to "best effort save"
+// because skipping the lock would resurrect the load-modify-save race the
+// lock exists to prevent.
+func acquireFileLock(path string) (*fileLock, error) {
+	deadline := time.Now().Add(LockTimeout)
+	noticeAt := time.Now().Add(LockWaitNotice)
+	noticed := false
+
+	for {
+		l, err := tryAcquireFileLockOnce(path)
+		if err == nil {
+			return l, nil
+		}
+		if !errors.Is(err, errLockHeld) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf(
+				"timed out after %s waiting for lock %s — another ezs process appears stuck. "+
+					"Check `ps` for hung ezs processes; if none, delete the lock file and retry",
+				LockTimeout, path,
+			)
+		}
+		if !noticed && time.Now().After(noticeAt) {
+			noticed = true
+			fmt.Fprintf(os.Stderr, "ezs: waiting for stacks.json lock (held by another ezs process)...\n")
+		}
+		time.Sleep(LockPollInterval)
+	}
+}

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -13,6 +13,14 @@ import (
 // exhaustion, ENOENT on the parent dir, etc.) and surfaced verbatim.
 var errLockHeld = errors.New("lock held by another process")
 
+// ErrLockTimeout is returned by acquireFileLock when LockTimeout elapses
+// while a peer process actively holds the lock. Callers can distinguish
+// this from "lock subsystem broken" failures (open errors, permission
+// denied) so they can decide whether unlocked-fallback is appropriate.
+// In particular, the LoadStackConfig migration path uses this to skip
+// the persist step rather than racing the peer with an unlocked write.
+var ErrLockTimeout = errors.New("timed out waiting for lock held by another process")
+
 // LockWaitNotice is the duration we'll silently wait for the lock before
 // printing a "waiting" message to stderr. Tunable for tests.
 var LockWaitNotice = 2 * time.Second
@@ -55,9 +63,9 @@ func acquireFileLock(path string) (*fileLock, error) {
 		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf(
-				"timed out after %s waiting for lock %s — another ezs process appears stuck. "+
+				"%w: %s after %s — another ezs process appears stuck. "+
 					"Check `ps` for hung ezs processes; if none, delete the lock file and retry",
-				LockTimeout, path,
+				ErrLockTimeout, path, LockTimeout,
 			)
 		}
 		if !noticed && time.Now().After(noticeAt) {

--- a/internal/config/lock_test.go
+++ b/internal/config/lock_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAcquireFileLock_SerialAcquireRelease is the cheapest possible smoke
+// test: acquire, release, acquire again. Catches a regression where the
+// release path leaks the underlying flock so the second acquire would
+// block forever (or hit the timeout path).
+func TestAcquireFileLock_SerialAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	for i := 0; i < 3; i++ {
+		l, err := acquireFileLock(path)
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		l.release()
+	}
+}
+
+// TestAcquireFileLock_BlocksUntilHolderReleases verifies the polling
+// behavior: when the lock is held, a second acquire blocks until the
+// first releases (within the polling interval), and then succeeds.
+//
+// We don't assert exact timing because CI is noisy, but we do assert that
+// the second acquire ran *after* the holder released — otherwise the lock
+// isn't actually serializing access.
+func TestAcquireFileLock_BlocksUntilHolderReleases(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	l1, err := acquireFileLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// Tighten the polling interval and notice/timeout for the test so we
+	// don't spend 60s on the timeout path if something regresses.
+	origPoll, origNotice, origTimeout := LockPollInterval, LockWaitNotice, LockTimeout
+	LockPollInterval = 5 * time.Millisecond
+	LockWaitNotice = 100 * time.Millisecond
+	LockTimeout = 5 * time.Second
+	defer func() {
+		LockPollInterval, LockWaitNotice, LockTimeout = origPoll, origNotice, origTimeout
+	}()
+
+	releasedAt := make(chan time.Time, 1)
+	acquiredAt := make(chan time.Time, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l2, err := acquireFileLock(path)
+		acquiredAt <- time.Now()
+		if err != nil {
+			t.Errorf("second acquire: %v", err)
+			return
+		}
+		l2.release()
+	}()
+
+	// Hold for ~50ms so the second acquire definitely starts polling.
+	time.Sleep(50 * time.Millisecond)
+	releasedAt <- time.Now()
+	l1.release()
+
+	wg.Wait()
+
+	rel := <-releasedAt
+	acq := <-acquiredAt
+	if !acq.After(rel) {
+		t.Errorf("second acquire returned at %v but holder released at %v — lock didn't serialize", acq, rel)
+	}
+}
+
+// TestAcquireFileLock_TimesOutOnStuckHolder verifies the hard timeout
+// path: if the holder never releases, the second acquire returns a
+// timeout error rather than hanging forever. The error message must point
+// at the lock path so a user knows what to clean up.
+func TestAcquireFileLock_TimesOutOnStuckHolder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stuck.lock")
+
+	holder, err := acquireFileLock(path)
+	if err != nil {
+		t.Fatalf("holder acquire: %v", err)
+	}
+	defer holder.release()
+
+	origPoll, origNotice, origTimeout := LockPollInterval, LockWaitNotice, LockTimeout
+	LockPollInterval = 5 * time.Millisecond
+	LockWaitNotice = 1 * time.Hour // suppress notice line in test output
+	LockTimeout = 100 * time.Millisecond
+	defer func() {
+		LockPollInterval, LockWaitNotice, LockTimeout = origPoll, origNotice, origTimeout
+	}()
+
+	start := time.Now()
+	_, err = acquireFileLock(path)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed < LockTimeout {
+		t.Errorf("returned in %v, want at least %v", elapsed, LockTimeout)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("returned in %v, way past timeout %v — polling loop may be unbounded", elapsed, LockTimeout)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("timeout error %q should name the lock path %q", err.Error(), path)
+	}
+	if !strings.Contains(err.Error(), "stuck") && !strings.Contains(err.Error(), "another ezs") {
+		t.Errorf("timeout error %q should hint at stale-lock recovery", err.Error())
+	}
+}
+
+// TestAcquireFileLock_PropagatesNonHeldErrors verifies that errors
+// other than "lock held" (e.g. permission denied on the parent dir) are
+// returned immediately rather than being retried — the caller can't fix
+// them by waiting.
+func TestAcquireFileLock_PropagatesNonHeldErrors(t *testing.T) {
+	// Use a path inside a non-existent directory. OpenFile returns an
+	// error that isn't errLockHeld, so acquireFileLock must surface it
+	// without entering the poll loop.
+	bogus := filepath.Join(t.TempDir(), "no", "such", "dir", "test.lock")
+
+	origTimeout := LockTimeout
+	LockTimeout = 5 * time.Second // generous; failure should be near-instant
+	defer func() { LockTimeout = origTimeout }()
+
+	start := time.Now()
+	_, err := acquireFileLock(bogus)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error opening lock file in bogus path, got nil")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("took %v to fail — non-held errors should not retry, but should return immediately", elapsed)
+	}
+}

--- a/internal/config/lock_unix.go
+++ b/internal/config/lock_unix.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -15,13 +16,20 @@ type fileLock struct {
 	f *os.File
 }
 
-func acquireFileLock(path string) (*fileLock, error) {
+// tryAcquireFileLockOnce attempts a single non-blocking flock. Returns
+// errLockHeld if another process owns the lock; any other error indicates
+// a real failure (e.g. permissions, parent dir missing). The shared
+// acquireFileLock in lock.go wraps this in a poll/timeout loop.
+func tryAcquireFileLockOnce(path string) (*fileLock, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, errLockHeld
+		}
 		return nil, err
 	}
 	return &fileLock{f: f}, nil

--- a/internal/config/lock_windows.go
+++ b/internal/config/lock_windows.go
@@ -23,13 +23,21 @@ type fileLock struct {
 const lockBytesLow = 0xFFFFFFFF
 const lockBytesHigh = 0xFFFFFFFF
 
-func acquireFileLock(path string) (*fileLock, error) {
+// tryAcquireFileLockOnce attempts a single non-blocking LockFileEx.
+// Returns errLockHeld if another process owns the lock; any other error
+// indicates a real failure. The shared acquireFileLock in lock.go wraps
+// this in a poll/timeout loop so callers get a consistent wait/timeout
+// experience across platforms.
+func tryAcquireFileLockOnce(path string) (*fileLock, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return nil, err
 	}
-	if err := lockHandle(windows.Handle(f.Fd()), false); err != nil {
+	if err := lockHandle(windows.Handle(f.Fd()), true); err != nil {
 		f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, errLockHeld
+		}
 		return nil, err
 	}
 	return &fileLock{f: f}, nil

--- a/internal/git/commits.go
+++ b/internal/git/commits.go
@@ -164,6 +164,11 @@ func (g *Git) HasUnresolvedConflicts() (bool, error) {
 
 // Push pushes the current branch to the specified remote.
 // If remote is empty, defaults to "origin".
+//
+// Deprecated: prefer PushBranch(branchName, force, remote). Push consults
+// CurrentBranch() at call time, which means after a transient checkout (e.g.
+// the syncViaCheckout codepath that restores HEAD to main) it will push the
+// wrong branch. New callers should pass an explicit branch name.
 func (g *Git) Push(force bool, remote ...string) error {
 	r := "origin"
 	if len(remote) > 0 && remote[0] != "" {
@@ -196,8 +201,11 @@ func (g *Git) PushBranch(branch string, force bool, remote ...string) error {
 	return g.RunInteractive(args...)
 }
 
-// PushSetUpstream pushes and sets upstream.
+// PushSetUpstream pushes and sets upstream for the current branch.
 // If remote is empty, defaults to "origin".
+//
+// Deprecated: prefer PushBranchSetUpstream(branch, remote) — see Push for the
+// reasoning.
 func (g *Git) PushSetUpstream(remote ...string) error {
 	r := "origin"
 	if len(remote) > 0 && remote[0] != "" {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -428,16 +428,22 @@ func (g *Git) GetDiffStat(base, head string) (added int, removed int, err error)
 // IsLocalAheadOfRemote checks if the local branch has commits not in the remote.
 // If remote is empty, defaults to "origin".
 // Returns true if local is ahead (needs push), false if in sync or behind.
+//
+// Distinguishes "remote ref doesn't exist" (treat as ahead — first push) from
+// transient or unrelated rev-parse failures (lock contention, repo corruption,
+// bad ref name) which are surfaced as errors. Returning (true, nil) on any
+// error would let downstream code push to a remote ref that may not be the
+// one we expected.
 func (g *Git) IsLocalAheadOfRemote(branch string, remote string) (bool, error) {
 	if remote == "" {
 		remote = "origin"
 	}
 	remoteBranch := remote + "/" + branch
-	// Check if remote branch exists
-	_, err := g.run("rev-parse", "--verify", remoteBranch)
-	if err != nil {
-		// Remote branch doesn't exist - local is ahead (needs first push)
-		return true, nil
+	if _, err := g.run("rev-parse", "--verify", remoteBranch); err != nil {
+		if isMissingRefError(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("rev-parse %s: %w", remoteBranch, err)
 	}
 	ahead, err := g.GetCommitsAhead(branch, remoteBranch)
 	if err != nil {
@@ -446,16 +452,46 @@ func (g *Git) IsLocalAheadOfRemote(branch string, remote string) (bool, error) {
 	return ahead > 0, nil
 }
 
+// isMissingRefError returns true if err's message looks like git's
+// "ref not found" output from `rev-parse --verify`. Git emits one of:
+//
+//	"fatal: Needed a single revision"
+//	"fatal: ambiguous argument 'X': unknown revision or path not in the working tree."
+//	"fatal: bad revision 'X'"
+//
+// These all mean "the ref doesn't exist". Anything else (lock contention,
+// repo corruption, transient errors) is propagated as a real error so the
+// caller can decide how to react.
+func isMissingRefError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unknown revision") ||
+		strings.Contains(msg, "Needed a single revision") ||
+		strings.Contains(msg, "bad revision") ||
+		strings.Contains(msg, "not a valid object name")
+}
+
 // IsLocalAheadOfOrigin checks if the local branch has commits not in origin.
 // Deprecated: Use IsLocalAheadOfRemote instead.
 func (g *Git) IsLocalAheadOfOrigin(branch string) (bool, error) {
 	return g.IsLocalAheadOfRemote(branch, "origin")
 }
 
-// RemoteBranchExists checks if a remote branch exists
+// RemoteBranchExists checks if a branch exists on `origin`.
+// Use RemoteHasBranch when the remote may not be `origin` (e.g. fork remotes).
 func (g *Git) RemoteBranchExists(branch string) bool {
-	originBranch := "origin/" + branch
-	_, err := g.run("rev-parse", "--verify", originBranch)
+	return g.RemoteHasBranch("origin", branch)
+}
+
+// RemoteHasBranch checks if `branch` exists on the given remote. Defaults to
+// `origin` if remote is empty.
+func (g *Git) RemoteHasBranch(remote, branch string) bool {
+	if remote == "" {
+		remote = "origin"
+	}
+	_, err := g.run("rev-parse", "--verify", remote+"/"+branch)
 	return err == nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -545,33 +545,46 @@ func ValidateBranchName(name string) error {
 	return nil
 }
 
-// HasDivergedFromOrigin checks if local and remote branches have diverged
-// Returns (hasDiverged, localAhead, remoteBehind, error)
-// hasDiverged is true if both local has commits not in remote AND remote has commits not in local
-func (g *Git) HasDivergedFromOrigin(branch string) (bool, int, int, error) {
-	originBranch := "origin/" + branch
-	// Check if origin branch exists
-	_, err := g.run("rev-parse", "--verify", originBranch)
-	if err != nil {
-		// Origin branch doesn't exist - not diverged, just needs first push
-		return false, 0, 0, nil
+// HasDivergedFromRemote checks if local and remote branches have diverged.
+// Returns (hasDiverged, localAhead, remoteBehind, error). hasDiverged is
+// true only when local has commits not in remote AND remote has commits
+// not in local. If the remote ref doesn't exist yet, returns (false, 0, 0,
+// nil) — the branch just hasn't been pushed. Other rev-parse failures are
+// surfaced as errors so callers can distinguish "no remote yet" from real
+// repo problems. If remote is empty, defaults to "origin".
+func (g *Git) HasDivergedFromRemote(branch, remote string) (bool, int, int, error) {
+	if remote == "" {
+		remote = "origin"
+	}
+	remoteBranch := remote + "/" + branch
+	if _, err := g.run("rev-parse", "--verify", remoteBranch); err != nil {
+		if isMissingRefError(err) {
+			return false, 0, 0, nil
+		}
+		return false, 0, 0, fmt.Errorf("rev-parse %s: %w", remoteBranch, err)
 	}
 
-	// Get commits local has that remote doesn't
-	localAhead, err := g.GetCommitsAhead(branch, originBranch)
+	localAhead, err := g.GetCommitsAhead(branch, remoteBranch)
 	if err != nil {
 		return false, 0, 0, err
 	}
 
-	// Get commits remote has that local doesn't
-	remoteBehind, err := g.GetCommitsBehind(branch, originBranch)
+	remoteBehind, err := g.GetCommitsBehind(branch, remoteBranch)
 	if err != nil {
 		return false, 0, 0, err
 	}
 
-	// Diverged if both have unique commits
 	hasDiverged := localAhead > 0 && remoteBehind > 0
 	return hasDiverged, localAhead, remoteBehind, nil
+}
+
+// HasDivergedFromOrigin is a convenience wrapper for the common case.
+//
+// Deprecated: prefer HasDivergedFromRemote(branch, remote) so callers in
+// fork workflows can target the contributor's fork remote instead of
+// silently inspecting `origin`.
+func (g *Git) HasDivergedFromOrigin(branch string) (bool, int, int, error) {
+	return g.HasDivergedFromRemote(branch, "origin")
 }
 
 // RebaseResult contains the result of a rebase operation
@@ -854,6 +867,11 @@ func (g *Git) FetchRemote(remote string) error {
 
 // PushForce force pushes the current branch with lease (safer than --force).
 // If remote is empty, defaults to "origin".
+//
+// Deprecated: prefer PushForceBranch(branch, remote). PushForce consults
+// CurrentBranch() at call time, which is wrong when the active checkout
+// has been transiently swapped (e.g. syncViaCheckout restored HEAD to
+// main) or when the caller acts on a branch other than HEAD.
 func (g *Git) PushForce(remote ...string) error {
 	r := "origin"
 	if len(remote) > 0 && remote[0] != "" {
@@ -862,6 +880,17 @@ func (g *Git) PushForce(remote ...string) error {
 	branch, err := g.CurrentBranch()
 	if err != nil {
 		return fmt.Errorf("failed to get current branch: %w", err)
+	}
+	return g.RunInteractive("push", "--force-with-lease", r, branch)
+}
+
+// PushForceBranch force-pushes a specific branch with lease (safer than
+// --force). If remote is empty, defaults to "origin". Prefer this over
+// PushForce — it never reads CurrentBranch().
+func (g *Git) PushForceBranch(branch string, remote ...string) error {
+	r := "origin"
+	if len(remote) > 0 && remote[0] != "" {
+		r = remote[0]
 	}
 	return g.RunInteractive("push", "--force-with-lease", r, branch)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -552,6 +552,12 @@ func ValidateBranchName(name string) error {
 // nil) — the branch just hasn't been pushed. Other rev-parse failures are
 // surfaced as errors so callers can distinguish "no remote yet" from real
 // repo problems. If remote is empty, defaults to "origin".
+//
+// Uses a single `git rev-list --left-right --count` invocation so the
+// ahead/behind counts are computed against one consistent snapshot of the
+// object database. The previous two-call form (GetCommitsAhead +
+// GetCommitsBehind) could see a stale upper bound if a concurrent fetch /
+// prune landed between calls.
 func (g *Git) HasDivergedFromRemote(branch, remote string) (bool, int, int, error) {
 	if remote == "" {
 		remote = "origin"
@@ -564,12 +570,7 @@ func (g *Git) HasDivergedFromRemote(branch, remote string) (bool, int, int, erro
 		return false, 0, 0, fmt.Errorf("rev-parse %s: %w", remoteBranch, err)
 	}
 
-	localAhead, err := g.GetCommitsAhead(branch, remoteBranch)
-	if err != nil {
-		return false, 0, 0, err
-	}
-
-	remoteBehind, err := g.GetCommitsBehind(branch, remoteBranch)
+	localAhead, remoteBehind, err := g.GetAheadBehind(branch, remoteBranch)
 	if err != nil {
 		return false, 0, 0, err
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1169,3 +1169,109 @@ func TestHasDivergedFromOrigin_DelegatesToRemote(t *testing.T) {
 		t.Errorf("delegation mismatch: origin=(%v,%d,%d), remote=(%v,%d,%d)", d1, a1, b1, d2, a2, b2)
 	}
 }
+
+// TestRemoteHasBranch_OriginAndFork pins the contract that pushChildBranches
+// uses to gate "never publish a branch the user hasn't shared". Pre-fix, the
+// existence check was hardcoded to origin and would return false for a
+// fork-tracked branch even when the branch did exist on the user's fork —
+// which would either resurrect the silent-publish bug (if the gate's polarity
+// flips) or block legitimate fork pushes.
+//
+// Three cases:
+//  1. Branch exists on origin → RemoteHasBranch("origin", b) == true,
+//     RemoteHasBranch("fork-user", b) == false.
+//  2. Branch exists on a fork remote ("fork-user") but not origin → reverse.
+//  3. Empty remote string → defaults to origin (consistency with the rest of
+//     the API). This is the migration-friendly default; a future caller that
+//     accidentally passes "" still gets the historical origin-only behavior.
+func TestRemoteHasBranch_OriginAndFork(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Two bare remotes: origin and fork-user. Push different branches to each.
+	originBare, err := os.MkdirTemp("", "remote-has-branch-origin-*")
+	if err != nil {
+		t.Fatalf("mkdtemp origin: %v", err)
+	}
+	defer os.RemoveAll(originBare)
+	forkBare, err := os.MkdirTemp("", "remote-has-branch-fork-*")
+	if err != nil {
+		t.Fatalf("mkdtemp fork: %v", err)
+	}
+	defer os.RemoveAll(forkBare)
+
+	for _, b := range []string{originBare, forkBare} {
+		if err := exec.Command("git", "init", "--bare", "-b", "main", b).Run(); err != nil {
+			t.Fatalf("init bare %s: %v", b, err)
+		}
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "origin", originBare).Run(); err != nil {
+		t.Fatalf("add origin: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "fork-user", forkBare).Run(); err != nil {
+		t.Fatalf("add fork-user: %v", err)
+	}
+
+	// Create "shared" on top of main, push to origin.
+	if err := exec.Command("git", "-C", dir, "checkout", "-b", "shared").Run(); err != nil {
+		t.Fatalf("co -b shared: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "s.txt"), []byte("s\n"), 0644); err != nil {
+		t.Fatalf("write s: %v", err)
+	}
+	exec.Command("git", "-C", dir, "add", ".").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "shared").Run()
+	if err := exec.Command("git", "-C", dir, "push", "origin", "shared").Run(); err != nil {
+		t.Fatalf("push shared origin: %v", err)
+	}
+
+	// Create "fork-only" on top of main, push to fork-user only.
+	exec.Command("git", "-C", dir, "checkout", "main").Run()
+	if err := exec.Command("git", "-C", dir, "checkout", "-b", "fork-only").Run(); err != nil {
+		t.Fatalf("co -b fork-only: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("f\n"), 0644); err != nil {
+		t.Fatalf("write f: %v", err)
+	}
+	exec.Command("git", "-C", dir, "add", ".").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "fork-only").Run()
+	if err := exec.Command("git", "-C", dir, "push", "fork-user", "fork-only").Run(); err != nil {
+		t.Fatalf("push fork-only fork-user: %v", err)
+	}
+
+	g := New(dir)
+
+	// Case 1: shared exists on origin only.
+	if !g.RemoteHasBranch("origin", "shared") {
+		t.Errorf("origin/shared should exist, got false")
+	}
+	if g.RemoteHasBranch("fork-user", "shared") {
+		t.Errorf("fork-user/shared should NOT exist, got true")
+	}
+
+	// Case 2: fork-only exists on fork-user only.
+	if g.RemoteHasBranch("origin", "fork-only") {
+		t.Errorf("origin/fork-only should NOT exist, got true")
+	}
+	if !g.RemoteHasBranch("fork-user", "fork-only") {
+		t.Errorf("fork-user/fork-only should exist, got false")
+	}
+
+	// Case 3: empty remote defaults to origin.
+	if !g.RemoteHasBranch("", "shared") {
+		t.Errorf("RemoteHasBranch(\"\", shared) should default to origin and return true")
+	}
+	if g.RemoteHasBranch("", "fork-only") {
+		t.Errorf("RemoteHasBranch(\"\", fork-only) should default to origin and return false")
+	}
+
+	// Case 4: nonexistent branch returns false.
+	if g.RemoteHasBranch("origin", "never-existed") {
+		t.Errorf("RemoteHasBranch on missing branch should return false")
+	}
+
+	// Case 5: nonexistent remote returns false (does NOT panic / error).
+	if g.RemoteHasBranch("ghost-remote", "shared") {
+		t.Errorf("RemoteHasBranch on missing remote should return false")
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1018,3 +1018,154 @@ func TestPushBranchSetUpstream_PushesNamedBranchAndSetsUpstream(t *testing.T) {
 		t.Errorf("branch.feature.merge = %q, want %q", got, "refs/heads/feature")
 	}
 }
+
+// TestPushForceBranch_PushesNamedBranchNotCurrent mirrors the PushBranch
+// regression coverage for the force-with-lease path. PushForce reads
+// CurrentBranch(); PushForceBranch must not.
+func TestPushForceBranch_PushesNamedBranchNotCurrent(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	if out, err := exec.Command("git", "-C", dir, "branch", "feature").CombinedOutput(); err != nil {
+		t.Fatalf("create feature branch: %v: %s", err, out)
+	}
+	if err := exec.Command("git", "-C", dir, "checkout", "feature").Run(); err != nil {
+		t.Fatalf("checkout feature: %v", err)
+	}
+	featureFile := filepath.Join(dir, "feature.txt")
+	if err := os.WriteFile(featureFile, []byte("feature-only\n"), 0644); err != nil {
+		t.Fatalf("write feature.txt: %v", err)
+	}
+	exec.Command("git", "-C", dir, "add", ".").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "feature commit").Run()
+	if err := exec.Command("git", "-C", dir, "checkout", "main").Run(); err != nil {
+		t.Fatalf("checkout main: %v", err)
+	}
+
+	bare, err := os.MkdirTemp("", "push-force-branch-remote-*")
+	if err != nil {
+		t.Fatalf("mkdtemp remote: %v", err)
+	}
+	defer os.RemoveAll(bare)
+	if err := exec.Command("git", "init", "--bare", "-b", "main", bare).Run(); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "origin", bare).Run(); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+
+	g := New(dir)
+	if err := g.PushForceBranch("feature", "origin"); err != nil {
+		t.Fatalf("PushForceBranch(feature): %v", err)
+	}
+
+	if out, err := exec.Command("git", "-C", bare, "rev-parse", "--verify", "refs/heads/feature").CombinedOutput(); err != nil {
+		t.Errorf("feature was not force-pushed: %v: %s", err, out)
+	}
+	if err := exec.Command("git", "-C", bare, "rev-parse", "--verify", "refs/heads/main").Run(); err == nil {
+		t.Error("main was pushed despite PushForceBranch being called with 'feature'; force-push leaked CurrentBranch()")
+	}
+}
+
+// TestHasDivergedFromRemote covers the four states a branch can be in
+// relative to a remote ref: no remote, in-sync, local-ahead, true
+// divergence. Each case is exercised against a non-"origin" remote so the
+// fork-aware path is real, not just a pass-through to HasDivergedFromOrigin.
+func TestHasDivergedFromRemote(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	g := New(dir)
+
+	// No remote yet -> not diverged, no error.
+	diverged, ahead, behind, err := g.HasDivergedFromRemote("main", "fork")
+	if err != nil {
+		t.Fatalf("missing remote returned error: %v", err)
+	}
+	if diverged || ahead != 0 || behind != 0 {
+		t.Errorf("missing remote: got diverged=%v ahead=%d behind=%d, want all zero/false", diverged, ahead, behind)
+	}
+
+	// Set up bare and push main so we have a baseline.
+	bare, err := os.MkdirTemp("", "diverged-remote-*")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(bare)
+	if err := exec.Command("git", "init", "--bare", "-b", "main", bare).Run(); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "fork", bare).Run(); err != nil {
+		t.Fatalf("add fork remote: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "push", "fork", "main").Run(); err != nil {
+		t.Fatalf("push to fork: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "fetch", "fork").Run(); err != nil {
+		t.Fatalf("fetch fork: %v", err)
+	}
+
+	// In-sync -> not diverged, ahead/behind zero.
+	diverged, ahead, behind, err = g.HasDivergedFromRemote("main", "fork")
+	if err != nil {
+		t.Fatalf("in-sync error: %v", err)
+	}
+	if diverged || ahead != 0 || behind != 0 {
+		t.Errorf("in-sync: got diverged=%v ahead=%d behind=%d, want all zero/false", diverged, ahead, behind)
+	}
+
+	// Add a local commit that fork doesn't have -> ahead, not diverged.
+	if err := os.WriteFile(filepath.Join(dir, "local-only.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	exec.Command("git", "-C", dir, "add", ".").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "local only").Run()
+	diverged, ahead, behind, err = g.HasDivergedFromRemote("main", "fork")
+	if err != nil {
+		t.Fatalf("ahead error: %v", err)
+	}
+	if diverged || ahead == 0 || behind != 0 {
+		t.Errorf("local-ahead: got diverged=%v ahead=%d behind=%d, want diverged=false ahead>0 behind=0", diverged, ahead, behind)
+	}
+
+	// Now actually diverge: rewind local main, push a different commit to
+	// fork, fetch, leave local with the old "local only" commit. This is the
+	// hardest path for the function — it must report both ahead AND behind.
+	headBeforeDiverge, _ := g.run("rev-parse", "HEAD")
+	exec.Command("git", "-C", dir, "reset", "--hard", "HEAD~1").Run()
+	if err := os.WriteFile(filepath.Join(dir, "fork-only.txt"), []byte("y\n"), 0644); err != nil {
+		t.Fatalf("write fork-only: %v", err)
+	}
+	exec.Command("git", "-C", dir, "add", ".").Run()
+	exec.Command("git", "-C", dir, "commit", "-m", "fork only").Run()
+	exec.Command("git", "-C", dir, "push", "-f", "fork", "main").Run()
+	exec.Command("git", "-C", dir, "reset", "--hard", strings.TrimSpace(headBeforeDiverge)).Run()
+	exec.Command("git", "-C", dir, "fetch", "fork").Run()
+
+	diverged, ahead, behind, err = g.HasDivergedFromRemote("main", "fork")
+	if err != nil {
+		t.Fatalf("diverged error: %v", err)
+	}
+	if !diverged || ahead == 0 || behind == 0 {
+		t.Errorf("diverged: got diverged=%v ahead=%d behind=%d, want diverged=true ahead>0 behind>0", diverged, ahead, behind)
+	}
+}
+
+// TestHasDivergedFromOrigin_DelegatesToRemote ensures the deprecated
+// wrapper behaves identically to the explicit-remote form for the origin
+// case, so existing callers see no behavior change after the refactor.
+func TestHasDivergedFromOrigin_DelegatesToRemote(t *testing.T) {
+	dir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	g := New(dir)
+
+	d1, a1, b1, err1 := g.HasDivergedFromOrigin("main")
+	d2, a2, b2, err2 := g.HasDivergedFromRemote("main", "origin")
+	if (err1 == nil) != (err2 == nil) {
+		t.Fatalf("error parity: origin err=%v, remote err=%v", err1, err2)
+	}
+	if d1 != d2 || a1 != a2 || b1 != b2 {
+		t.Errorf("delegation mismatch: origin=(%v,%d,%d), remote=(%v,%d,%d)", d1, a1, b1, d2, a2, b2)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -44,11 +44,14 @@ type Client struct {
 // tooling). Repo names with internal dots — `my-repo.io`, `foo.bar` —
 // are preserved; only the literal `.git` suffix is removed.
 //
-// The third capture group `(?:/.*)?$` accepts and discards extra path
-// segments after the repo name. This lets users paste browser URLs like
+// The non-capturing tail `(?:/[^\s#?]*)?(?:[#?].*)?$` accepts and discards
+// extra path segments after the repo name (and a trailing `?query`/`#anchor`).
+// This lets users paste browser URLs like
 // `https://github.com/owner/repo/tree/main` or `.../pull/123` and have
 // the parser extract just `(owner, repo)` instead of failing — the most
-// common ezstack onboarding mistake before this change.
+// common ezstack onboarding mistake before this change. The `[^\s#?]*`
+// inside the path-tail intentionally excludes `?` and `#` so the
+// query/anchor branch can still claim them when present.
 var gitHubURLRe = regexp.MustCompile(`(?i)(?:^|@|//)github\.com(?::\d+)?[:/]([^/\s#?]+)/([^/\s#?]+?)(?:\.git)?(?:/[^\s#?]*)?(?:[#?].*)?$`)
 
 // NewClient creates a new GitHub client by parsing the remote URL.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -25,11 +25,12 @@ type Client struct {
 	repo  string
 }
 
-// NewClient creates a new GitHub client by parsing the remote URL
+// NewClient creates a new GitHub client by parsing the remote URL.
+// Handles: git@github.com:owner/repo.git or https://github.com/owner/repo.git
+// Repo names containing dots (e.g. "my-repo.io") are preserved — only a
+// trailing ".git" suffix is stripped.
 func NewClient(remoteURL string) (*Client, error) {
-	// Parse owner/repo from URL
-	// Handles: git@github.com:owner/repo.git or https://github.com/owner/repo.git
-	re := regexp.MustCompile(`github\.com[:/]([^/]+)/([^/.]+)`)
+	re := regexp.MustCompile(`github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$`)
 	matches := re.FindStringSubmatch(remoteURL)
 	if len(matches) != 3 {
 		return nil, fmt.Errorf("could not parse GitHub URL: %s", remoteURL)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -25,14 +25,33 @@ type Client struct {
 	repo  string
 }
 
+// gitHubURLRe matches a github.com URL in the common forms ezstack sees:
+//
+//   - SSH:               git@github.com:owner/repo[.git]
+//   - HTTPS:             https://[user[:pw]@]github.com[:port]/owner/repo[.git][/]
+//   - SSH-protocol URI:  ssh://git@github.com[:port]/owner/repo[.git]
+//   - git protocol:      git://github.com[:port]/owner/repo[.git]
+//
+// The host is anchored on `(^|@|//)` — start of string (bare-SCP form),
+// after a userinfo `@` (SSH or HTTPS-with-credentials), or after the
+// scheme separator `//`. This prevents false positives on URLs where
+// `github.com` only appears as a path segment of an unrelated host
+// (e.g. `https://example.com/proxy/github.com/foo/bar`) and on hosts
+// that *contain* `github.com` as a substring without equaling it
+// (`my-github.com`, `agithub.com.example.io`). The trailing `.git` is
+// stripped case-insensitively (some repos surface as `.GIT` from older
+// tooling). Repo names with internal dots — `my-repo.io`, `foo.bar` —
+// are preserved; only the literal `.git` suffix is removed.
+var gitHubURLRe = regexp.MustCompile(`(?i)(?:^|@|//)github\.com(?::\d+)?[:/]([^/\s#?]+)/([^/\s#?]+?)(?:\.git)?/?(?:[#?].*)?$`)
+
 // NewClient creates a new GitHub client by parsing the remote URL.
-// Handles: git@github.com:owner/repo.git or https://github.com/owner/repo.git
-// Repo names containing dots (e.g. "my-repo.io") are preserved — only a
-// trailing ".git" suffix is stripped.
+// Accepts SSH, HTTPS, ssh://, and git:// URLs against github.com — including
+// URLs that carry a port (`https://github.com:443/...`), a query / anchor
+// suffix (`...?ref=…`, `...#readme`), or a `.git` suffix in any case.
+// Returns an error for non-github.com hosts and for malformed inputs.
 func NewClient(remoteURL string) (*Client, error) {
-	re := regexp.MustCompile(`github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$`)
-	matches := re.FindStringSubmatch(remoteURL)
-	if len(matches) != 3 {
+	matches := gitHubURLRe.FindStringSubmatch(remoteURL)
+	if len(matches) != 3 || matches[1] == "" || matches[2] == "" {
 		return nil, fmt.Errorf("could not parse GitHub URL: %s", remoteURL)
 	}
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -31,6 +31,7 @@ type Client struct {
 //   - HTTPS:             https://[user[:pw]@]github.com[:port]/owner/repo[.git][/]
 //   - SSH-protocol URI:  ssh://git@github.com[:port]/owner/repo[.git]
 //   - git protocol:      git://github.com[:port]/owner/repo[.git]
+//   - Browser URLs:      https://github.com/owner/repo/{tree,pull,blob,...}/...
 //
 // The host is anchored on `(^|@|//)` — start of string (bare-SCP form),
 // after a userinfo `@` (SSH or HTTPS-with-credentials), or after the
@@ -42,7 +43,13 @@ type Client struct {
 // stripped case-insensitively (some repos surface as `.GIT` from older
 // tooling). Repo names with internal dots — `my-repo.io`, `foo.bar` —
 // are preserved; only the literal `.git` suffix is removed.
-var gitHubURLRe = regexp.MustCompile(`(?i)(?:^|@|//)github\.com(?::\d+)?[:/]([^/\s#?]+)/([^/\s#?]+?)(?:\.git)?/?(?:[#?].*)?$`)
+//
+// The third capture group `(?:/.*)?$` accepts and discards extra path
+// segments after the repo name. This lets users paste browser URLs like
+// `https://github.com/owner/repo/tree/main` or `.../pull/123` and have
+// the parser extract just `(owner, repo)` instead of failing — the most
+// common ezstack onboarding mistake before this change.
+var gitHubURLRe = regexp.MustCompile(`(?i)(?:^|@|//)github\.com(?::\d+)?[:/]([^/\s#?]+)/([^/\s#?]+?)(?:\.git)?(?:/[^\s#?]*)?(?:[#?].*)?$`)
 
 // NewClient creates a new GitHub client by parsing the remote URL.
 // Accepts SSH, HTTPS, ssh://, and git:// URLs against github.com — including

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -94,6 +94,81 @@ func TestNewClient(t *testing.T) {
 			remoteURL: "",
 			wantErr:   true,
 		},
+		// Hardened regex (audit M-tier): ports, anchors, query strings,
+		// uppercase .GIT, and embedded github.com look-alikes used to
+		// either fail to match or false-positive. Each line below is a
+		// previously-broken case.
+		{
+			name:      "HTTPS URL with explicit port",
+			remoteURL: "https://github.com:443/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "ssh:// scheme with port",
+			remoteURL: "ssh://git@github.com:22/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "git:// scheme",
+			remoteURL: "git://github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "HTTPS URL with userinfo",
+			remoteURL: "https://user:token@github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "URL with anchor strips anchor from repo name",
+			remoteURL: "https://github.com/owner/repo.git#readme",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "URL with query string strips query from repo name",
+			remoteURL: "https://github.com/owner/repo.git?ref=main",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Uppercase .GIT suffix is stripped (case-insensitive)",
+			remoteURL: "git@github.com:OWNER/REPO.GIT",
+			wantOwner: "OWNER",
+			wantRepo:  "REPO",
+			wantErr:   false,
+		},
+		{
+			name:      "Mixed case .Git suffix is stripped",
+			remoteURL: "https://github.com/owner/repo.Git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		// False-positive guards: the old regex matched anywhere
+		// "github.com" appeared as a substring; the anchored form
+		// requires a `^|@|/` boundary so unrelated hosts that happen to
+		// embed "github.com" in their path don't get misparsed as
+		// github.com URLs.
+		{
+			name:      "Invalid - github.com only as path segment of another host",
+			remoteURL: "https://example.com/proxy/github.com/owner/repo.git",
+			wantErr:   true,
+		},
+		{
+			name:      "Invalid - host containing github.com but not equal",
+			remoteURL: "https://my-github.com/owner/repo.git",
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -169,6 +169,67 @@ func TestNewClient(t *testing.T) {
 			remoteURL: "https://my-github.com/owner/repo.git",
 			wantErr:   true,
 		},
+		// Browser-style URLs: users routinely paste these into `ezs new` /
+		// `ezs config set` flows. Pre-fix the regex required the path to
+		// end at the repo name, so these all errored out — a common
+		// onboarding failure. The trailing path is now accepted and
+		// discarded; we extract just (owner, repo).
+		{
+			name:      "Browser tree URL",
+			remoteURL: "https://github.com/owner/repo/tree/main",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser pull URL",
+			remoteURL: "https://github.com/owner/repo/pull/123",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser blob URL with file path",
+			remoteURL: "https://github.com/owner/repo/blob/main/README.md",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser issues URL",
+			remoteURL: "https://github.com/owner/repo/issues/42",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser actions URL",
+			remoteURL: "https://github.com/owner/repo/actions/runs/123",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser tree URL with .git in path (rare but well-formed)",
+			remoteURL: "https://github.com/owner/repo.git/tree/main",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser URL with anchor on a deep path",
+			remoteURL: "https://github.com/owner/repo/blob/main/foo.go#L10",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "Browser URL with query string on a deep path",
+			remoteURL: "https://github.com/owner/repo/tree/main?w=1",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -59,6 +59,27 @@ func TestNewClient(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "Repo name with dot is preserved",
+			remoteURL: "https://github.com/owner/my-repo.io.git",
+			wantOwner: "owner",
+			wantRepo:  "my-repo.io",
+			wantErr:   false,
+		},
+		{
+			name:      "Repo name with dot, no .git suffix",
+			remoteURL: "git@github.com:owner/foo.bar",
+			wantOwner: "owner",
+			wantRepo:  "foo.bar",
+			wantErr:   false,
+		},
+		{
+			name:      "HTTPS URL with trailing slash",
+			remoteURL: "https://github.com/owner/repo/",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
 			name:      "Invalid URL - no github.com",
 			remoteURL: "git@gitlab.com:owner/repo.git",
 			wantErr:   true,

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1309,6 +1309,48 @@ func (m *Manager) DetectRenamedBranches(orphaned []string, untracked []git.Workt
 	return renames
 }
 
+// mergeBranchCaches combines two BranchCache pointers — the renamed-from
+// entry (`old`) and the pre-existing renamed-to entry (`new`) — into a
+// single BranchCache that loses no information from either side. For each
+// field, the rule is "non-empty wins; on tie, prefer `old` because the
+// rename targets the same logical branch and `old` carried the
+// authoritative PR/merge metadata before the rename".
+//
+// Both inputs are assumed non-nil; callers handle the nil cases inline.
+func mergeBranchCaches(old, new *config.BranchCache) *config.BranchCache {
+	out := *old // start from old (preserves zero values too)
+
+	if out.WorktreePath == "" && new.WorktreePath != "" {
+		out.WorktreePath = new.WorktreePath
+	}
+	if out.PRUrl == "" && new.PRUrl != "" {
+		out.PRUrl = new.PRUrl
+		out.PRNumber = new.PRNumber
+		// PRState only makes sense with the PR it describes; pull it in too
+		// so the new entry's state doesn't outlive its URL.
+		out.PRState = new.PRState
+	}
+	if out.PRState == "" && new.PRState != "" {
+		out.PRState = new.PRState
+	}
+	if !out.IsMerged && new.IsMerged {
+		// IsMerged is only ever flipped on; if either side has the merged
+		// flag set we should preserve it.
+		out.IsMerged = true
+	}
+	if !out.IsRemote && new.IsRemote {
+		out.IsRemote = true
+	}
+	if out.Remote == "" && new.Remote != "" {
+		out.Remote = new.Remote
+	}
+	if out.PreSyncCommit == "" && new.PreSyncCommit != "" {
+		out.PreSyncCommit = new.PreSyncCommit
+		out.PreSyncCommitAt = new.PreSyncCommitAt
+	}
+	return &out
+}
+
 // ApplyBranchRenames updates the config to reflect branch renames.
 // For each rename, it updates the tree key, moves the cache entry, and preserves all metadata.
 func (m *Manager) ApplyBranchRenames(renames []RenamedBranchInfo) error {
@@ -1325,18 +1367,36 @@ func (m *Manager) ApplyBranchRenames(renames []RenamedBranchInfo) error {
 			stack.RenameBranchInTree(rename.OldName, rename.NewName)
 
 			// Move cache entry: copy old metadata to new key, delete old key.
-			// Skip the move if the new name already has a cache entry — that
-			// means a concurrent process or a prior command already populated
-			// it, and clobbering it would lose PR URLs / merged flags.
+			//
+			// Collision policy (when `newName` already has a cache entry):
+			//   - If `oldCache` carries data the new entry doesn't (PRUrl,
+			//     PRState, IsMerged, Remote, PreSyncCommit), prefer `oldCache`
+			//     and merge any non-empty new-entry fields into it. The old
+			//     entry is the authoritative one — rename targets the same
+			//     branch, and the new-name entry is typically a stub auto-
+			//     created by a concurrent worktree-listing pass.
+			//   - Otherwise keep the new entry as-is (concurrent peer
+			//     populated it with valid data first, and our oldCache had
+			//     no extra information to add).
+			//
+			// Pre-fix this branch silently dropped `oldCache` whenever the
+			// new name pre-existed, losing PR URL / merged flag history.
 			oldCache := cache.GetBranchCache(rename.OldName)
-			if cache.GetBranchCache(rename.NewName) == nil {
-				if oldCache != nil {
-					cache.SetBranchCache(rename.NewName, oldCache)
-				} else {
-					cache.SetBranchCache(rename.NewName, &config.BranchCache{
-						WorktreePath: rename.WorktreePath,
-					})
-				}
+			newCache := cache.GetBranchCache(rename.NewName)
+			switch {
+			case newCache == nil && oldCache != nil:
+				cache.SetBranchCache(rename.NewName, oldCache)
+			case newCache == nil:
+				cache.SetBranchCache(rename.NewName, &config.BranchCache{
+					WorktreePath: rename.WorktreePath,
+				})
+			case oldCache != nil:
+				// Both exist. Keep `oldCache` if it has fields newCache lacks;
+				// otherwise newCache wins and we just drop oldCache. We also
+				// fold in any field newCache uniquely had so neither side
+				// loses data.
+				merged := mergeBranchCaches(oldCache, newCache)
+				cache.SetBranchCache(rename.NewName, merged)
 			}
 			delete(cache.Branches, rename.OldName)
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1324,14 +1324,19 @@ func (m *Manager) ApplyBranchRenames(renames []RenamedBranchInfo) error {
 			// Rename in tree (hash stays stable - stack identity doesn't change)
 			stack.RenameBranchInTree(rename.OldName, rename.NewName)
 
-			// Move cache entry: copy old metadata to new key, delete old key
+			// Move cache entry: copy old metadata to new key, delete old key.
+			// Skip the move if the new name already has a cache entry — that
+			// means a concurrent process or a prior command already populated
+			// it, and clobbering it would lose PR URLs / merged flags.
 			oldCache := cache.GetBranchCache(rename.OldName)
-			if oldCache != nil {
-				cache.SetBranchCache(rename.NewName, oldCache)
-			} else {
-				cache.SetBranchCache(rename.NewName, &config.BranchCache{
-					WorktreePath: rename.WorktreePath,
-				})
+			if cache.GetBranchCache(rename.NewName) == nil {
+				if oldCache != nil {
+					cache.SetBranchCache(rename.NewName, oldCache)
+				} else {
+					cache.SetBranchCache(rename.NewName, &config.BranchCache{
+						WorktreePath: rename.WorktreePath,
+					})
+				}
 			}
 			delete(cache.Branches, rename.OldName)
 

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1617,3 +1617,161 @@ func TestManager_CreateBranch_TargetSpecificStack(t *testing.T) {
 		t.Errorf("feature-c should be in stack %s, got %v", sbHash, sc)
 	}
 }
+
+// TestApplyBranchRenames_CollisionPreservesPRMetadata pins the data-loss
+// fix: when renaming `old` → `new` and `new` already has a cache entry
+// (e.g. a stub created by a concurrent worktree-listing pass), the rename
+// must preserve `old`'s PR URL / merged flag rather than silently dropping
+// them. Pre-fix, the entire move was skipped on collision and `old`'s
+// cache entry was deleted — so `pr_url`, `pr_state`, and `is_merged`
+// vanished after a rename whenever the new name pre-existed.
+//
+// This test uses ListLocalBranches-friendly setup: we create both `old-name`
+// and `new-name` as real git branches so Reconcile() doesn't prune them.
+// Then we seed cache entries for both, run ApplyBranchRenames, and verify
+// `new-name` ends up with `old-name`'s rich data (not clobbered).
+func TestApplyBranchRenames_CollisionPreservesPRMetadata(t *testing.T) {
+	repoDir, _, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, _ := NewManager(repoDir)
+	if _, err := mgr.CreateBranch("old-name", "main", "", ""); err != nil {
+		t.Fatalf("create old-name: %v", err)
+	}
+	if _, err := mgr.CreateBranch("new-name", "main", "", ""); err != nil {
+		t.Fatalf("create new-name: %v", err)
+	}
+
+	mgr, _ = NewManager(repoDir)
+	cache := mgr.stackConfig.Cache
+
+	// Seed the OLD entry with rich PR metadata.
+	cache.SetBranchCache("old-name", &config.BranchCache{
+		WorktreePath: "/wt/old",
+		PRUrl:        "https://github.com/owner/repo/pull/42",
+		PRNumber:     42,
+		PRState:      "OPEN",
+		IsMerged:     false,
+		Remote:       "fork-user",
+	})
+	// Seed the NEW entry as a stub (only WorktreePath set) — simulating
+	// a concurrent process that auto-created it without PR data.
+	cache.SetBranchCache("new-name", &config.BranchCache{
+		WorktreePath: "/wt/new-stub",
+	})
+
+	if err := mgr.ApplyBranchRenames([]RenamedBranchInfo{
+		{OldName: "old-name", NewName: "new-name", WorktreePath: "/wt/new"},
+	}); err != nil {
+		t.Fatalf("ApplyBranchRenames: %v", err)
+	}
+
+	// Inspect the in-memory cache directly — this avoids Reconcile's orphan
+	// pruning, which would otherwise strip new-name because we never
+	// actually `git branch -m`'d it. The point of this test is to pin the
+	// rename merge logic, not the Reconcile dance.
+	got := cache.GetBranchCache("new-name")
+	if got == nil {
+		t.Fatal("new-name cache entry missing after rename")
+	}
+	if got.PRUrl != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("PRUrl = %q, want preserved from old (regression: rename clobbered PR URL)", got.PRUrl)
+	}
+	if got.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", got.PRNumber)
+	}
+	if got.PRState != "OPEN" {
+		t.Errorf("PRState = %q, want OPEN", got.PRState)
+	}
+	if got.Remote != "fork-user" {
+		t.Errorf("Remote = %q, want fork-user (regression: rename lost fork remote)", got.Remote)
+	}
+	if cache.GetBranchCache("old-name") != nil {
+		t.Error("old-name cache entry should be deleted after rename")
+	}
+}
+
+// TestApplyBranchRenames_CollisionMergesNonOverlappingFields covers the
+// "both sides carry information" case: old has a PR, new has a worktree.
+// The merge must produce an entry that has BOTH — not whichever side
+// happened to win an overwrite.
+func TestApplyBranchRenames_CollisionMergesNonOverlappingFields(t *testing.T) {
+	repoDir, _, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	mgr, _ := NewManager(repoDir)
+	if _, err := mgr.CreateBranch("old-name", "main", "", ""); err != nil {
+		t.Fatalf("create old-name: %v", err)
+	}
+
+	mgr, _ = NewManager(repoDir)
+	cache := mgr.stackConfig.Cache
+
+	cache.SetBranchCache("old-name", &config.BranchCache{
+		// old has the PR data but no worktree path (e.g. branch was tracked remotely)
+		PRUrl:    "https://github.com/owner/repo/pull/7",
+		PRNumber: 7,
+		PRState:  "MERGED",
+		IsMerged: true,
+		IsRemote: true,
+	})
+	cache.SetBranchCache("new-name", &config.BranchCache{
+		// new has the worktree but no PR data
+		WorktreePath: "/wt/new-actual",
+	})
+
+	if err := mgr.ApplyBranchRenames([]RenamedBranchInfo{
+		{OldName: "old-name", NewName: "new-name"},
+	}); err != nil {
+		t.Fatalf("ApplyBranchRenames: %v", err)
+	}
+
+	got := cache.GetBranchCache("new-name")
+	if got == nil {
+		t.Fatal("new-name cache entry missing")
+	}
+	if got.PRUrl != "https://github.com/owner/repo/pull/7" {
+		t.Errorf("PRUrl = %q, want merged from old", got.PRUrl)
+	}
+	if !got.IsMerged {
+		t.Error("IsMerged = false, want true (preserved from old)")
+	}
+	if got.WorktreePath != "/wt/new-actual" {
+		t.Errorf("WorktreePath = %q, want preserved from new (regression: merge lost new entry's data)", got.WorktreePath)
+	}
+}
+
+// TestMergeBranchCaches_PrefersOldThenFillsFromNew is a unit-level pin on
+// the merge helper itself, independent of the Manager save dance. It
+// captures the priority rules: non-empty old wins; empty old gets filled
+// from new; boolean-or for IsMerged / IsRemote.
+func TestMergeBranchCaches_PrefersOldThenFillsFromNew(t *testing.T) {
+	old := &config.BranchCache{
+		PRUrl:    "old-pr",
+		PRNumber: 1,
+		PRState:  "OPEN",
+		Remote:   "fork-a",
+	}
+	newE := &config.BranchCache{
+		WorktreePath: "/wt",
+		PRUrl:        "new-pr", // should NOT win
+		IsMerged:     true,
+		IsRemote:     true,
+	}
+	got := mergeBranchCaches(old, newE)
+	if got.PRUrl != "old-pr" {
+		t.Errorf("PRUrl = %q, want old-pr (old wins on conflict)", got.PRUrl)
+	}
+	if got.WorktreePath != "/wt" {
+		t.Errorf("WorktreePath = %q, want /wt (filled from new)", got.WorktreePath)
+	}
+	if !got.IsMerged {
+		t.Error("IsMerged = false, want true (boolean OR from new)")
+	}
+	if !got.IsRemote {
+		t.Error("IsRemote = false, want true (boolean OR from new)")
+	}
+	if got.Remote != "fork-a" {
+		t.Errorf("Remote = %q, want fork-a (old wins)", got.Remote)
+	}
+}

--- a/internal/stack/sync.go
+++ b/internal/stack/sync.go
@@ -1876,9 +1876,13 @@ func (m *Manager) RebaseChildren(useMerge ...bool) ([]RebaseResult, error) {
 		// worktreePath (not child.WorktreePath) so a drift heal performed
 		// above propagates here without depending on the cache mutation
 		// having been observed back via the *config.Branch pointer.
+		// Use NewReadOnlyManager so the recursive descent doesn't run a
+		// full Reconcile() mid-rebase — orphan/prune detection during an
+		// in-flight rebase can disturb the branch we're operating on. The
+		// top-level command already reconciled before kicking off the sync.
 		var childResults []RebaseResult
 		if worktreePath != "" {
-			childMgr, err := NewManager(worktreePath)
+			childMgr, err := NewReadOnlyManager(worktreePath)
 			if err != nil {
 				result := RebaseResult{
 					Branch:       child.Name,
@@ -1914,7 +1918,7 @@ func (m *Manager) RebaseChildren(useMerge ...bool) ([]RebaseResult, error) {
 				results = append(results, result)
 				return results, nil
 			}
-			childMgr, err := NewManager(m.repoDir)
+			childMgr, err := NewReadOnlyManager(m.repoDir)
 			if err != nil {
 				_ = m.git.CheckoutBranch(origBranch)
 				result := RebaseResult{

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -239,10 +239,25 @@ func (t *TerminalBackend) SelectBranch(branches []*config.Branch, prompt string)
 	return SelectBranchWithStacks(branches, nil, prompt)
 }
 
-// SelectBranchWithStacks uses fzf to select a branch with optional stack preview
+// SelectBranchWithStacks uses fzf to select a branch with optional stack preview.
+//
+// Under YesMode (MCP / -y) we cannot run fzf — there's no controlling
+// terminal — so multi-match calls fail loudly with a structured error
+// instead of hanging. The exact-match path (single branch) returns it
+// without prompting so callers that already narrowed don't pay the cost.
 func SelectBranchWithStacks(branches []*config.Branch, stacks []*config.Stack, prompt string) (*config.Branch, error) {
 	if len(branches) == 0 {
 		return nil, fmt.Errorf("no branches to select from")
+	}
+	if YesMode {
+		if len(branches) == 1 {
+			return branches[0], nil
+		}
+		names := make([]string, 0, len(branches))
+		for _, b := range branches {
+			names = append(names, b.Name)
+		}
+		return nil, fmt.Errorf("multiple branches match (%s) — disambiguate with an exact branch name; interactive selection is unavailable in -y / MCP mode", strings.Join(names, ", "))
 	}
 
 	// Build fzf input with preview data embedded
@@ -316,10 +331,22 @@ type WorktreeInfo struct {
 	Branch string
 }
 
-// SelectWorktree uses fzf to select a worktree from a list
+// SelectWorktree uses fzf to select a worktree from a list.
+// Under YesMode it returns the lone worktree if there is only one and errors
+// loudly otherwise, mirroring SelectWorktreeWithStackPreview.
 func SelectWorktree(worktrees []WorktreeInfo, prompt string) (*WorktreeInfo, error) {
 	if len(worktrees) == 0 {
 		return nil, fmt.Errorf("no worktrees to select from")
+	}
+	if YesMode {
+		if len(worktrees) == 1 {
+			return &worktrees[0], nil
+		}
+		names := make([]string, 0, len(worktrees))
+		for _, w := range worktrees {
+			names = append(names, w.Branch)
+		}
+		return nil, fmt.Errorf("multiple worktrees match (%s) — disambiguate with an exact branch name; interactive selection is unavailable in -y / MCP mode", strings.Join(names, ", "))
 	}
 
 	var input strings.Builder
@@ -423,6 +450,16 @@ func SelectStack(stacks []*config.Stack, prompt string) (*config.Stack, error) {
 func (t *TerminalBackend) SelectStack(stacks []*config.Stack, prompt string) (*config.Stack, error) {
 	if len(stacks) == 0 {
 		return nil, fmt.Errorf("no stacks to select from")
+	}
+	if YesMode {
+		if len(stacks) == 1 {
+			return stacks[0], nil
+		}
+		names := make([]string, 0, len(stacks))
+		for _, s := range stacks {
+			names = append(names, s.DisplayName())
+		}
+		return nil, fmt.Errorf("multiple stacks match (%s) — disambiguate with --stack <hash>; interactive selection is unavailable in -y / MCP mode", strings.Join(names, ", "))
 	}
 
 	var input strings.Builder
@@ -1481,13 +1518,27 @@ func (t *TerminalBackend) SelectOption(options []string, prompt string) (int, er
 	return SelectOptionWithSuggested(options, prompt, -1)
 }
 
-// SelectOptionWithSuggested uses fzf to select from a list of options
-// suggestedIdx is the 0-based index of the suggested option (-1 for none)
-// The suggested option will be marked with "(suggested)" and appear first
-// Returns the 0-based index of the selected option
+// SelectOptionWithSuggested uses fzf to select from a list of options.
+// suggestedIdx is the 0-based index of the suggested option (-1 for none).
+// The suggested option will be marked with "(suggested)" and appear first.
+// Returns the 0-based index of the selected option.
+//
+// Under YesMode it auto-resolves: if a suggested option is provided, that's
+// the answer; if a single option is the only choice, return it; otherwise
+// fail loudly so MCP / -y callers surface a structured error rather than
+// hanging on fzf with no TTY.
 func SelectOptionWithSuggested(options []string, prompt string, suggestedIdx int) (int, error) {
 	if len(options) == 0 {
 		return -1, fmt.Errorf("no options to select from")
+	}
+	if YesMode {
+		if suggestedIdx >= 0 && suggestedIdx < len(options) {
+			return suggestedIdx, nil
+		}
+		if len(options) == 1 {
+			return 0, nil
+		}
+		return -1, fmt.Errorf("multiple options for %q (%s) and no suggested default — provide an explicit choice; interactive selection is unavailable in -y / MCP mode", prompt, strings.Join(options, ", "))
 	}
 
 	var input strings.Builder
@@ -1529,6 +1580,12 @@ func SelectOptionWithBack(options []string, prompt string) (int, error) {
 func (t *TerminalBackend) SelectOptionWithBack(options []string, prompt string) (int, error) {
 	if len(options) == 0 {
 		return -1, fmt.Errorf("no options to select from")
+	}
+	if YesMode {
+		if len(options) == 1 {
+			return 0, nil
+		}
+		return -1, fmt.Errorf("multiple options for %q (%s) — provide an explicit choice; interactive selection is unavailable in -y / MCP mode", prompt, strings.Join(options, ", "))
 	}
 
 	var input strings.Builder

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -442,7 +442,16 @@ func SelectWorktreeWithStackPreview(worktrees []WorktreeInfo, stacks []*config.S
 	return nil, fmt.Errorf("worktree not found: %s", branchName)
 }
 
-// SelectStack uses fzf to select a stack
+// SelectStack uses fzf to select a stack.
+//
+// The YesMode guard lives on the TerminalBackend method (below), NOT on
+// this package-level wrapper. Backend-aware: MCPBackend.SelectStack uses
+// JSON-Schema elicitation (no TTY required), which works correctly under
+// YesMode — a package-level guard would force auto-pick / error and
+// short-circuit the MCP client's natural disambiguation flow.
+// TerminalBackend.SelectStack, in contrast, calls runFzf which DOES hang
+// on a missing TTY, so it has its own guard. Same pattern applies to
+// SelectBranch and SelectOptionWithBack (also dispatched through Backend).
 func SelectStack(stacks []*config.Stack, prompt string) (*config.Stack, error) {
 	return activeBackend.SelectStack(stacks, prompt)
 }
@@ -1573,6 +1582,12 @@ func SelectOptionWithSuggested(options []string, prompt string, suggestedIdx int
 // SelectOptionWithBack uses fzf to select from a list of options with a back option.
 // Returns the 0-based index of the selected option, or ErrBack if back was selected.
 // The back option is displayed as an unnumbered "← back" at the end of the list.
+//
+// As with SelectStack and SelectBranch, the YesMode guard lives on the
+// TerminalBackend method (below), not here. MCPBackend.SelectOptionWithBack
+// uses elicitation rather than fzf and does not hang on a missing TTY,
+// so a package-level guard would short-circuit the elicitation path
+// and break MCP tools that depend on user disambiguation.
 func SelectOptionWithBack(options []string, prompt string) (int, error) {
 	return activeBackend.SelectOptionWithBack(options, prompt)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1244,7 +1245,17 @@ func Info(msg string) {
 
 // Prompt asks for text input with a prompt and optional default value
 // Returns the user input or the default if empty input is given
+// Prompt asks the user a question and returns their answer, or `defaultVal`
+// if they pressed Enter. Honors YesMode: under MCP / -y the function returns
+// the default immediately rather than blocking on readline against a stdin
+// that no terminal will ever feed. Without this guard, MCP tool calls that
+// route through Prompt — most notably `ezstack_pr_create` without a `title`
+// arg — hang forever.
 func Prompt(prompt, defaultVal string) string {
+	if YesMode {
+		fmt.Fprintf(os.Stderr, "%s%s?%s %s %s→ %q%s\n", Bold, Yellow, Reset, prompt, Green, defaultVal, Reset)
+		return defaultVal
+	}
 	return activeBackend.Prompt(prompt, defaultVal)
 }
 
@@ -1298,8 +1309,14 @@ func (t *TerminalBackend) Prompt(prompt, defaultVal string) string {
 }
 
 // PromptPath asks for a file path with tab completion support
-// Returns the user input or the default if empty input is given
+// Returns the user input or the default if empty input is given. Like
+// Prompt, returns the default immediately under YesMode so MCP / -y callers
+// don't hang on a missing TTY.
 func PromptPath(promptText, defaultVal string) string {
+	if YesMode {
+		fmt.Fprintf(os.Stderr, "%s%s?%s %s %s→ %q%s\n", Bold, Yellow, Reset, promptText, Green, defaultVal, Reset)
+		return defaultVal
+	}
 	// Print the question on its own line first
 	fmt.Fprintf(os.Stderr, "%s%s?%s %s\n", Bold, Yellow, Reset, promptText)
 
@@ -1387,8 +1404,22 @@ func pathCompleterFunc(prefix string) *readline.PrefixCompleter {
 	return readline.PcItem(prefix)
 }
 
-// PromptRequired asks for text input and keeps asking until a non-empty value is provided
+// ErrPromptRequiredInYesMode is returned (panic-free) by callers that opt
+// into the error-returning variant of PromptRequired. Direct PromptRequired
+// callers under YesMode get an os.Exit since they have no way to recover.
+var ErrPromptRequiredInYesMode = errors.New("required prompt cannot be answered in non-interactive mode")
+
+// PromptRequired asks for text input and keeps asking until a non-empty
+// value is provided. Under YesMode there is no human to keep asking, so the
+// loop would spin forever on closed stdin. Print a clear diagnostic and exit
+// rather than hang the MCP server / scripted run indefinitely.
 func PromptRequired(prompt string) string {
+	if YesMode {
+		fmt.Fprintf(os.Stderr,
+			"ezs: error: required prompt %q cannot be answered in non-interactive mode (YesMode/-y/MCP). "+
+				"Re-run interactively or pass the value explicitly via the relevant flag.\n", prompt)
+		os.Exit(2)
+	}
 	return activeBackend.PromptRequired(prompt)
 }
 
@@ -1645,7 +1676,26 @@ func WithSpinner(message string, fn func() error) error {
 // and returns the edited content. If the user saves and exits, the content is returned.
 // If the user aborts (empty file or error), an error is returned.
 // The editor is determined by $EDITOR, $VISUAL, or falls back to "vim".
+//
+// Under YesMode there's no controlling terminal for $EDITOR to draw on, so
+// the editor would hang indefinitely. Skip it and return the initial
+// content unchanged — MCP / -y callers that want to edit should pass the
+// content via the relevant flag instead.
 func EditWithEditor(initialContent, fileExtension string) (string, error) {
+	if YesMode {
+		fmt.Fprintf(os.Stderr, "%sezs: skipping interactive editor in non-interactive mode (using initial content)%s\n", Gray, Reset)
+		return strings.TrimSpace(initialContent), nil
+	}
+	// Belt-and-braces: even when YesMode is off, an MCP-style invocation
+	// has no TTY for $EDITOR to draw on. Detect that and short-circuit
+	// rather than launch vim against /dev/null and hang. The TTY check
+	// covers stdin/stdout — most editors require both. We deliberately
+	// require BOTH to be terminals so a user redirecting only stdout
+	// (e.g. `ezs ... > file`) is not misclassified.
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Fprintf(os.Stderr, "%sezs: no terminal attached, skipping interactive editor%s\n", Gray, Reset)
+		return strings.TrimSpace(initialContent), nil
+	}
 	// Get the editor from environment
 	editor := os.Getenv("EDITOR")
 	if editor == "" {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -347,11 +347,23 @@ func SelectWorktree(worktrees []WorktreeInfo, prompt string) (*WorktreeInfo, err
 	return nil, fmt.Errorf("worktree not found: %s", branchName)
 }
 
-// SelectWorktreeWithStackPreview uses fzf to select a worktree with stack preview
-// For worktrees not in any stack, the preview shows "Not part of a stack"
+// SelectWorktreeWithStackPreview uses fzf to select a worktree with stack preview.
+// For worktrees not in any stack, the preview shows "Not part of a stack".
+//
+// Under YesMode (MCP / -y) we cannot run fzf — there's no controlling terminal
+// — so multi-match calls fail loudly with a structured error instead of
+// hanging on an interactive prompt. The exact-match path (single worktree)
+// still works because callers handle len==1 before reaching here.
 func SelectWorktreeWithStackPreview(worktrees []WorktreeInfo, stacks []*config.Stack, prompt string) (*WorktreeInfo, error) {
 	if len(worktrees) == 0 {
 		return nil, fmt.Errorf("no worktrees to select from")
+	}
+	if YesMode && len(worktrees) > 1 {
+		names := make([]string, 0, len(worktrees))
+		for _, w := range worktrees {
+			names = append(names, w.Branch)
+		}
+		return nil, fmt.Errorf("multiple worktrees match (%s) — disambiguate with an exact branch name; interactive selection is unavailable in -y / MCP mode", strings.Join(names, ", "))
 	}
 
 	// Build a map of branch -> stack for quick lookup
@@ -1088,8 +1100,22 @@ func (t *TerminalBackend) ConfirmWithDefault(prompt string, defaultYes bool) boo
 // options is the list of options to display
 // prompt is the question to ask
 // defaultIdx is the 0-based index of the default selected option
-// Returns the 0-based index of the selected option, or -1 if cancelled
+// Returns the 0-based index of the selected option, or -1 if cancelled.
+//
+// Honors YesMode: under MCP / -y the menu auto-resolves to defaultIdx
+// instead of trying to drive a TTY that isn't there. Without this guard,
+// MCP tool calls that route through SelectTUI hang indefinitely waiting
+// for keystrokes from a controlling terminal.
 func SelectTUI(options []string, prompt string, defaultIdx int) int {
+	if YesMode {
+		if len(options) == 0 {
+			return -1
+		}
+		if defaultIdx < 0 || defaultIdx >= len(options) {
+			defaultIdx = 0
+		}
+		return defaultIdx
+	}
 	return activeBackend.Select(options, prompt, defaultIdx)
 }
 

--- a/internal/ui/yesmode_test.go
+++ b/internal/ui/yesmode_test.go
@@ -244,9 +244,13 @@ func runWithDeadline(t *testing.T, d time.Duration, fn func()) {
 // TestSelectBranchWithStacks_YesMode pins three contracts:
 // (1) zero branches → not-found error, not a hang.
 // (2) one branch → return it without prompting (callers that already
-//     narrowed don't pay an interactive cost).
+//
+//	narrowed don't pay an interactive cost).
+//
 // (3) multiple branches → structured "multiple ... match" error naming the
-//     candidates, so MCP / scripted callers can surface guidance.
+//
+//	candidates, so MCP / scripted callers can surface guidance.
+//
 // The deadline guard catches the regression mode (block on fzf with no TTY).
 func TestSelectBranchWithStacks_YesMode(t *testing.T) {
 	withYesMode(t, func() {

--- a/internal/ui/yesmode_test.go
+++ b/internal/ui/yesmode_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
 )
 
 // withYesMode flips YesMode for the duration of fn and restores it
@@ -218,4 +220,186 @@ type fakeBackend struct {
 func (f *fakeBackend) PromptRequired(prompt string) string {
 	f.promptRequiredCalls++
 	return f.promptRequiredAnswer
+}
+
+// runWithDeadline guards against test regressions where a Select* helper
+// reaches its fzf invocation despite YesMode being on — `exec.Command("fzf",
+// ...)` against a missing TTY would block indefinitely. The deadline is
+// generous so a slow CI doesn't false-fail; the failure mode under regression
+// is "blocks forever", so any reasonable bound catches it.
+func runWithDeadline(t *testing.T, d time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("Select* call did not complete within %s — YesMode guard regressed and the helper is blocked on fzf / TTY", d)
+	}
+}
+
+// TestSelectBranchWithStacks_YesMode pins three contracts:
+// (1) zero branches → not-found error, not a hang.
+// (2) one branch → return it without prompting (callers that already
+//     narrowed don't pay an interactive cost).
+// (3) multiple branches → structured "multiple ... match" error naming the
+//     candidates, so MCP / scripted callers can surface guidance.
+// The deadline guard catches the regression mode (block on fzf with no TTY).
+func TestSelectBranchWithStacks_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			// (1) empty
+			if _, err := SelectBranchWithStacks(nil, nil, "x"); err == nil || !strings.Contains(err.Error(), "no branches") {
+				t.Errorf("empty branches: want 'no branches' err, got %v", err)
+			}
+
+			// (2) single
+			only := &config.Branch{Name: "only"}
+			got, err := SelectBranchWithStacks([]*config.Branch{only}, nil, "x")
+			if err != nil {
+				t.Fatalf("single branch: unexpected err %v", err)
+			}
+			if got != only {
+				t.Errorf("single branch: got %v, want %v", got, only)
+			}
+
+			// (3) multiple → structured error
+			a := &config.Branch{Name: "a"}
+			b := &config.Branch{Name: "b"}
+			_, err = SelectBranchWithStacks([]*config.Branch{a, b}, nil, "x")
+			if err == nil {
+				t.Fatal("multiple branches under YesMode: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "multiple branches") {
+				t.Errorf("multi err = %q, want 'multiple branches' substring", err)
+			}
+			if !strings.Contains(err.Error(), "a") || !strings.Contains(err.Error(), "b") {
+				t.Errorf("multi err must name candidates a & b: %q", err)
+			}
+		})
+	})
+}
+
+// TestSelectBranch_YesMode pins that the public SelectBranch wrapper (which
+// dispatches to TerminalBackend.SelectBranch → SelectBranchWithStacks) honors
+// the same YesMode contract. Without this test, a future backend rewrite
+// could route around the guard.
+func TestSelectBranch_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			only := &config.Branch{Name: "only"}
+			got, err := SelectBranch([]*config.Branch{only}, "x")
+			if err != nil || got != only {
+				t.Errorf("SelectBranch(single): got (%v, %v), want (%v, nil)", got, err, only)
+			}
+
+			_, err = SelectBranch([]*config.Branch{{Name: "a"}, {Name: "b"}}, "x")
+			if err == nil {
+				t.Errorf("SelectBranch(multi) under YesMode: expected error, got nil")
+			}
+		})
+	})
+}
+
+// TestSelectWorktree_YesMode mirrors the SelectBranch contract for
+// SelectWorktree (the non-stack-preview variant). The stack-preview variant
+// already had a guard before this change; the bare SelectWorktree was the
+// regression path.
+func TestSelectWorktree_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			one := []WorktreeInfo{{Branch: "feat", Path: "/tmp/feat"}}
+			got, err := SelectWorktree(one, "x")
+			if err != nil {
+				t.Fatalf("single worktree: unexpected err %v", err)
+			}
+			if got == nil || got.Branch != "feat" {
+				t.Errorf("single worktree: got %+v, want branch=feat", got)
+			}
+
+			two := []WorktreeInfo{{Branch: "a"}, {Branch: "b"}}
+			_, err = SelectWorktree(two, "x")
+			if err == nil {
+				t.Fatal("multi worktrees: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "multiple worktrees") {
+				t.Errorf("multi err = %q, want 'multiple worktrees' substring", err)
+			}
+		})
+	})
+}
+
+// TestSelectStack_YesMode pins that the SelectStack helper either auto-picks
+// a single stack or surfaces a structured error listing candidates — never
+// blocks on fzf.
+func TestSelectStack_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			one := []*config.Stack{{Hash: "abc12345"}}
+			got, err := SelectStack(one, "x")
+			if err != nil || got != one[0] {
+				t.Errorf("single stack: got (%v, %v), want (%v, nil)", got, err, one[0])
+			}
+
+			two := []*config.Stack{{Hash: "abc12345"}, {Hash: "def67890"}}
+			_, err = SelectStack(two, "x")
+			if err == nil {
+				t.Fatal("multi stacks: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "multiple stacks") {
+				t.Errorf("multi err = %q, want 'multiple stacks' substring", err)
+			}
+		})
+	})
+}
+
+// TestSelectOptionWithSuggested_YesMode pins three resolution cases in
+// priority order: (a) suggested index in range → return it; (b) no suggestion
+// but only one option → return 0; (c) ambiguous → structured error. The
+// suggestion-first ordering matters: many ezstack code paths (e.g. parent
+// pickers) compute a sensible default and fall back to interactive only when
+// they can't.
+func TestSelectOptionWithSuggested_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			// (a) honor suggestion
+			idx, err := SelectOptionWithSuggested([]string{"x", "y", "z"}, "p", 2)
+			if err != nil || idx != 2 {
+				t.Errorf("suggested=2: got (%d, %v), want (2, nil)", idx, err)
+			}
+			// (b) single option
+			idx, err = SelectOptionWithSuggested([]string{"only"}, "p", -1)
+			if err != nil || idx != 0 {
+				t.Errorf("single option: got (%d, %v), want (0, nil)", idx, err)
+			}
+			// (c) ambiguous + no suggestion
+			_, err = SelectOptionWithSuggested([]string{"a", "b"}, "p", -1)
+			if err == nil || !strings.Contains(err.Error(), "multiple options") {
+				t.Errorf("ambiguous: want 'multiple options' err, got %v", err)
+			}
+		})
+	})
+}
+
+// TestSelectOptionWithBack_YesMode pins that the back-menu variant either
+// auto-picks the lone option or errors loudly. Critically: this helper has
+// no "suggested" parameter — the only safe auto-resolution is len==1, since
+// silently picking option [0] under YesMode would let MCP scripts proceed
+// past a menu they didn't actually consent to.
+func TestSelectOptionWithBack_YesMode(t *testing.T) {
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			idx, err := SelectOptionWithBack([]string{"only"}, "p")
+			if err != nil || idx != 0 {
+				t.Errorf("single: got (%d, %v), want (0, nil)", idx, err)
+			}
+			_, err = SelectOptionWithBack([]string{"a", "b", "c"}, "p")
+			if err == nil || !strings.Contains(err.Error(), "multiple options") {
+				t.Errorf("multi: want 'multiple options' err, got %v", err)
+			}
+		})
+	})
 }

--- a/internal/ui/yesmode_test.go
+++ b/internal/ui/yesmode_test.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withYesMode flips YesMode for the duration of fn and restores it
+// afterwards even if fn panics. Tests that mutate the package var must
+// use this helper to avoid leaking state into other tests in the same
+// `go test` run (the suite is sequential by default but a parallel
+// invocation would still expose the leak).
+func withYesMode(t *testing.T, fn func()) {
+	t.Helper()
+	old := YesMode
+	YesMode = true
+	defer func() { YesMode = old }()
+	fn()
+}
+
+// captureStderr redirects os.Stderr to a pipe, runs fn, restores
+// os.Stderr, and returns whatever fn wrote. The stderr output of
+// YesMode prompts (the "→ value" trace) must appear so users running
+// scripted runs can see what answer was auto-accepted; this helper
+// makes that observable in tests.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = orig
+	}()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+	w.Close()
+	<-done
+	return buf.String()
+}
+
+// TestPrompt_YesMode_ReturnsDefault asserts the headline production-grade
+// guarantee for `Prompt`: under YesMode (MCP / -y) it returns the default
+// value immediately rather than blocking on readline. Without the guard,
+// `ezs-mcp ezstack_pr_create` with no `title` arg would hang forever
+// waiting for keystrokes that no terminal will ever supply.
+func TestPrompt_YesMode_ReturnsDefault(t *testing.T) {
+	withYesMode(t, func() {
+		var got string
+		out := captureStderr(t, func() {
+			got = Prompt("PR title", "feat/x")
+		})
+		if got != "feat/x" {
+			t.Errorf("Prompt under YesMode = %q, want default %q", got, "feat/x")
+		}
+		if !strings.Contains(out, "PR title") {
+			t.Errorf("expected stderr trace to mention prompt; got %q", out)
+		}
+		if !strings.Contains(out, "feat/x") {
+			t.Errorf("expected stderr trace to show selected value; got %q", out)
+		}
+	})
+}
+
+// TestPrompt_YesMode_DoesNotBlock pins the regression: pre-fix, Prompt
+// would call readline.NewEx → block forever on closed stdin. We assert
+// the call returns within a tight bound.
+func TestPrompt_YesMode_DoesNotBlock(t *testing.T) {
+	withYesMode(t, func() {
+		done := make(chan string, 1)
+		go func() {
+			done <- Prompt("anything?", "yes")
+		}()
+		select {
+		case got := <-done:
+			if got != "yes" {
+				t.Errorf("got %q, want default %q", got, "yes")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Prompt under YesMode hung — regression of the MCP-hang bug")
+		}
+	})
+}
+
+// TestPromptPath_YesMode_ReturnsDefault: the same guarantee for the
+// path-completion variant, which has its own readline session and is
+// reachable from `ezs config set worktree_base_dir` and `ezs new`.
+func TestPromptPath_YesMode_ReturnsDefault(t *testing.T) {
+	withYesMode(t, func() {
+		got := PromptPath("Worktree base dir", "/tmp/ezs")
+		if got != "/tmp/ezs" {
+			t.Errorf("PromptPath under YesMode = %q, want %q", got, "/tmp/ezs")
+		}
+	})
+}
+
+// TestPromptRequired_YesMode_ExitsCleanly verifies that
+// PromptRequired — which has no defaultVal to fall back to — does NOT
+// spin forever under YesMode. The spec is: print a clear diagnostic to
+// stderr and exit 2. Caller running scripted needs the "this needed a
+// value" signal to fix their invocation. We test by re-execing the
+// current binary with an env flag that triggers a tiny program that
+// calls PromptRequired under YesMode.
+func TestPromptRequired_YesMode_ExitsCleanly(t *testing.T) {
+	if os.Getenv("EZS_TEST_PROMPT_REQUIRED_YESMODE") == "1" {
+		// Child mode: simulate the production path.
+		YesMode = true
+		PromptRequired("Enter branch name")
+		// Should never reach here.
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestPromptRequired_YesMode_ExitsCleanly")
+	cmd.Env = append(os.Environ(), "EZS_TEST_PROMPT_REQUIRED_YESMODE=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit from PromptRequired under YesMode, got success")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected exit error, got: %v", err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Errorf("exit code = %d, want 2", exitErr.ExitCode())
+	}
+	if !strings.Contains(stderr.String(), "Enter branch name") {
+		t.Errorf("stderr should name the prompt; got: %q", stderr.String())
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "non-interactive") {
+		t.Errorf("stderr should explain why; got: %q", stderr.String())
+	}
+}
+
+// TestEditWithEditor_YesMode_ReturnsInitialContent: under YesMode the
+// editor is skipped (no TTY for $EDITOR) and the unchanged initial
+// content is returned. Pre-fix, `ezs pr create` (which runs
+// `ConfirmTUI("Edit PR description?")` → returns true under YesMode →
+// EditWithEditor) would launch vim against a non-existent terminal and
+// hang.
+func TestEditWithEditor_YesMode_ReturnsInitialContent(t *testing.T) {
+	withYesMode(t, func() {
+		initial := "# PR description\n\nDetails here.\n"
+		got, err := EditWithEditor(initial, ".md")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The function trims trailing whitespace from the returned content;
+		// initial string ends with "\n" so the trimmed comparison is valid.
+		want := strings.TrimSpace(initial)
+		if got != want {
+			t.Errorf("EditWithEditor under YesMode = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestEditWithEditor_YesMode_DoesNotShellOut: belt-and-braces — make
+// sure no `vim` / $EDITOR process is spawned. We point $EDITOR at a
+// command that would fail loudly if invoked, and assert no error
+// surfaces (the function must short-circuit).
+func TestEditWithEditor_YesMode_DoesNotShellOut(t *testing.T) {
+	t.Setenv("EDITOR", "/nonexistent-editor-binary")
+	t.Setenv("VISUAL", "")
+	withYesMode(t, func() {
+		_, err := EditWithEditor("hello", ".md")
+		if err != nil {
+			t.Fatalf("EditWithEditor under YesMode tried to shell out: %v", err)
+		}
+	})
+}
+
+// TestPromptRequired_NotInYesMode_StillCallsBackend: regression guard —
+// the YesMode branch must not change behavior when YesMode is false.
+// The TerminalBackend would normally try readline; we install a fake
+// backend that records the call and returns a fixed answer.
+func TestPromptRequired_NotInYesMode_StillCallsBackend(t *testing.T) {
+	old := activeBackend
+	defer func() { activeBackend = old }()
+	fb := &fakeBackend{TerminalBackend: TerminalBackend{}, promptRequiredAnswer: "hello"}
+	activeBackend = fb
+
+	got := PromptRequired("Enter something")
+	if got != "hello" {
+		t.Errorf("PromptRequired = %q, want %q (backend should be called when not in YesMode)", got, "hello")
+	}
+	if fb.promptRequiredCalls != 1 {
+		t.Errorf("backend.PromptRequired calls = %d, want 1", fb.promptRequiredCalls)
+	}
+}
+
+// fakeBackend lets us assert that the activeBackend is bypassed under
+// YesMode for the prompt-family functions and used otherwise. Embeds
+// TerminalBackend so we satisfy the full interface without rewriting
+// every method.
+type fakeBackend struct {
+	TerminalBackend
+	promptRequiredAnswer string
+	promptRequiredCalls  int
+}
+
+func (f *fakeBackend) PromptRequired(prompt string) string {
+	f.promptRequiredCalls++
+	return f.promptRequiredAnswer
+}

--- a/internal/ui/yesmode_test.go
+++ b/internal/ui/yesmode_test.go
@@ -407,3 +407,101 @@ func TestSelectOptionWithBack_YesMode(t *testing.T) {
 		})
 	})
 }
+
+// fakeMCPishBackend simulates a non-Terminal backend (MCPBackend in
+// production). Each Select* method increments a counter and returns a
+// deterministic answer — we only care whether the package-level wrapper
+// dispatched to us at all.
+type fakeMCPishBackend struct {
+	TerminalBackend
+	stackCalls     int
+	optionWithBack int
+	branchCalls    int
+}
+
+func (f *fakeMCPishBackend) SelectStack(stacks []*config.Stack, _ string) (*config.Stack, error) {
+	f.stackCalls++
+	if len(stacks) == 0 {
+		return nil, nil
+	}
+	return stacks[0], nil
+}
+
+func (f *fakeMCPishBackend) SelectOptionWithBack(options []string, _ string) (int, error) {
+	f.optionWithBack++
+	if len(options) == 0 {
+		return -1, nil
+	}
+	return 0, nil
+}
+
+func (f *fakeMCPishBackend) SelectBranch(branches []*config.Branch, _ string) (*config.Branch, error) {
+	f.branchCalls++
+	if len(branches) == 0 {
+		return nil, nil
+	}
+	return branches[0], nil
+}
+
+// TestBackendDispatch_YesMode_PreservesElicitation pins the asymmetric design
+// described in ui.go:445 (and the SelectOptionWithBack docstring): for
+// helpers dispatched through the Backend interface (SelectStack,
+// SelectOptionWithBack, SelectBranch), the YesMode guard must live on the
+// TerminalBackend method, NOT the package-level wrapper. Otherwise an MCP
+// invocation — which installs MCPBackend (uses elicitation, doesn't hang on
+// missing TTY) AND flips YesMode=true — would never reach MCPBackend's
+// elicitation code, breaking multi-stack disambiguation flows that depend
+// on user input via the MCP client.
+//
+// We assert this by replacing activeBackend with a fake that records calls,
+// flipping YesMode=true, and verifying the fake is invoked even when there
+// are 2+ items (the case where TerminalBackend would short-circuit).
+func TestBackendDispatch_YesMode_PreservesElicitation(t *testing.T) {
+	old := activeBackend
+	defer func() { activeBackend = old }()
+	fb := &fakeMCPishBackend{}
+	activeBackend = fb
+
+	withYesMode(t, func() {
+		runWithDeadline(t, 2*time.Second, func() {
+			// SelectStack: 2+ stacks. With package-level guard this would
+			// auto-error and never call the backend. We expect the fake's
+			// SelectStack to be invoked once.
+			stacks := []*config.Stack{{Hash: "abc12345"}, {Hash: "def67890"}}
+			got, err := SelectStack(stacks, "x")
+			if err != nil {
+				t.Errorf("SelectStack(non-Terminal, multi): unexpected err %v", err)
+			}
+			if got != stacks[0] {
+				t.Errorf("SelectStack: got %v, want stacks[0]", got)
+			}
+			if fb.stackCalls != 1 {
+				t.Errorf("SelectStack: backend called %d times, want 1 (regression: package-level guard short-circuited the backend)", fb.stackCalls)
+			}
+
+			// Same for SelectOptionWithBack.
+			idx, err := SelectOptionWithBack([]string{"a", "b", "c"}, "p")
+			if err != nil || idx != 0 {
+				t.Errorf("SelectOptionWithBack: got (%d, %v), want (0, nil)", idx, err)
+			}
+			if fb.optionWithBack != 1 {
+				t.Errorf("SelectOptionWithBack: backend called %d times, want 1", fb.optionWithBack)
+			}
+
+			// SelectBranch dispatches to the backend, which on TerminalBackend
+			// flows through SelectBranchWithStacks (package-level guard).
+			// On a non-Terminal backend it must call SelectBranch directly.
+			branches := []*config.Branch{{Name: "a"}, {Name: "b"}}
+			b, err := SelectBranch(branches, "p")
+			if err != nil {
+				t.Errorf("SelectBranch: unexpected err %v", err)
+			}
+			if b != branches[0] {
+				t.Errorf("SelectBranch: got %v, want branches[0]", b)
+			}
+			if fb.branchCalls != 1 {
+				t.Errorf("SelectBranch: backend called %d times, want 1", fb.branchCalls)
+			}
+		})
+	})
+}

--- a/itests/concurrent_save_helper.go
+++ b/itests/concurrent_save_helper.go
@@ -1,0 +1,51 @@
+package itests
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+)
+
+// concurrentSaveHelperMain is the body executed when the test binary is
+// re-invoked with EZS_CONCURRENT_SAVE_HELPER=1. It performs a fixed number
+// of LoadStackConfig + add-a-stack + Save iterations against the
+// EZSTACK_HOME the parent points it at, then exits 0 on success.
+//
+// Used by TestStackConfig_MultiProcessConcurrentSave to verify that
+// flock + three-way merge survive real cross-process contention (not
+// just goroutines). Goroutines in one process share heap state and miss
+// the inter-process race that flock is supposed to defend against.
+func concurrentSaveHelperMain() {
+	repo := os.Getenv("EZS_HELPER_REPO")
+	prefix := os.Getenv("EZS_HELPER_PREFIX")
+	itersStr := os.Getenv("EZS_HELPER_ITERS")
+	if repo == "" || prefix == "" || itersStr == "" {
+		fmt.Fprintln(os.Stderr, "concurrent save helper: missing EZS_HELPER_REPO/PREFIX/ITERS")
+		os.Exit(2)
+	}
+	iters, err := strconv.Atoi(itersStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "concurrent save helper: bad ITERS %q: %v\n", itersStr, err)
+		os.Exit(2)
+	}
+
+	for i := 0; i < iters; i++ {
+		sc, err := config.LoadStackConfig(repo)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "iter %d: load: %v\n", i, err)
+			os.Exit(1)
+		}
+		hash := config.GenerateStackHash(fmt.Sprintf("%s-%03d", prefix, i))
+		sc.Stacks[hash] = &config.Stack{
+			Hash: hash,
+			Root: "main",
+			Tree: config.BranchTree{fmt.Sprintf("%s-%03d", prefix, i): config.BranchTree{}},
+		}
+		if err := sc.Save(repo); err != nil {
+			fmt.Fprintf(os.Stderr, "iter %d: save: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/itests/concurrent_save_test.go
+++ b/itests/concurrent_save_test.go
@@ -1,0 +1,180 @@
+package itests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+)
+
+// TestStackConfig_MultiProcessConcurrentSave is the cross-process flavor
+// of the existing in-process concurrency tests. Spawning real subprocesses
+// catches regressions that goroutines can't see — most importantly, an
+// flock implementation that's actually no-op on the host OS, or a Save
+// path that reads stacks.json *before* taking the lock.
+//
+// The test re-execs the test binary itself with EZS_CONCURRENT_SAVE_HELPER=1
+// (see TestMain). Each child writes 30 distinct stacks under its own
+// prefix; with workers=4 we expect 120 total stacks in stacks.json
+// afterwards. Anything less means an update was lost across processes.
+//
+// Tuned timeouts: 30s per child is generous on cold-cache CI, but the
+// test as a whole must finish well inside Go's default 10-minute test
+// budget so there's no risk of slipping into a flaky timeout pattern.
+func TestStackConfig_MultiProcessConcurrentSave(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	tmpHome := t.TempDir()
+	const repo = "/test/cross-process"
+	const workers = 4
+	const iters = 30
+
+	prefixes := []string{"alpha", "beta", "gamma", "delta"}
+	if len(prefixes) != workers {
+		t.Fatalf("test setup bug: workers=%d but prefixes=%d", workers, len(prefixes))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	start := time.Now()
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(prefix string) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			cmd := exec.CommandContext(ctx, exe, "-test.run=^$") // run no tests in child
+			cmd.Env = append(os.Environ(),
+				"EZS_CONCURRENT_SAVE_HELPER=1",
+				"EZSTACK_HOME="+tmpHome,
+				"EZS_HELPER_REPO="+repo,
+				"EZS_HELPER_PREFIX="+prefix,
+				fmt.Sprintf("EZS_HELPER_ITERS=%d", iters),
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				errs <- fmt.Errorf("worker %s: %w\noutput:\n%s", prefix, err, out)
+			}
+		}(prefixes[w])
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Errorf("%v", e)
+	}
+	if t.Failed() {
+		return
+	}
+
+	t.Logf("multi-process save took %v", time.Since(start))
+
+	// Reload final state and assert.
+	t.Setenv("EZSTACK_HOME", tmpHome)
+	final, err := config.LoadStackConfig(repo)
+	if err != nil {
+		t.Fatalf("final load: %v", err)
+	}
+	want := workers * iters
+	if got := len(final.Stacks); got != want {
+		t.Errorf("after multi-process save: %d stacks in repo, want %d (lost %d)", got, want, want-got)
+	}
+
+	// Every prefix must contribute exactly `iters` stacks. A regression
+	// where one writer's prefix went missing entirely would only show up
+	// in the per-prefix breakdown — total-count parity is necessary but
+	// not sufficient.
+	perPrefix := map[string]int{}
+	for _, s := range final.Stacks {
+		for name := range s.Tree {
+			for _, p := range prefixes {
+				if len(name) >= len(p) && name[:len(p)] == p {
+					perPrefix[p]++
+				}
+			}
+		}
+	}
+	for _, p := range prefixes {
+		if perPrefix[p] != iters {
+			t.Errorf("prefix %q contributed %d stacks, want %d", p, perPrefix[p], iters)
+		}
+	}
+}
+
+// TestAcquireFileLock_StaleLockFileRecoversAfterHolderExit is a
+// process-level companion to the in-process TestAcquireFileLock_*
+// suite: when a child process holding the lock exits, the OS releases
+// flock automatically and a follow-up acquire from the parent (or a
+// fresh child) must succeed without manual intervention. This catches
+// regressions where the lock file's lifecycle is tied to the lock
+// itself (e.g., we deleted the lock file on release and a stuck child
+// blocks every future invocation).
+func TestAcquireFileLock_StaleLockFileRecoversAfterHolderExit(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	tmpHome := t.TempDir()
+	const repo = "/test/stale-lock"
+
+	// Run the helper once with iters=1 and let it exit. That establishes
+	// the lock file on disk. After it exits, the OS has released flock,
+	// so an in-process acquire here must succeed promptly.
+	cmd := exec.Command(exe, "-test.run=^$")
+	cmd.Env = append(os.Environ(),
+		"EZS_CONCURRENT_SAVE_HELPER=1",
+		"EZSTACK_HOME="+tmpHome,
+		"EZS_HELPER_REPO="+repo,
+		"EZS_HELPER_PREFIX=stale",
+		"EZS_HELPER_ITERS=1",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed run failed: %v\n%s", err, out)
+	}
+
+	// The stacks.json.lock file should exist now.
+	lockPath := filepath.Join(tmpHome, "stacks.json.lock")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock file should exist after child exit: %v", err)
+	}
+
+	// Now exercise the parent path: load + save in this process. If lock
+	// recovery is broken, this would either hang or time out.
+	t.Setenv("EZSTACK_HOME", tmpHome)
+
+	done := make(chan error, 1)
+	go func() {
+		sc, err := config.LoadStackConfig(repo)
+		if err != nil {
+			done <- err
+			return
+		}
+		hash := config.GenerateStackHash("post-helper")
+		sc.Stacks[hash] = &config.Stack{
+			Hash: hash,
+			Root: "main",
+			Tree: config.BranchTree{"post-helper": config.BranchTree{}},
+		}
+		done <- sc.Save(repo)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("post-helper save: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("post-helper save hung — lock file was not released after child exit")
+	}
+}

--- a/itests/main_test.go
+++ b/itests/main_test.go
@@ -1,0 +1,21 @@
+package itests
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain dispatches to the concurrent-save helper when the parent test
+// re-invokes this binary with EZS_CONCURRENT_SAVE_HELPER=1. The "test
+// binary as a multi-purpose executable" pattern lets us exercise true
+// multi-process file locking without shipping a separate helper binary.
+//
+// Important: always fall through to m.Run() in the normal case so the
+// rest of the itest suite is unaffected.
+func TestMain(m *testing.M) {
+	if os.Getenv("EZS_CONCURRENT_SAVE_HELPER") == "1" {
+		concurrentSaveHelperMain()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -97,6 +97,15 @@ if [ -f "$FILE" ] && command -v node >/dev/null 2>&1; then
     changed+=("tauri-ui/package-lock.json")
 fi
 
+# 7b. Tauri desktop frontend version constant — displayed in the title bar and
+#     settings dialog. Until this file is bumped, the desktop UI shows a stale
+#     version string even though the Cargo binary itself reports the right one.
+FILE="$REPO_ROOT/tauri-ui/src/version.ts"
+if [ -f "$FILE" ]; then
+    sed -i.bak "s/APP_VERSION = \"[^\"]*\"/APP_VERSION = \"$NEW_VERSION\"/" "$FILE"
+    changed+=("tauri-ui/src/version.ts")
+fi
+
 # 8. Tauri desktop tauri.conf.json
 FILE="$REPO_ROOT/tauri-ui/src-tauri/tauri.conf.json"
 if [ -f "$FILE" ]; then

--- a/tauri-ui/src-tauri/src/types.rs
+++ b/tauri-ui/src-tauri/src/types.rs
@@ -13,6 +13,10 @@ pub struct Branch {
     pub pr_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additions: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,6 +45,16 @@ pub struct Stack {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub root: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_base: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_pr_number: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_additions: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_deletions: Option<i32>,
     pub branches: Vec<Branch>,
 }
 
@@ -50,6 +64,16 @@ pub struct StatusStack {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub root: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_base: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_pr_number: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_additions: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_deletions: Option<i32>,
     pub branches: Vec<StatusBranch>,
 }
 
@@ -60,7 +84,11 @@ pub struct CommandResult {
     pub exit_code: i32,
 }
 
-// Mirrors ~/.ezstack/config.json
+// Mirrors ~/.ezstack/config.json. READ-ONLY — these structs deliberately omit
+// fields the desktop app doesn't read (github_token, cd_after_new,
+// use_worktrees, init_submodules, auto_draft_wip_commits, agent_command). If
+// the app ever needs to *write* this file, fill in those fields first or it
+// will silently strip them on round-trip.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EzstackConfig {
     #[serde(default)]

--- a/tauri-ui/src-tauri/src/types.rs
+++ b/tauri-ui/src-tauri/src/types.rs
@@ -33,10 +33,10 @@ pub struct StatusBranch {
     pub mergeable: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub review_state: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub additions: Option<i32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deletions: Option<i32>,
+    // additions / deletions live on `branch` (flattened above). Defining
+    // them here too made serde emit two values for the same JSON key —
+    // ambiguous on serialize and last-write-wins on deserialize — exactly
+    // the bug the Go side fixed in statusBranchJSON. Read via `b.branch.additions`.
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tauri-ui/src/types/ezstack.ts
+++ b/tauri-ui/src/types/ezstack.ts
@@ -6,6 +6,11 @@ export interface Branch {
   pr_number?: number;
   pr_url?: string;
   worktree_path?: string;
+  // Per-branch line deltas relative to parent. The CLI started emitting
+  // these in v4.7; the Rust types.rs::Branch struct mirrors them, and the
+  // frontend reads them on the StatusBranch subclass via inheritance.
+  additions?: number;
+  deletions?: number;
 }
 
 export interface StatusBranch extends Branch {
@@ -14,15 +19,38 @@ export interface StatusBranch extends Branch {
   ci_summary?: string;
   mergeable?: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
   review_state?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED";
-  additions?: number;
-  deletions?: number;
+  // additions/deletions are inherited from Branch above.
 }
 
-export interface StatusStack {
+// Stack root metadata. The CLI emits these so the desktop can display the
+// PR status and line counts of the root branch (typically the one that
+// targets `main`) without recomputing from `branches`. They are optional
+// because old CLIs (< v4.7) don't emit them and the frontend must still
+// render those payloads.
+export interface StackRootInfo {
+  root_base?: string;
+  root_pr_number?: number;
+  root_pr_url?: string;
+  root_additions?: number;
+  root_deletions?: number;
+}
+
+export interface StatusStack extends StackRootInfo {
   hash: string;
   name?: string;
   root: string;
   branches: StatusBranch[];
+}
+
+// Mirrors Rust types.rs::Stack — the non-status variant the CLI emits for
+// commands that don't enrich with PR/CI state. The desktop primarily uses
+// StatusStack but having Stack defined keeps the schemas symmetric (and
+// type-checked) so future commands that return plain Stack don't drift.
+export interface Stack extends StackRootInfo {
+  hash: string;
+  name?: string;
+  root: string;
+  branches: Branch[];
 }
 
 export interface RepoConfig {

--- a/tauri-ui/src/version.ts
+++ b/tauri-ui/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "3.2.6-tauri-beta.3";
+export const APP_VERSION = "4.7.6";

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -145,6 +145,26 @@ export async function activate(
     return;
   }
 
+  // Warn if the CLI is too old. The extension calls features that landed in
+  // 4.7.0 (--cascade, --draft-all, --all-remotes, --verify, pr stack,
+  // config export/import, stack rename, agent --preset). Older binaries hit
+  // cryptic errors at the call site; nudge the user toward `ezs upgrade`.
+  const MIN_CLI_VERSION = { major: 4, minor: 7, patch: 0 };
+  const v = await cli.getVersionSemver();
+  if (v) {
+    const tooOld =
+      v.major < MIN_CLI_VERSION.major ||
+      (v.major === MIN_CLI_VERSION.major && v.minor < MIN_CLI_VERSION.minor) ||
+      (v.major === MIN_CLI_VERSION.major &&
+        v.minor === MIN_CLI_VERSION.minor &&
+        v.patch < MIN_CLI_VERSION.patch);
+    if (tooOld) {
+      vscode.window.showWarningMessage(
+        `ezstack: detected ezs v${v.major}.${v.minor}.${v.patch} — extension features may fail. Run \`ezs upgrade\` to update to ${MIN_CLI_VERSION.major}.${MIN_CLI_VERSION.minor}.${MIN_CLI_VERSION.patch} or newer.`,
+      );
+    }
+  }
+
   // Folder decorations (colored badges on workspace folders)
   const decorations = new FolderDecorationProvider(cli);
   context.subscriptions.push(

--- a/vscode-extension/src/ezsCli.test.ts
+++ b/vscode-extension/src/ezsCli.test.ts
@@ -62,3 +62,51 @@ describe("parseJSON", () => {
     );
   });
 });
+
+describe("EzsCli.parseVersionSemver", () => {
+  it("parses the standard ezstack version line", () => {
+    expect(EzsCli.parseVersionSemver("ezstack version 4.7.6\n")).toEqual({
+      major: 4,
+      minor: 7,
+      patch: 6,
+    });
+  });
+
+  it("parses a leading 'v' prefix", () => {
+    expect(EzsCli.parseVersionSemver("ezstack version v4.7.0\n")).toEqual({
+      major: 4,
+      minor: 7,
+      patch: 0,
+    });
+  });
+
+  it("anchors on 'version ' so trailing build metadata can't introduce a spurious match", () => {
+    // If the regex only matched any numeric triple, the build-metadata
+    // hash 2025.05.03 below would race the real triple. The anchor
+    // prevents that — we should still get 1.2.3.
+    expect(EzsCli.parseVersionSemver("ezstack version 1.2.3-rc.1+2025.05.03")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+    });
+  });
+
+  it("returns null when the version line is missing", () => {
+    expect(EzsCli.parseVersionSemver("")).toBeNull();
+    expect(EzsCli.parseVersionSemver("garbage 1.2 not enough segments")).toBeNull();
+  });
+
+  it("ignores leading non-version lines", () => {
+    // Future-proofing: if `ezs --version` ever prepends a deprecation
+    // notice, the parser should still find the canonical line.
+    const out = ["warning: outdated config schema", "ezstack version 4.7.5"].join("\n");
+    expect(EzsCli.parseVersionSemver(out)).toEqual({ major: 4, minor: 7, patch: 5 });
+  });
+
+  it("does not pick up a non-version triple like `git 2.43.0`", () => {
+    // Without the 'version ' anchor we'd match `2.43.0` from doctor-style
+    // output and wrongly claim the CLI is 2.43.0.
+    const out = "git: 2.43.0\nfzf: 0.45.0\n"; // no `ezstack version` line
+    expect(EzsCli.parseVersionSemver(out)).toBeNull();
+  });
+});

--- a/vscode-extension/src/ezsCli.test.ts
+++ b/vscode-extension/src/ezsCli.test.ts
@@ -109,4 +109,36 @@ describe("EzsCli.parseVersionSemver", () => {
     const out = "git: 2.43.0\nfzf: 0.45.0\n"; // no `ezstack version` line
     expect(EzsCli.parseVersionSemver(out)).toBeNull();
   });
+
+  it("parses the ezs-mcp variant emitted as 'ezstack-mcp version X.Y.Z'", () => {
+    // The MCP server's --version line was tightened to share the
+    // 'version ' anchor with the main CLI — verify the regex matches
+    // both binaries identically so a future caller that points the
+    // gate at ezs-mcp doesn't silently fall through to "unknown
+    // version → skip warning".
+    expect(EzsCli.parseVersionSemver("ezstack-mcp version 4.7.6\n")).toEqual({
+      major: 4,
+      minor: 7,
+      patch: 6,
+    });
+  });
+
+  it("tolerates Windows CRLF line endings", () => {
+    // ezs --version on Windows ends lines with \r\n. The regex must
+    // tolerate the carriage return — \b matches between `6` and `\r`,
+    // so we expect the same triple as the LF case.
+    expect(EzsCli.parseVersionSemver("ezstack version 4.7.6\r\n")).toEqual({
+      major: 4,
+      minor: 7,
+      patch: 6,
+    });
+  });
+
+  it("treats the empty result as 'unknown' rather than throwing", () => {
+    // Defensive: if `ezs --version` ever prints to stderr instead of
+    // stdout, the captured stdout could be empty. The activation gate
+    // must degrade to skipping the warning, not to a thrown exception.
+    expect(() => EzsCli.parseVersionSemver("")).not.toThrow();
+    expect(EzsCli.parseVersionSemver("")).toBeNull();
+  });
 });

--- a/vscode-extension/src/ezsCli.ts
+++ b/vscode-extension/src/ezsCli.ts
@@ -266,17 +266,34 @@ export class EzsCli {
    * when the extension is paired with a too-old CLI that lacks features the
    * extension calls (e.g. `--cascade`, `--draft-all`, `pr stack`,
    * `config export/import`, `stack rename`, `agent --preset`).
+   *
+   * Matches `ezstack version X.Y.Z` (the literal `cmd/ezs/main.go` format)
+   * with optional pre-release/build suffix (e.g. `4.7.0-rc.1+abc`). The
+   * leading "version " anchor is intentional: it stops a trailing build
+   * hash like `1.2.3-2025.05.03+abc` from contributing a spurious second
+   * triple match further down the string.
    */
   async getVersionSemver(): Promise<{ major: number; minor: number; patch: number } | null> {
     try {
       const out = await this.getVersion();
-      // `ezs --version` prints `ezstack version X.Y.Z`
-      const m = out.match(/(\d+)\.(\d+)\.(\d+)/);
+      const m = out.match(/version\s+v?(\d+)\.(\d+)\.(\d+)\b/i);
       if (!m) return null;
       return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10), patch: parseInt(m[3], 10) };
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Exposed only for tests — `getVersion` shells out to the CLI and is
+   * inconvenient to stub. parseVersionSemver runs the same regex against
+   * an arbitrary string so tests can pin both happy-path output and
+   * adversarial inputs (build metadata, garbage, blank lines).
+   */
+  static parseVersionSemver(out: string): { major: number; minor: number; patch: number } | null {
+    const m = out.match(/version\s+v?(\d+)\.(\d+)\.(\d+)\b/i);
+    if (!m) return null;
+    return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10), patch: parseInt(m[3], 10) };
   }
 
   async getLocalBranches(): Promise<string[]> {

--- a/vscode-extension/src/ezsCli.ts
+++ b/vscode-extension/src/ezsCli.ts
@@ -4,11 +4,8 @@ import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import {
-  DiffOutputJSON,
-  LogOutputJSON,
   StackJSON,
   StatusStackJSON,
-  SyncInfoJSON,
   WorktreeGitStatus,
 } from "./types";
 
@@ -263,6 +260,25 @@ export class EzsCli {
     return out.trim();
   }
 
+  /**
+   * Return the parsed semver of the resolved `ezs` binary, or null if the
+   * version line couldn't be parsed. Used by the activation gate to detect
+   * when the extension is paired with a too-old CLI that lacks features the
+   * extension calls (e.g. `--cascade`, `--draft-all`, `pr stack`,
+   * `config export/import`, `stack rename`, `agent --preset`).
+   */
+  async getVersionSemver(): Promise<{ major: number; minor: number; patch: number } | null> {
+    try {
+      const out = await this.getVersion();
+      // `ezs --version` prints `ezstack version X.Y.Z`
+      const m = out.match(/(\d+)\.(\d+)\.(\d+)/);
+      if (!m) return null;
+      return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10), patch: parseInt(m[3], 10) };
+    } catch {
+      return null;
+    }
+  }
+
   async getLocalBranches(): Promise<string[]> {
     const out = await this.execGit(["branch", "--format=%(refname:short)"]);
     return out.trim().split("\n").filter(Boolean);
@@ -284,15 +300,6 @@ export class EzsCli {
     }
     const out = await this.exec(args);
     return EzsCli.parseJSON(out, "status --json");
-  }
-
-  async syncDryRun(all = false): Promise<SyncInfoJSON[]> {
-    const args = ["sync", "--dry-run", "--json"];
-    if (all) {
-      args.push("--all");
-    }
-    const out = await this.exec(args);
-    return EzsCli.parseJSON(out, "sync --dry-run --json");
   }
 
   // ── Mutations (headless with -y) ──
@@ -429,21 +436,6 @@ export class EzsCli {
 
   async syncBranch(branch: string): Promise<void> {
     await this.execYes(["sync", "--branch", branch]);
-  }
-
-  async diffJSON(branch: string): Promise<DiffOutputJSON> {
-    const out = await this.exec(["diff", "--branch", branch, "--json"]);
-    return EzsCli.parseJSON(out, "diff --json");
-  }
-
-  async logJSON(branch: string): Promise<LogOutputJSON> {
-    const out = await this.exec(["log", "--branch", branch, "--json"]);
-    return EzsCli.parseJSON(out, "log --json");
-  }
-
-  async statusBranch(branch: string): Promise<StatusStackJSON[]> {
-    const out = await this.exec(["status", "--branch", branch, "--json"]);
-    return EzsCli.parseJSON(out, "status --branch --json");
   }
 
   // ── Interactive (terminal) ──

--- a/vscode-extension/src/parentPicker.test.ts
+++ b/vscode-extension/src/parentPicker.test.ts
@@ -14,6 +14,8 @@ const branch = (name: string, parent = "main") => ({
   parent,
   is_merged: false,
   is_current: false,
+  additions: 0,
+  deletions: 0,
 });
 
 describe("buildParentPickChoices", () => {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -3,6 +3,12 @@ export interface StackJSON {
   hash: string;
   name?: string;
   root: string;
+  /** Set when the stack root is itself a tracked branch with its own PR. */
+  root_base?: string;
+  root_pr_number?: number;
+  root_pr_url?: string;
+  root_additions?: number;
+  root_deletions?: number;
   branches: BranchJSON[];
 }
 
@@ -15,6 +21,9 @@ export interface BranchJSON {
   pr_number?: number;
   pr_url?: string;
   worktree_path?: string;
+  /** Always emitted (no omitempty). */
+  additions: number;
+  deletions: number;
 }
 
 /** Mirrors the Go statusStackJSON struct (ezs status --json) */
@@ -22,6 +31,11 @@ export interface StatusStackJSON {
   hash: string;
   name?: string;
   root: string;
+  root_base?: string;
+  root_pr_number?: number;
+  root_pr_url?: string;
+  root_additions?: number;
+  root_deletions?: number;
   branches: StatusBranchJSON[];
 }
 
@@ -31,9 +45,8 @@ export interface StatusBranchJSON extends BranchJSON {
   ci_state?: "success" | "failure" | "pending" | "none" | "";
   ci_summary?: string;
   mergeable?: "MERGEABLE" | "CONFLICTING" | "UNKNOWN" | "";
-  review_state?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "";
-  additions?: number;
-  deletions?: number;
+  /** "" appears for PRs without a review yet; gh also returns "COMMENTED". */
+  review_state?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "COMMENTED" | "";
 }
 
 /** Per-file git status indicator. */
@@ -54,9 +67,14 @@ export interface WorktreeGitStatus {
 export interface SyncInfoJSON {
   branch: string;
   needs_sync: boolean;
-  reason?: string;
-  parent?: string;
+  /** Set when the parent branch has been merged into the stack root. */
+  merged_parent?: string;
+  /** Set when the branch is behind its parent (rebase needed). */
+  behind_parent?: string;
+  /** Number of commits this branch is behind its parent. */
   behind_by?: number;
+  /** The branch this stack is rooted on (typically the default base). */
+  stack_root: string;
 }
 
 /** Mirrors the Go diffOutputJSON struct from cmd/ezs/commands/diff.go */

--- a/vscode-extension/src/views/stackTreeProvider.test.ts
+++ b/vscode-extension/src/views/stackTreeProvider.test.ts
@@ -8,6 +8,8 @@ function makeBranch(overrides: Partial<StatusBranchJSON> = {}): StatusBranchJSON
     parent: "main",
     is_merged: false,
     is_current: false,
+    additions: 0,
+    deletions: 0,
     ...overrides,
   };
 }

--- a/vscode-extension/src/views/stackTreeProvider.ts
+++ b/vscode-extension/src/views/stackTreeProvider.ts
@@ -260,16 +260,16 @@ export class StackTreeProvider
       fetched = await this.cli.statusStacks(true);
     } catch {
       try {
-        // Fallback: basic listStacks lacks status fields — normalize so
-        // downstream consumers don't see `undefined` where they expect
-        // booleans / paths.
+        // Fallback: basic listStacks lacks PR/CI status fields, but
+        // is_merged and worktree_path are already on BranchJSON — preserve
+        // them so merged branches don't render as not-merged just because
+        // gh is unavailable.
         const basic = await this.cli.listStacks(true);
         fetched = basic.map((s) => ({
           ...s,
           branches: s.branches.map((b) => ({
             ...b,
-            is_merged: false,
-            worktree_path: (b as unknown as { worktree_path?: string }).worktree_path ?? "",
+            worktree_path: b.worktree_path ?? "",
           })),
         })) as unknown as StatusStackJSON[];
       } catch {

--- a/vscode-extension/src/views/statusBarManager.test.ts
+++ b/vscode-extension/src/views/statusBarManager.test.ts
@@ -37,9 +37,9 @@ describe("findCurrentBranch", () => {
         hash: "abc",
         root: "main",
         branches: [
-          { name: "feat-a", parent: "main", is_merged: false, is_current: false },
-          { name: "feat-b", parent: "feat-a", is_merged: false, is_current: true },
-          { name: "feat-c", parent: "feat-b", is_merged: false, is_current: false },
+          { name: "feat-a", parent: "main", is_merged: false, is_current: false, additions: 0, deletions: 0 },
+          { name: "feat-b", parent: "feat-a", is_merged: false, is_current: true, additions: 0, deletions: 0 },
+          { name: "feat-c", parent: "feat-b", is_merged: false, is_current: false, additions: 0, deletions: 0 },
         ],
       },
     ];
@@ -56,7 +56,7 @@ describe("findCurrentBranch", () => {
         hash: "abc",
         root: "main",
         branches: [
-          { name: "feat-a", parent: "main", is_merged: false, is_current: false },
+          { name: "feat-a", parent: "main", is_merged: false, is_current: false, additions: 0, deletions: 0 },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Comprehensive audit of `main` (v4.7.6) found drift between the CLI and its satellites (MCP server, VS Code extension, Tauri desktop, Neovim plugin) plus several latent bugs in the Go code. This bundles fixes for all of them in a single PR.

## Bug fixes by severity

### Critical (silent data loss / process bricked)
- **MCP `captureCommand` panic leak** (`cmd/ezs-mcp/main.go`): a panic in any tool handler left `os.Stdout` pinned to a closed pipe and leaked drain goroutines. Wrapped restoration in `defer`.
- **`StackConfig.Save` TOCTOU** (`internal/config/config.go`): two parallel `ezs sync`s on different stacks of the same repo silently lost one process's writes. Save now does a three-way merge against the disk state captured at load time. New tests cover same-repo concurrency and the merge primitive.
- **`atomicWriteFile` not crash-safe**: added `tmp.Sync()` and parent-directory fsync so power loss can't leave `stacks.json` zero-length.
- **`status --json --all` returned empty stdout** when no stacks exist; broke Tauri's serde parser. Now emits `[]`.
- **Tauri version stuck at `3.2.6-tauri-beta.3`** in `tauri-ui/src/version.ts` (display only, but very visible). Bumped to 4.7.6 and added the file to `scripts/bump-version.sh` so it can't drift again.

### High
- **`ApplyBranchRenames` cache clobber**: rename to a name with prior cache entry wiped the existing entry's PR URL / merged flag. Now skips overwrite.
- **`pushChildBranches` fork-blind**: existence check was origin-only; for fork remotes the "never silently publish" gate was bypassed. New `Git.RemoteHasBranch(remote, branch)` helper.
- **`prCreateAllDraft` hardcoded origin**: ignored `Branch.EffectiveRemote()`. Now uses new `PushSetUpstreamBranch(branch, remote)`.
- **`removeBranchFromTree` sibling clobber**: removing a branch whose child shares a name with a sibling silently dropped the sibling's grandchildren. Now merges subtrees on collision.
- **`RebaseChildren` mid-rebase `Reconcile`**: recursive descent ran full reconciliation while a rebase was in flight, with potential to delete the branch we were rebasing onto. Switched to `NewReadOnlyManager`.
- **`IsLocalAheadOfRemote` error conflation**: any `rev-parse --verify` failure was treated as "ref doesn't exist". Now distinguishes "unknown revision" from real errors.
- **GitHub URL regex strips dots**: `my-repo.io` parsed as `my-repo`. Fixed regex to preserve dots and strip a trailing `.git` separately.

### Medium
- **`SelectTUI` / `SelectWorktreeWithStackPreview` ignored YesMode**: hung MCP tool calls. Now honors YesMode (returns default / errors loudly).
- **MCP doc count drift**: docs claimed 21 tools, actual 25. Added `ezstack_doctor`, `ezstack_pr_draft_all`, `ezstack_config_export`, `ezstack_config_import` to the catalog table.
- **`ezstack_pr_merge` undocumented side effect**: tool description now discloses that it auto-runs `Sync(["-s"])` after merge under YesMode.
- **VS Code `SyncInfoJSON` schema rot**: TS interface had `reason`/`parent` fields that the CLI never emitted. Aligned with actual `merged_parent`/`behind_parent`/`stack_root`.
- **VS Code is_merged override**: gh-unavailable fallback in `stackTreeProvider` overwrote the real `is_merged` value with `false`. Removed.
- **VS Code min-CLI version warning**: extension uses several v4.7-only flags but had no version check. Now warns on activation if `ezs --version` < 4.7.0.
- **Tauri schema gaps**: `StatusStack` / `Stack` were missing the five `root_*` fields the CLI emits; `Branch` was missing `additions`/`deletions`. `EzstackConfig`/`RepoConfig` annotated read-only.
- **Neovim `agent prompt edit` used `--reset`** to "create" prompt files, but `--reset` only deletes existing files. Plugin now creates the file directly with the same starter content the CLI writes.
- **Neovim `sync_branch` ignored its arg**: CLI gained `sync -b` in v4.7; plugin now passes it through.
- **Neovim min CLI version documented** in README and `doc/ezstack.txt`.

### Low / cleanup
- `Git.Push` and `Git.PushSetUpstream` (which read `CurrentBranch`) tagged Deprecated — they were the source of the v4.7.4 sync push-main bug. New callers should use `PushBranch` / `PushSetUpstreamBranch`.
- VS Code dead methods removed: `syncDryRun`, `diffJSON`, `logJSON`, `statusBranch`.

### Skipped (out of scope — pure feature work, not bugs)

Capability gaps the audit listed but this PR does not address:
- MCP missing flags: `ezstack_pr_create --stack`, `ezstack_delete --force/--stack`, `ezstack_reparent --merge/--rebase`, `ezstack_commit --push/--push-children/--no-push`, `ezstack_push --verify/--all-remotes`, `ezstack_new --worktree/--template/...`, `ezstack_stack rename` subcommand.
- Neovim unwired CLI features: `sync -p/-C`, `status --watch`, `new --template/--from-remote/...`, `reparent --merge/--rebase`, `push -b`, `:Ezs upgrade`, `agent --no-push/--preset/...`.
- Tauri frontend not yet calling `doctor`, `prDraftAll`, `gotoSearch`, `configExport/import` (backend exposes them; UI work pending).

## Test plan
- [x] `go test ./...` — all packages pass; new tests added for TOCTOU same-repo merge, three-way-merge unit, remove-branch sibling collision, GitHub URL regex
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `cargo check` (Tauri Rust) builds
- [x] VS Code: `tsc --noEmit` clean, all 41 vitest tests pass
- [x] Neovim: all 17 plenary tests pass against the bumped submodule
- [ ] Manual smoke test of `ezs status --json --all` on a stackless repo (CI doesn't cover)
- [ ] Manual smoke test of MCP `ezstack_commit` on a branch with children (no longer hangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)