### PR TITLE
fix(completions): surface pr refresh / pr unlink in tab completion

### DIFF
--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -18,7 +18,7 @@ var topLevelCommands = []string{
 	"reparent", "stack", "status", "sync", "unstack", "up", "upgrade",
 }
 
-var prSubcommands = []string{"create", "draft", "merge", "stack", "update"}
+var prSubcommands = []string{"create", "draft", "merge", "refresh", "stack", "unlink", "update"}
 
 var configSubcommands = []string{"set", "show", "export", "import"}
 
@@ -81,11 +81,13 @@ var commandFlags = map[string][]string{
 // `ezs pr create --<TAB>` surfaces create's flags rather than just the
 // top-level `--help`/`-h` from `pr` itself. Same drift-gate test applies.
 var prSubcommandFlags = map[string][]string{
-	"create": {"--stack", "-s", "--draft-all", "--title", "-t", "--body", "-b", "--draft", "-d", "--branch", "--auto", "--ai", "--force", "-f", "--recreate", "--help", "-h"},
-	"update": {"--branch", "--help", "-h"},
-	"merge":  {"--method", "-m", "--branch", "--no-delete-branch", "--help", "-h"},
-	"draft":  {"--branch", "--help", "-h"},
-	"stack":  {"--branch", "--help", "-h"},
+	"create":  {"--stack", "-s", "--draft-all", "--title", "-t", "--body", "-b", "--draft", "-d", "--branch", "--auto", "--ai", "--force", "-f", "--recreate", "--help", "-h"},
+	"update":  {"--branch", "--help", "-h"},
+	"merge":   {"--method", "-m", "--branch", "--no-delete-branch", "--help", "-h"},
+	"draft":   {"--branch", "--help", "-h"},
+	"stack":   {"--branch", "--help", "-h"},
+	"refresh": {"--branch", "--stack", "-s", "--help", "-h"},
+	"unlink":  {"--branch", "--all", "--yes", "-y", "--help", "-h"},
 }
 
 // agentSubcommandFlags lists the flags `ezs agent prompt` accepts. Without

--- a/itests/completions_test.go
+++ b/itests/completions_test.go
@@ -96,7 +96,7 @@ func TestCompletions_PRSubcommands(t *testing.T) {
 	defer env.Cleanup()
 
 	got := runCompletions(t, env, "pr", "")
-	for _, want := range []string{"create", "draft", "merge", "stack", "update"} {
+	for _, want := range []string{"create", "draft", "merge", "refresh", "stack", "unlink", "update"} {
 		if !itestContains(got, want) {
 			t.Errorf("pr subcommand %q missing in %v", want, got)
 		}
@@ -496,6 +496,156 @@ func TestCompletions_FlagTableMatchesHelpOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCompletions_SubcommandTableMatchesHelpOutput is the bidirectional drift
+// gate for *subcommand* completion — the sibling of FlagTableMatchesHelpOutput
+// for the layer above flags. For each parent command that has a SUBCOMMANDS
+// section in its --help, we exercise both directions:
+//
+//  1. help ⊆ completion: every subcommand documented in `<cmd> --help`
+//     SUBCOMMANDS must appear in `--completions <cmd> ""`. Catches the
+//     "command grew a subcommand, completion table didn't" failure mode that
+//     left `pr refresh` and `pr unlink` invisible to tab completion despite
+//     being implemented and documented.
+//  2. completion ⊆ help: every subcommand the completion offers must appear
+//     in --help (no phantom subcommands users tab to that the dispatcher
+//     then rejects).
+//
+// This complements FlagTableMatchesHelpOutput, which only checks the OPTIONS
+// section. Without this gate, dispatcher / help / completion can diverge at
+// the subcommand layer without CI noticing.
+func TestCompletions_SubcommandTableMatchesHelpOutput(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	// Each entry's parent command must (a) have a SUBCOMMANDS section in its
+	// --help and (b) emit subcommand candidates from --completions when the
+	// cursor sits in the slot immediately after the parent. The `agent`
+	// command intentionally uses a MODES section rather than SUBCOMMANDS
+	// (the default mode is unnamed; "feature/feat" and "ls/list" are documented
+	// as aliases inline), so it is covered separately by
+	// TestCompletions_AgentSubcommands rather than this gate.
+	parents := []struct {
+		cmd        string
+		extras     map[string]bool // completion candidates allowed despite being absent from help
+		exemptHelp map[string]bool // help subcommands allowed despite being absent from completion
+	}{
+		{cmd: "pr"},
+		{cmd: "config"},
+	}
+
+	bin := buildEzs(t)
+	for _, p := range parents {
+		t.Run(p.cmd, func(t *testing.T) {
+			compCmd := exec.Command(bin, "--completions", p.cmd, "")
+			compCmd.Dir = env.RepoDir
+			compCmd.Env = append(compCmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+			compOut, err := compCmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ezs --completions %s '' failed: %v\n%s", p.cmd, err, compOut)
+			}
+			compSubs := splitCompletionLines(compOut)
+
+			helpCmd := exec.Command(bin, p.cmd, "--help")
+			helpCmd.Dir = env.RepoDir
+			helpCmd.Env = append(helpCmd.Environ(), "EZSTACK_HOME="+env.ConfigDir)
+			helpOut, err := helpCmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ezs %s --help failed: %v\n%s", p.cmd, err, helpOut)
+			}
+			helpSubs := parseHelpSubcommands(string(helpOut))
+			if len(helpSubs) == 0 {
+				t.Fatalf("expected SUBCOMMANDS section in `ezs %s --help` but parsed none", p.cmd)
+			}
+
+			compSet := map[string]bool{}
+			for _, s := range compSubs {
+				compSet[s] = true
+			}
+			helpSet := map[string]bool{}
+			for _, s := range helpSubs {
+				helpSet[s] = true
+			}
+
+			for _, s := range helpSubs {
+				if p.exemptHelp[s] {
+					continue
+				}
+				if !compSet[s] {
+					t.Errorf("subcommand %q in `ezs %s --help` SUBCOMMANDS is missing from completion; %s subcommand list needs updating",
+						s, p.cmd, p.cmd)
+				}
+			}
+			for _, s := range compSubs {
+				if helpSet[s] || p.extras[s] {
+					continue
+				}
+				t.Errorf("phantom subcommand %q: completion offers it but `ezs %s --help` doesn't list it — does the dispatcher actually accept it?",
+					s, p.cmd)
+			}
+		})
+	}
+}
+
+// parseHelpSubcommands pulls the first token of each line in an ezs
+// `--help` SUBCOMMANDS section. The section follows this convention:
+//
+//	SUBCOMMANDS
+//	    create    Create a new pull request
+//	    draft     Toggle PR between draft and ready
+//	    refresh   Reconcile cached PR state from GitHub
+//
+// We strip ANSI, locate the SUBCOMMANDS heading, and read entries until
+// the next column-zero heading. The first whitespace-delimited token of
+// each indented line is the subcommand name.
+func parseHelpSubcommands(help string) []string {
+	help = stripANSI(help)
+	lines := strings.Split(help, "\n")
+	inSubs := false
+	var out []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "SUBCOMMANDS") {
+			inSubs = true
+			continue
+		}
+		if !inSubs {
+			continue
+		}
+		if line != "" && line[0] != ' ' && line[0] != '\t' {
+			break
+		}
+		if trimmed == "" {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) == 0 {
+			continue
+		}
+		tok := fields[0]
+		// Skip lines that aren't subcommand rows — e.g., wrapped description
+		// lines or notes that start with punctuation. Subcommand names are
+		// lowercase letters / digits / dashes.
+		if !isSubcommandToken(tok) {
+			continue
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+func isSubcommandToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-'
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // splitCompletionLines splits the stdout of `ezs --completions ...` into


### PR DESCRIPTION
## Summary

Audit pass across CLI / MCP / VSCode / nvim / Tauri turned up one concrete silent unintended behavior: `ezs pr refresh` and `ezs pr unlink` are documented in `ezs pr --help` and dispatched in `pr.go`, but neither the `prSubcommands` candidate list nor the `prSubcommandFlags` table in `completions.go` included them. So:

- `ezs pr <TAB>` silently surfaced only 5 of the 7 documented subcommands — users couldn't discover `refresh` or `unlink` via completion.
- `ezs pr refresh --<TAB>` (and `pr unlink --<TAB>`) fell through to the parent `pr` flag set (`--draft-all/--help/-h`) instead of the refresh- / unlink-specific flags the parser actually accepts. Tabbing to a phantom flag here would have triggered "unknown flag" at runtime.

Both are discoverability bugs — no runtime data corruption, but the kind of drift the existing flag drift gate (`TestCompletions_FlagTableMatchesHelpOutput`) is built to prevent. That gate only covers the OPTIONS section, leaving the SUBCOMMANDS layer unguarded — which is why this drift went unnoticed until the audit.

### Changes

- `cmd/ezs/completions.go`: add `refresh` and `unlink` to `prSubcommands` (candidate list) and to `prSubcommandFlags` (per-subcommand flag table) with their actual flag sets from `pr.go`.
- `itests/completions_test.go`:
  - extend `TestCompletions_PRSubcommands` to assert on the new subcommands too.
  - add a new bidirectional drift gate `TestCompletions_SubcommandTableMatchesHelpOutput` that parses the SUBCOMMANDS section of `<cmd> --help` and asserts both directions: help ⊆ completion (no missing subcommands) and completion ⊆ help (no phantom subcommands). Covers `pr` and `config`. `agent` is exempted because its help intentionally uses MODES rather than SUBCOMMANDS, and its coverage stays in `TestCompletions_AgentSubcommands`.

### Other audit findings (non-actionable here)

The audit also flagged a few items I deliberately did NOT include in this PR after verification:

- **VSCode `.catch(() => [])` on parent-branch lookup** (`commands/index.ts:113-114`): UX polish — silent fallback to empty picker. Worth a follow-up but not the same kind of structural drift this PR addresses.
- **MCP `pr_merge.method` lacks an `mcp.Enum(...)` constraint**: the CLI rejects bad values, so it's a schema-completeness / client-validation niceity rather than silent unintended behavior.
- **`runStatusWatch` writes ANSI escape codes to stderr unconditionally**: `--watch` is fundamentally interactive (the comment in code says so); not a real bug.
- Several other agent reports turned out to be false positives once the actual code was read (e.g. `pr refresh` "unimplemented" — it's at `pr.go:1258`; viewer "auto-reopens after close" — `bufhidden=wipe` at `ui.lua:467` rules that out).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green; `TestCompletions_*` green including the new drift gate)
- [x] Live verification: `ezs --completions pr ""` now emits all 7 subcommands; `ezs --completions pr refresh --` emits `--branch / --stack / -s / --help / -h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)