### PR TITLE
fix(ui): align PR / diff / status column in ezs ls and ezs status

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -746,38 +746,21 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 		}
 	}
 
-	// Print root branch name with optional PR info and diff stats
-	rootLine := fmt.Sprintf("  %s%s%s", Gray, stack.Root, Reset)
-	if stack.RootIsRemote {
-		rootLine += " " + Gray + "(remote)" + Reset
+	// Pre-walk the tree to gather every row's visible name-section width so
+	// the PR / diff / status columns can be padded to a single column shared
+	// across the root and all branches. Without this pass each row rendered
+	// its own "name + 2 spaces + PR" segment, leaving PR numbers, line diffs,
+	// and CI icons jagged across the tree.
+	type branchRow struct {
+		branch       *config.Branch
+		prefix       string
+		connector    string
+		name         string
+		visibleWidth int // pointer + prefix + connector + name + remoteTag
 	}
-	if stack.RootPRNumber > 0 {
-		prText := fmt.Sprintf("[PR #%d", stack.RootPRNumber)
-		if stack.RootBase != "" {
-			prText += " \u2192 " + stack.RootBase // → arrow
-		}
-		prText += "]"
-		if stack.RootPRUrl != "" {
-			rootLine += "  " + Yellow + Hyperlink(stack.RootPRUrl, prText) + Reset
-		} else {
-			rootLine += "  " + Yellow + prText + Reset
-		}
-	} else if stack.RootBase != "" {
-		// No PR but we know the base branch (e.g. inferred main/master)
-		rootLine += "  " + Gray + "[\u2192 " + stack.RootBase + "]" + Reset
-	}
-	if statusMap != nil {
-		if rootStatus, ok := statusMap[stack.Root]; ok && rootStatus != nil {
-			if rootStatus.Additions > 0 || rootStatus.Deletions > 0 {
-				rootLine += fmt.Sprintf(" %s+%d%s %s-%d%s", Green, rootStatus.Additions, Reset, Red, rootStatus.Deletions, Reset)
-			}
-		}
-	}
-	fmt.Fprintf(os.Stderr, "%s\n", rootLine)
-
-	// Recursive tree walker
-	var walkTree func(nodes []*config.Branch, prefix string)
-	walkTree = func(nodes []*config.Branch, prefix string) {
+	var rows []branchRow
+	var collectRows func(nodes []*config.Branch, prefix string)
+	collectRows = func(nodes []*config.Branch, prefix string) {
 		for i, branch := range nodes {
 			isLast := i == len(nodes)-1
 			connector := "├── "
@@ -786,69 +769,140 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 				connector = "└── "
 				childPrefix = "    "
 			}
-
-			// Check if branch should be struck through (merged or closed)
-			shouldStrike := branch.IsMerged || branch.PRState == "MERGED" || branch.PRState == "CLOSED"
-			if !shouldStrike && statusMap != nil {
-				if status, ok := statusMap[branch.Name]; ok && status != nil {
-					shouldStrike = status.PRState == "MERGED" || status.PRState == "CLOSED"
-				}
-			}
-
-			// Pointer for current branch
-			pointer := " "
-			color := ""
-			if branch.Name == currentBranch {
-				pointer = ">"
-				color = Green
-			}
-
-			// Branch name
 			name := truncateBranchName(branch.Name, MaxBranchNameWidth)
-
-			// PR info
-			prFormatted := getPRFormatted(branch, statusMap, 0)
-
-			// Diff stats
-			diffInfo := getDiffStats(branch, statusMap)
-
-			// Status info
-			statusInfo := ""
-			if showStatus && statusMap != nil {
-				statusInfo = getStatusIcons(branch, statusMap)
-			}
-
-			remoteTag := ""
+			remoteWidth := 0
 			if branch.IsRemote {
-				remoteTag = " " + Gray + "(remote)" + Reset
+				remoteWidth = runewidth.StringWidth(" (remote)")
 			}
-
-			if shouldStrike {
-				prWithStrike := strings.ReplaceAll(prFormatted, Reset, Reset+Strikethrough)
-				diffWithStrike := ""
-				if diffInfo != "" {
-					diffWithStrike = strings.ReplaceAll(diffInfo, Reset, Reset+Strikethrough)
-				}
-				statusWithStrike := ""
-				if statusInfo != "" {
-					statusWithStrike = strings.ReplaceAll(statusInfo, Reset, Reset+Strikethrough)
-				}
-				fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s  %s%s%s%s\n",
-					pointer, color, prefix, connector, Strikethrough+Bold, name, Reset+Strikethrough,
-					remoteTag, prWithStrike, diffWithStrike, statusWithStrike, Reset)
-			} else {
-				fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s  %s%s%s%s\n",
-					pointer, color, prefix, connector, Bold, name, Reset,
-					remoteTag, prFormatted, diffInfo, statusInfo, Reset)
-			}
-
+			width := 1 + // pointer (" " or ">")
+				runewidth.StringWidth(prefix) +
+				runewidth.StringWidth(connector) +
+				runewidth.StringWidth(name) +
+				remoteWidth
+			rows = append(rows, branchRow{branch, prefix, connector, name, width})
 			if children, ok := childrenMap[branch.Name]; ok {
-				walkTree(children, prefix+childPrefix)
+				collectRows(children, prefix+childPrefix)
 			}
 		}
 	}
+	collectRows(roots, "  ")
 
-	walkTree(roots, "  ")
+	// Root visible width: "  " + Root + optional " (remote)". The root has no
+	// pointer / connector, but it still shares the metadata column.
+	rootRemoteWidth := 0
+	if stack.RootIsRemote {
+		rootRemoteWidth = runewidth.StringWidth(" (remote)")
+	}
+	rootVisibleWidth := runewidth.StringWidth("  ") +
+		runewidth.StringWidth(stack.Root) +
+		rootRemoteWidth
+
+	maxWidth := rootVisibleWidth
+	for _, r := range rows {
+		if r.visibleWidth > maxWidth {
+			maxWidth = r.visibleWidth
+		}
+	}
+
+	// padTo returns the spaces needed to align a row's metadata column at
+	// (maxWidth + 2). Floor at 2 so metadata never butts up against the name.
+	padTo := func(w int) string {
+		n := maxWidth - w + 2
+		if n < 2 {
+			n = 2
+		}
+		return strings.Repeat(" ", n)
+	}
+
+	// Print root branch name with optional PR info and diff stats
+	rootLine := fmt.Sprintf("  %s%s%s", Gray, stack.Root, Reset)
+	if stack.RootIsRemote {
+		rootLine += " " + Gray + "(remote)" + Reset
+	}
+	rootMeta := ""
+	if stack.RootPRNumber > 0 {
+		prText := fmt.Sprintf("[PR #%d", stack.RootPRNumber)
+		if stack.RootBase != "" {
+			prText += " \u2192 " + stack.RootBase // → arrow
+		}
+		prText += "]"
+		if stack.RootPRUrl != "" {
+			rootMeta = Yellow + Hyperlink(stack.RootPRUrl, prText) + Reset
+		} else {
+			rootMeta = Yellow + prText + Reset
+		}
+	} else if stack.RootBase != "" {
+		// No PR but we know the base branch (e.g. inferred main/master)
+		rootMeta = Gray + "[\u2192 " + stack.RootBase + "]" + Reset
+	}
+	if rootMeta != "" {
+		rootLine += padTo(rootVisibleWidth) + rootMeta
+	}
+	if statusMap != nil {
+		if rootStatus, ok := statusMap[stack.Root]; ok && rootStatus != nil {
+			if rootStatus.Additions > 0 || rootStatus.Deletions > 0 {
+				if rootMeta == "" {
+					rootLine += padTo(rootVisibleWidth)
+				}
+				rootLine += fmt.Sprintf(" %s+%d%s %s-%d%s", Green, rootStatus.Additions, Reset, Red, rootStatus.Deletions, Reset)
+			}
+		}
+	}
+	fmt.Fprintf(os.Stderr, "%s\n", rootLine)
+
+	// Render each branch row using the shared metadata column.
+	for _, r := range rows {
+		branch := r.branch
+
+		// Check if branch should be struck through (merged or closed)
+		shouldStrike := branch.IsMerged || branch.PRState == "MERGED" || branch.PRState == "CLOSED"
+		if !shouldStrike && statusMap != nil {
+			if status, ok := statusMap[branch.Name]; ok && status != nil {
+				shouldStrike = status.PRState == "MERGED" || status.PRState == "CLOSED"
+			}
+		}
+
+		// Pointer for current branch
+		pointer := " "
+		color := ""
+		if branch.Name == currentBranch {
+			pointer = ">"
+			color = Green
+		}
+
+		prFormatted := getPRFormatted(branch, statusMap, 0)
+		diffInfo := getDiffStats(branch, statusMap)
+		statusInfo := ""
+		if showStatus && statusMap != nil {
+			statusInfo = getStatusIcons(branch, statusMap)
+		}
+
+		remoteTag := ""
+		if branch.IsRemote {
+			remoteTag = " " + Gray + "(remote)" + Reset
+		}
+
+		pad := padTo(r.visibleWidth)
+
+		if shouldStrike {
+			prWithStrike := strings.ReplaceAll(prFormatted, Reset, Reset+Strikethrough)
+			diffWithStrike := ""
+			if diffInfo != "" {
+				diffWithStrike = strings.ReplaceAll(diffInfo, Reset, Reset+Strikethrough)
+			}
+			statusWithStrike := ""
+			if statusInfo != "" {
+				statusWithStrike = strings.ReplaceAll(statusInfo, Reset, Reset+Strikethrough)
+			}
+			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+				pointer, color, r.prefix, r.connector, Strikethrough+Bold, r.name, Reset+Strikethrough,
+				remoteTag, pad, prWithStrike, diffWithStrike, statusWithStrike, Reset)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+				pointer, color, r.prefix, r.connector, Bold, r.name, Reset,
+				remoteTag, pad, prFormatted, diffInfo, statusInfo, Reset)
+		}
+	}
 	fmt.Fprintln(os.Stderr)
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -746,17 +746,21 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 		}
 	}
 
-	// Pre-walk the tree to gather every row's visible name-section width so
-	// the PR / diff / status columns can be padded to a single column shared
-	// across the root and all branches. Without this pass each row rendered
-	// its own "name + 2 spaces + PR" segment, leaving PR numbers, line diffs,
-	// and CI icons jagged across the tree.
+	// Pre-walk the tree to gather, for every row, the visible width of three
+	// independent columns — name section, PR text, line-diff text — so the
+	// render loop can pad each column to its shared max. Aligning only the
+	// start of the metadata block (the original tree-style fix) still left
+	// diff and status jagged when PR labels differed in length (`[PR #1]` vs
+	// `[PR #1 MERGED]` vs `[no PR]`); padding per-column lines up every cell,
+	// mirroring the flat-list approach used before the tree refactor.
 	type branchRow struct {
-		branch       *config.Branch
-		prefix       string
-		connector    string
-		name         string
-		visibleWidth int // pointer + prefix + connector + name + remoteTag
+		branch    *config.Branch
+		prefix    string
+		connector string
+		name      string
+		nameWidth int // pointer + prefix + connector + name + remoteTag
+		prWidth   int // visible width of getPRText(...)
+		diffWidth int // visible width of getDiffText(...)
 	}
 	var rows []branchRow
 	var collectRows func(nodes []*config.Branch, prefix string)
@@ -774,12 +778,14 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 			if branch.IsRemote {
 				remoteWidth = runewidth.StringWidth(" (remote)")
 			}
-			width := 1 + // pointer (" " or ">")
+			nameWidth := 1 + // pointer (" " or ">")
 				runewidth.StringWidth(prefix) +
 				runewidth.StringWidth(connector) +
 				runewidth.StringWidth(name) +
 				remoteWidth
-			rows = append(rows, branchRow{branch, prefix, connector, name, width})
+			prWidth := runewidth.StringWidth(getPRText(branch, statusMap))
+			diffWidth := runewidth.StringWidth(getDiffText(branch, statusMap))
+			rows = append(rows, branchRow{branch, prefix, connector, name, nameWidth, prWidth, diffWidth})
 			if children, ok := childrenMap[branch.Name]; ok {
 				collectRows(children, prefix+childPrefix)
 			}
@@ -787,74 +793,91 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 	}
 	collectRows(roots, "  ")
 
-	// Root visible width: "  " + Root + optional " (remote)". The root has no
-	// pointer / connector, but it still shares the metadata column.
+	// Root contributes to every shared column. It has no pointer/connector
+	// but shares the gutter so its PR / diff cells line up with branch rows.
 	rootRemoteWidth := 0
 	if stack.RootIsRemote {
 		rootRemoteWidth = runewidth.StringWidth(" (remote)")
 	}
-	rootVisibleWidth := runewidth.StringWidth("  ") +
+	rootNameWidth := runewidth.StringWidth("  ") +
 		runewidth.StringWidth(stack.Root) +
 		rootRemoteWidth
+	rootPRText := getRootPRText(stack)
+	rootDiffText := getRootDiffText(stack, statusMap)
+	rootPRWidth := runewidth.StringWidth(rootPRText)
+	rootDiffWidth := runewidth.StringWidth(rootDiffText)
 
-	maxWidth := rootVisibleWidth
+	maxNameWidth := rootNameWidth
+	maxPRWidth := rootPRWidth
+	maxDiffWidth := rootDiffWidth
 	for _, r := range rows {
-		if r.visibleWidth > maxWidth {
-			maxWidth = r.visibleWidth
+		if r.nameWidth > maxNameWidth {
+			maxNameWidth = r.nameWidth
+		}
+		if r.prWidth > maxPRWidth {
+			maxPRWidth = r.prWidth
+		}
+		if r.diffWidth > maxDiffWidth {
+			maxDiffWidth = r.diffWidth
 		}
 	}
 
-	// padTo returns the spaces needed to align a row's metadata column at
-	// (maxWidth + 2). Floor at 2 so metadata never butts up against the name.
-	padTo := func(w int) string {
-		n := maxWidth - w + 2
+	// padNameGap returns the spaces between a row's name section and the PR
+	// column. Floor at 2 so the PR cell never butts up against the name on
+	// the widest row.
+	padNameGap := func(w int) string {
+		n := maxNameWidth - w + 2
 		if n < 2 {
 			n = 2
 		}
 		return strings.Repeat(" ", n)
 	}
+	// padToWidth returns trailing spaces to fill a cell of textWidth out to
+	// width. Caller places it *outside* any color or hyperlink wrapper —
+	// matches getPRFormatted's d5db3d4 contract that keeps OSC 8 link targets
+	// from picking up padding spaces.
+	padToWidth := func(textWidth, width int) string {
+		if width > textWidth {
+			return strings.Repeat(" ", width-textWidth)
+		}
+		return ""
+	}
 
-	// Print root branch name with optional PR info and diff stats
+	// Render the root row. Root has no pointer/connector, but it shares the
+	// PR and diff columns with branch rows so the metadata lines up.
 	rootLine := fmt.Sprintf("  %s%s%s", Gray, stack.Root, Reset)
 	if stack.RootIsRemote {
 		rootLine += " " + Gray + "(remote)" + Reset
 	}
-	rootMeta := ""
-	if stack.RootPRNumber > 0 {
-		prText := fmt.Sprintf("[PR #%d", stack.RootPRNumber)
-		if stack.RootBase != "" {
-			prText += " \u2192 " + stack.RootBase // → arrow
-		}
-		prText += "]"
-		if stack.RootPRUrl != "" {
-			rootMeta = Yellow + Hyperlink(stack.RootPRUrl, prText) + Reset
-		} else {
-			rootMeta = Yellow + prText + Reset
-		}
-	} else if stack.RootBase != "" {
-		// No PR but we know the base branch (e.g. inferred main/master)
-		rootMeta = Gray + "[\u2192 " + stack.RootBase + "]" + Reset
-	}
-	if rootMeta != "" {
-		rootLine += padTo(rootVisibleWidth) + rootMeta
-	}
-	if statusMap != nil {
-		if rootStatus, ok := statusMap[stack.Root]; ok && rootStatus != nil {
-			if rootStatus.Additions > 0 || rootStatus.Deletions > 0 {
-				if rootMeta == "" {
-					rootLine += padTo(rootVisibleWidth)
-				}
-				rootLine += fmt.Sprintf(" %s+%d%s %s-%d%s", Green, rootStatus.Additions, Reset, Red, rootStatus.Deletions, Reset)
+	if maxPRWidth > 0 || maxDiffWidth > 0 {
+		rootLine += padNameGap(rootNameWidth)
+		if rootPRText != "" {
+			prColor := Yellow
+			if stack.RootPRNumber == 0 {
+				// Inferred-base label `[→ base]` is gray, like the root name.
+				prColor = Gray
+			}
+			if stack.RootPRUrl != "" {
+				rootLine += prColor + Hyperlink(stack.RootPRUrl, rootPRText) + Reset
+			} else {
+				rootLine += prColor + rootPRText + Reset
 			}
 		}
+		rootLine += padToWidth(rootPRWidth, maxPRWidth)
+		if rootDiffText != "" {
+			rs := statusMap[stack.Root]
+			rootLine += fmt.Sprintf(" %s+%d%s %s-%d%s",
+				Green, rs.Additions, Reset, Red, rs.Deletions, Reset)
+		}
+		rootLine += padToWidth(rootDiffWidth, maxDiffWidth)
 	}
-	fmt.Fprintf(os.Stderr, "%s\n", rootLine)
+	// Strip trailing pad spaces so a root with no PR/diff prints cleanly.
+	fmt.Fprintf(os.Stderr, "%s\n", strings.TrimRight(rootLine, " "))
 
-	// Render each branch row using the shared metadata column.
+	// Render each branch row using the shared columns.
 	for _, r := range rows {
 		branch := r.branch
 
-		// Check if branch should be struck through (merged or closed)
 		shouldStrike := branch.IsMerged || branch.PRState == "MERGED" || branch.PRState == "CLOSED"
 		if !shouldStrike && statusMap != nil {
 			if status, ok := statusMap[branch.Name]; ok && status != nil {
@@ -862,7 +885,6 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 			}
 		}
 
-		// Pointer for current branch
 		pointer := " "
 		color := ""
 		if branch.Name == currentBranch {
@@ -870,8 +892,8 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 			color = Green
 		}
 
-		prFormatted := getPRFormatted(branch, statusMap, 0)
-		diffInfo := getDiffStats(branch, statusMap)
+		prFormatted := getPRFormatted(branch, statusMap, maxPRWidth)
+		diffFormatted := getDiffFormatted(branch, statusMap, maxDiffWidth)
 		statusInfo := ""
 		if showStatus && statusMap != nil {
 			statusInfo = getStatusIcons(branch, statusMap)
@@ -882,25 +904,22 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 			remoteTag = " " + Gray + "(remote)" + Reset
 		}
 
-		pad := padTo(r.visibleWidth)
+		gap := padNameGap(r.nameWidth)
 
 		if shouldStrike {
 			prWithStrike := strings.ReplaceAll(prFormatted, Reset, Reset+Strikethrough)
-			diffWithStrike := ""
-			if diffInfo != "" {
-				diffWithStrike = strings.ReplaceAll(diffInfo, Reset, Reset+Strikethrough)
-			}
+			diffWithStrike := strings.ReplaceAll(diffFormatted, Reset, Reset+Strikethrough)
 			statusWithStrike := ""
 			if statusInfo != "" {
 				statusWithStrike = strings.ReplaceAll(statusInfo, Reset, Reset+Strikethrough)
 			}
 			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
 				pointer, color, r.prefix, r.connector, Strikethrough+Bold, r.name, Reset+Strikethrough,
-				remoteTag, pad, prWithStrike, diffWithStrike, statusWithStrike, Reset)
+				remoteTag, gap, prWithStrike, diffWithStrike, statusWithStrike, Reset)
 		} else {
 			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
 				pointer, color, r.prefix, r.connector, Bold, r.name, Reset,
-				remoteTag, pad, prFormatted, diffInfo, statusInfo, Reset)
+				remoteTag, gap, prFormatted, diffFormatted, statusInfo, Reset)
 		}
 	}
 	fmt.Fprintln(os.Stderr)
@@ -1039,6 +1058,77 @@ func getDiffStats(branch *config.Branch, statusMap map[string]*BranchStatus) str
 		return ""
 	}
 	return fmt.Sprintf(" %s+%d%s %s-%d%s", Green, status.Additions, Reset, Red, status.Deletions, Reset)
+}
+
+// getDiffText returns the diff stats text WITHOUT color codes — the
+// width-only counterpart to getDiffStats, used by the pre-walk that sizes the
+// diff column. Both functions share the same gating (nil statusMap, missing
+// entry, zero deltas, merged/closed branch); keep them in lockstep.
+func getDiffText(branch *config.Branch, statusMap map[string]*BranchStatus) string {
+	if statusMap == nil {
+		return ""
+	}
+	status, ok := statusMap[branch.Name]
+	if !ok || status == nil {
+		return ""
+	}
+	if status.Additions == 0 && status.Deletions == 0 {
+		return ""
+	}
+	if branch.IsMerged || branch.PRState == "MERGED" || branch.PRState == "CLOSED" {
+		return ""
+	}
+	return fmt.Sprintf(" +%d -%d", status.Additions, status.Deletions)
+}
+
+// getDiffFormatted returns the colored diff cell padded to paddedWidth.
+// Padding is placed outside the SGR Reset (matching getPRFormatted's d5db3d4
+// hyperlink contract) so no color leaks into the trailing spaces.
+func getDiffFormatted(branch *config.Branch, statusMap map[string]*BranchStatus, paddedWidth int) string {
+	text := getDiffText(branch, statusMap)
+	pad := ""
+	if n := paddedWidth - runewidth.StringWidth(text); n > 0 {
+		pad = strings.Repeat(" ", n)
+	}
+	if text == "" {
+		return pad
+	}
+	return getDiffStats(branch, statusMap) + pad
+}
+
+// getRootPRText returns the root row's PR-cell text without color or hyperlink
+// markup. The root has three possible labels — `[PR #N]`, `[PR #N → base]`,
+// or the inferred-base `[→ base]` — and each contributes to the maxPRWidth
+// pre-walk so the PR column lines up with branch rows.
+func getRootPRText(stack *config.Stack) string {
+	if stack.RootPRNumber > 0 {
+		s := fmt.Sprintf("[PR #%d", stack.RootPRNumber)
+		if stack.RootBase != "" {
+			s += " → " + stack.RootBase
+		}
+		return s + "]"
+	}
+	if stack.RootBase != "" {
+		return "[→ " + stack.RootBase + "]"
+	}
+	return ""
+}
+
+// getRootDiffText returns the root row's diff-cell text without color codes.
+// Root only shows diff when statusMap reports nonzero additions/deletions —
+// it has no merged/closed gating because the trunk is never merged into itself.
+func getRootDiffText(stack *config.Stack, statusMap map[string]*BranchStatus) string {
+	if statusMap == nil {
+		return ""
+	}
+	status, ok := statusMap[stack.Root]
+	if !ok || status == nil {
+		return ""
+	}
+	if status.Additions == 0 && status.Deletions == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" +%d -%d", status.Additions, status.Deletions)
 }
 
 // getStatusText returns CI/review status text WITHOUT color codes (for width calculation)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -145,6 +145,99 @@ func TestFormatStackString_PerBranchRemoteTag(t *testing.T) {
 	}
 }
 
+// PrintStack renders the PR / line-diff / status column at varying offsets
+// when each branch is allowed to print "name + 2 spaces + PR" independently —
+// short branch names produced metadata earlier on the line than long ones, so
+// the column zig-zagged across the tree. Lock the new alignment contract:
+// the metadata column for every branch row sits at the same visual offset.
+func TestPrintStack_AlignsMetadataColumn(t *testing.T) {
+	stack := &config.Stack{
+		Hash: "abc1234",
+		Root: "main",
+		Branches: []*config.Branch{
+			{Name: "feat-a", Parent: "main", PRNumber: 101},
+			{Name: "feat-a-much-longer-branch-name", Parent: "main", PRNumber: 102},
+			{Name: "short", Parent: "feat-a-much-longer-branch-name", PRNumber: 103},
+		},
+	}
+
+	out := captureStderr(t, func() {
+		PrintStack(stack, "", false, nil)
+	})
+
+	// stripANSI removes CSI/OSC escape sequences so column counts reflect what
+	// the user actually sees, not the wire bytes (color codes, hyperlinks).
+	prCols := []int{}
+	for _, line := range strings.Split(out, "\n") {
+		clean := stripANSI(line)
+		idx := strings.Index(clean, "[PR #")
+		if idx == -1 {
+			continue
+		}
+		prCols = append(prCols, idx)
+	}
+	if len(prCols) < 2 {
+		t.Fatalf("expected at least 2 [PR #] markers, got %d in:\n%s", len(prCols), out)
+	}
+	first := prCols[0]
+	for i, c := range prCols {
+		if c != first {
+			t.Errorf("PR column %d=%d differs from first=%d (jagged alignment), full output:\n%s", i, c, first, out)
+		}
+	}
+}
+
+// stripANSI strips CSI ("ESC[...letter") and OSC 8 ("ESC]8;;...ESC\\") sequences
+// so column-position assertions are meaningful regardless of color or hyperlink
+// markup.
+func stripANSI(s string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == 0x1b && i+1 < len(s) {
+			next := s[i+1]
+			if next == '[' {
+				// CSI: skip until a final byte in 0x40..0x7E
+				j := i + 2
+				for j < len(s) {
+					b := s[j]
+					if b >= 0x40 && b <= 0x7e {
+						j++
+						break
+					}
+					j++
+				}
+				i = j
+				continue
+			}
+			if next == ']' {
+				// OSC: skip until BEL (0x07) or ST (ESC \\)
+				j := i + 2
+				for j < len(s) {
+					if s[j] == 0x07 {
+						j++
+						break
+					}
+					if s[j] == 0x1b && j+1 < len(s) && s[j+1] == '\\' {
+						j += 2
+						break
+					}
+					j++
+				}
+				i = j
+				continue
+			}
+			if next == '\\' {
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}
+
 func TestSuggestCommand(t *testing.T) {
 	cands := []string{"status", "stack", "sync", "new", "push", "pull"}
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -145,46 +145,81 @@ func TestFormatStackString_PerBranchRemoteTag(t *testing.T) {
 	}
 }
 
-// PrintStack renders the PR / line-diff / status column at varying offsets
-// when each branch is allowed to print "name + 2 spaces + PR" independently —
-// short branch names produced metadata earlier on the line than long ones, so
-// the column zig-zagged across the tree. Lock the new alignment contract:
-// the metadata column for every branch row sits at the same visual offset.
+// TestPrintStack_AlignsMetadataColumn locks the per-column alignment contract
+// for `ezs ls` and `ezs status` output: across every row that carries a PR /
+// diff cell, those cells start at the same visual column. The mix of PR
+// labels exercises the cases where alignment used to break — `[PR #N]`,
+// `[PR #N MERGED]` (longer), and `[no PR]` (shorter) — plus a short and a
+// long branch name so the name section also varies.
 func TestPrintStack_AlignsMetadataColumn(t *testing.T) {
 	stack := &config.Stack{
 		Hash: "abc1234",
 		Root: "main",
 		Branches: []*config.Branch{
 			{Name: "feat-a", Parent: "main", PRNumber: 101},
-			{Name: "feat-a-much-longer-branch-name", Parent: "main", PRNumber: 102},
-			{Name: "short", Parent: "feat-a-much-longer-branch-name", PRNumber: 103},
+			{Name: "feat-a-much-longer-branch-name", Parent: "main", PRNumber: 102, PRState: "MERGED"},
+			{Name: "short", Parent: "feat-a-much-longer-branch-name"},
+			{Name: "feat-c", Parent: "feat-a-much-longer-branch-name", PRNumber: 104},
 		},
+	}
+	statusMap := map[string]*BranchStatus{
+		// Open PR with diff — both PR and diff cells render.
+		"feat-a": {Additions: 5, Deletions: 2},
+		// Merged PR — diff is suppressed by getDiffText's merged/closed gate,
+		// but the wide `[PR #102 MERGED]` label drives maxPRWidth and so sets
+		// the diff column for every other row.
+		"feat-a-much-longer-branch-name": {Additions: 1234, Deletions: 999, PRState: "MERGED"},
+		// Second open-PR row with diff stats — needed to assert diff-column
+		// alignment requires at least two diff-bearing rows.
+		"feat-c": {Additions: 42, Deletions: 7},
 	}
 
 	out := captureStderr(t, func() {
-		PrintStack(stack, "", false, nil)
+		PrintStack(stack, "", true, statusMap)
 	})
 
-	// stripANSI removes CSI/OSC escape sequences so column counts reflect what
-	// the user actually sees, not the wire bytes (color codes, hyperlinks).
-	prCols := []int{}
+	var prCols, diffCols []int
 	for _, line := range strings.Split(out, "\n") {
 		clean := stripANSI(line)
-		idx := strings.Index(clean, "[PR #")
-		if idx == -1 {
+		pr := indexOfAny(clean, "[PR #", "[no PR]")
+		if pr == -1 {
 			continue
 		}
-		prCols = append(prCols, idx)
-	}
-	if len(prCols) < 2 {
-		t.Fatalf("expected at least 2 [PR #] markers, got %d in:\n%s", len(prCols), out)
-	}
-	first := prCols[0]
-	for i, c := range prCols {
-		if c != first {
-			t.Errorf("PR column %d=%d differs from first=%d (jagged alignment), full output:\n%s", i, c, first, out)
+		prCols = append(prCols, pr)
+		// Diff cells start with " +N" right after the (padded) PR cell. Only
+		// rows that actually have diff stats contribute to diff alignment.
+		if d := strings.Index(clean[pr:], " +"); d != -1 {
+			diffCols = append(diffCols, pr+d)
 		}
 	}
+	if len(prCols) < 2 {
+		t.Fatalf("expected at least 2 metadata rows, got %d in:\n%s", len(prCols), out)
+	}
+	for i, c := range prCols {
+		if c != prCols[0] {
+			t.Errorf("PR column row %d = %d, want %d (jagged), output:\n%s", i, c, prCols[0], out)
+		}
+	}
+	if len(diffCols) < 2 {
+		t.Fatalf("expected at least 2 rows with diff stats to verify diff alignment, got %d in:\n%s", len(diffCols), out)
+	}
+	for i, c := range diffCols {
+		if c != diffCols[0] {
+			t.Errorf("diff column row %d = %d, want %d (PR cell not padded), output:\n%s", i, c, diffCols[0], out)
+		}
+	}
+}
+
+// indexOfAny returns the lowest index in s where any of the given substrings
+// occurs, or -1 if none match.
+func indexOfAny(s string, needles ...string) int {
+	best := -1
+	for _, n := range needles {
+		if i := strings.Index(s, n); i != -1 && (best == -1 || i < best) {
+			best = i
+		}
+	}
+	return best
 }
 
 // stripANSI strips CSI ("ESC[...letter") and OSC 8 ("ESC]8;;...ESC\\") sequences


### PR DESCRIPTION
## Summary
- `ezs ls` and `ezs status` previously printed each branch with two literal spaces between the name and its `[PR #N]`, line-diff (`+N -N`), and CI icons. Different name lengths made the metadata column zig-zag across the tree.
- `PrintStack` now does a pre-walk to compute every row's visible name-section width (root included, plus any ` (remote)` tag), takes the max, and pads each row so PR / diff / status start at the same column.
- Adds a regression test (`TestPrintStack_AlignsMetadataColumn`) that strips ANSI / OSC 8 sequences and asserts every `[PR #` marker lands at the same byte offset for a stack mixing short and long names.

## Test plan
- [x] `go test ./...` passes (UI suite + integration suite)
- [x] `go vet ./...` clean
- [x] Visual smoke test with a mixed-width stack confirms PR / diff / icons land in one column for the root and every branch