### PR TITLE
fix(tauri): push the targeted branch instead of git HEAD

### DIFF
--- a/tauri-ui/src-tauri/src/commands/operations.rs
+++ b/tauri-ui/src-tauri/src/commands/operations.rs
@@ -72,6 +72,7 @@ pub fn push_branch(
     force: bool,
     verify: Option<bool>,
     all_remotes: Option<bool>,
+    branch: Option<String>,
 ) -> Result<CommandResult, String> {
     let conn = locked_conn(&state)?;
     let mut args: Vec<&str> = vec!["-y", "push"];
@@ -86,6 +87,15 @@ pub fn push_branch(
     }
     if all_remotes.unwrap_or(false) {
         args.push("--all-remotes");
+    }
+    // Without -b the CLI pushes whatever git HEAD points at — wrong when
+    // the caller (right-pane "Push" button or per-row right-click) targets
+    // a specific branch in the UI rather than HEAD. Forward the explicit
+    // branch through so what runs matches what the UI promises.
+    let branch_value = branch.unwrap_or_default();
+    if !branch_value.is_empty() {
+        args.push("-b");
+        args.push(&branch_value);
     }
     run_ezs_auto(conn.as_ref(), &repo_path, &args)
 }

--- a/tauri-ui/src/App.tsx
+++ b/tauri-ui/src/App.tsx
@@ -198,7 +198,15 @@ export default function App() {
   const branchActions = selectedBranch_ && selectedRepoPath
     ? {
         onSync: () => setDialog({ type: "sync", branch: selectedBranch_.name }),
-        onPush: () => runAndRefresh(() => ezs.pushBranch(selectedRepoPath), "Push"),
+        // Without { branch } pushBranch falls back to git HEAD instead of
+        // the right-pane's selected branch. The sibling actions above and
+        // below (onSync, onCreatePR, onUpdatePR, ...) all forward
+        // selectedBranch_.name; push must too or the button label lies.
+        onPush: () =>
+          runAndRefresh(
+            () => ezs.pushBranch(selectedRepoPath, false, false, { branch: selectedBranch_.name }),
+            "Push",
+          ),
         onPushStack: () => runAndRefresh(() => ezs.pushBranch(selectedRepoPath, true), "Push stack"),
         onCreatePR: () => setDialog({ type: "pr-create", branch: selectedBranch_.name }),
         onUpdatePR: () => runAndRefresh(() => ezs.prUpdate(selectedRepoPath, selectedBranch_.name), "Update PR"),
@@ -223,7 +231,16 @@ export default function App() {
   const stackNodeActions: StackNodeActions | undefined = selectedRepoPath
     ? {
         onSync: (branchName) => setDialog({ type: "sync", branch: branchName }),
-        onPush: (branchName) => runAndRefresh(() => ezs.pushBranch(selectedRepoPath), `Push ${branchName}`),
+        // The toast says `Push ${branchName}` but without { branch }
+        // pushBranch silently runs against git HEAD — i.e. the user
+        // right-clicks branch B, sees "Push B" succeed, and branch A
+        // (whatever git HEAD points at) gets pushed instead. Same shape
+        // as the nvim viewer `p` keymap fix in ezstack.nvim#4.
+        onPush: (branchName) =>
+          runAndRefresh(
+            () => ezs.pushBranch(selectedRepoPath, false, false, { branch: branchName }),
+            `Push ${branchName}`,
+          ),
         onCreatePR: (branchName) => setDialog({ type: "pr-create", branch: branchName }),
         onUpdatePR: (branchName) => runAndRefresh(() => ezs.prUpdate(selectedRepoPath, branchName), `Update PR ${branchName}`),
         onOpenAgent: (branchName) => {

--- a/tauri-ui/src/commands/ezs.test.ts
+++ b/tauri-ui/src/commands/ezs.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture invoke calls. Mock @tauri-apps/api/core's `invoke` so we can
+// assert what argv (specifically the `branch` field) the frontend
+// shim passes to the Rust handler. The actual Tauri runtime never runs
+// during tests; only the wire shape matters here.
+const invokeCalls: { command: string; args: Record<string, unknown> }[] = [];
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(
+    (command: string, args: Record<string, unknown>): Promise<unknown> => {
+      invokeCalls.push({ command, args });
+      return Promise.resolve({ success: true, output: "" });
+    },
+  ),
+}));
+
+import * as ezs from "./ezs";
+
+beforeEach(() => {
+  invokeCalls.length = 0;
+});
+
+describe("ezs.pushBranch — branch opt passthrough (regression)", () => {
+  // Without the `branch` opt, the Rust handler runs `ezs -y push` and the
+  // CLI pushes whatever git HEAD points at — NOT the branch the right-pane
+  // button or right-click context menu was operating on. Same shape as the
+  // nvim viewer `p` keymap bug fixed in ezstack.nvim#4.
+
+  it("forwards branch through to invoke when callers want a specific branch (the bug regression)", async () => {
+    await ezs.pushBranch("/repo", false, false, { branch: "feat/auth" });
+    expect(invokeCalls).toHaveLength(1);
+    const args = invokeCalls[0].args;
+    expect(args.command).toBeUndefined();
+    expect(args.repoPath).toBe("/repo");
+    expect(args.stack).toBe(false);
+    expect(args.force).toBe(false);
+    expect(args.branch).toBe("feat/auth");
+  });
+
+  it("sends branch=null when no branch is provided (legacy current-HEAD push)", async () => {
+    await ezs.pushBranch("/repo");
+    expect(invokeCalls).toHaveLength(1);
+    expect(invokeCalls[0].args.branch).toBeNull();
+  });
+
+  it("sends branch=null when opts is provided without branch field", async () => {
+    await ezs.pushBranch("/repo", false, false, { verify: true });
+    expect(invokeCalls).toHaveLength(1);
+    expect(invokeCalls[0].args.branch).toBeNull();
+    expect(invokeCalls[0].args.verify).toBe(true);
+  });
+
+  it("preserves stack/force/verify/allRemotes alongside branch", async () => {
+    await ezs.pushBranch("/repo", true, true, {
+      verify: true,
+      allRemotes: true,
+      branch: "feat/auth",
+    });
+    expect(invokeCalls).toHaveLength(1);
+    const args = invokeCalls[0].args;
+    expect(args.stack).toBe(true);
+    expect(args.force).toBe(true);
+    expect(args.verify).toBe(true);
+    expect(args.allRemotes).toBe(true);
+    expect(args.branch).toBe("feat/auth");
+  });
+
+  it("invokes the push_branch Tauri command (not push or pushStack)", async () => {
+    await ezs.pushBranch("/repo", false, false, { branch: "feat/auth" });
+    expect(invokeCalls[0].command).toBe("push_branch");
+  });
+});

--- a/tauri-ui/src/commands/ezs.ts
+++ b/tauri-ui/src/commands/ezs.ts
@@ -77,7 +77,7 @@ export async function pushBranch(
   repoPath: string,
   stack: boolean = false,
   force: boolean = false,
-  opts?: { verify?: boolean; allRemotes?: boolean },
+  opts?: { verify?: boolean; allRemotes?: boolean; branch?: string },
 ): Promise<CommandResult> {
   return invoke<CommandResult>("push_branch", {
     repoPath,
@@ -85,6 +85,7 @@ export async function pushBranch(
     force,
     verify: opts?.verify ?? false,
     allRemotes: opts?.allRemotes ?? false,
+    branch: opts?.branch ?? null,
   });
 }
 


### PR DESCRIPTION
## Summary

Two `onPush` callbacks in `App.tsx` silently dropped the branch they were operating on, falling back to git HEAD. Same shape as the nvim viewer `p` keymap and telescope `<C-p>` bugs fixed in [ezstack.nvim#4](https://github.com/KulkarniKaustubh/ezstack.nvim/pull/4) — a wrapper that reads/validates a branch identifier, then ignores it and runs against the user's current checkout.

### Bugs

1. **`branchActions.onPush`** (App.tsx:201) — the right-pane "Push" button on the selected branch. Sibling callbacks (`onSync`, `onUpdatePR`, `onCreatePR`, `onDelete`, `onReparent`) all forward `selectedBranch_.name`; push alone called `ezs.pushBranch(selectedRepoPath)` with no branch arg, so the CLI pushed git HEAD.
2. **`stackNodeActions.onPush`** (App.tsx:226) — per-row right-click "Push" context menu. The callback accepts `branchName` and the toast even renders `Push ${branchName}`, but the body discards `branchName` and again calls `ezs.pushBranch(selectedRepoPath)`. User right-clicks branch B → toast says "Push B" succeeded → branch A (HEAD) is what was pushed.

### Fix

Wire `branch` through end-to-end:

- **`pushBranch()` (commands/ezs.ts)**: opts type gains `branch?: string`, forwarded as `branch: opts?.branch ?? null` so the Rust side sees an explicit null when callers want HEAD push.
- **`push_branch` (commands/operations.rs)**: handler accepts `branch: Option<String>` and appends `-b <name>` when non-empty, after the existing flags. Empty/null preserves the legacy current-HEAD behavior for callers that genuinely want HEAD (`onPushStack`, future code).
- **App.tsx**: both `onPush` callbacks now pass through `selectedBranch_.name` (right-pane) and `branchName` (right-click).

### Tests

5 new specs in `src/commands/ezs.test.ts`:

- `branch` propagates to invoke when caller provides it (the bug regression).
- `branch=null` when caller omits it (preserves HEAD-push behavior).
- `branch=null` when opts has other fields but no `branch`.
- All other flags (`stack`/`force`/`verify`/`allRemotes`) preserved alongside `branch`.
- Tauri command name pinned to `push_branch` (catches future renames).

All pre-existing tests still pass; `tsc --noEmit` clean; `cargo build` clean; full Go test suite still green.

## Test plan

- [x] `vitest run` — 34/34 pass (5 new + 29 existing).
- [x] `tsc --noEmit` clean.
- [x] `cargo build` clean (only pre-existing dead-code warning).
- [x] `go build ./... && go test ./...` — full Go suite green (no Go changes here, but verified compatibility).
- [ ] Manual verification: right-click a non-current branch → "Push" → confirm CLI logs show `ezs -y push -b <branch>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)