### PR TITLE
fix(navigate): walk effective tree so up/down skip merged ancestors

### DIFF
--- a/cmd/ezs/commands/navigate.go
+++ b/cmd/ezs/commands/navigate.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -94,9 +95,17 @@ func parseNavigateArgs(direction string, args []string) (int, error) {
 }
 
 // navigate handles the shared logic for up/down navigation.
-// Navigation follows the original tree structure (BaseBranch) so that
-// merged branches are still traversable. Up stops at the top of the
-// stack (does NOT go to main/root).
+//
+// Navigation follows the *effective* tree (skipping merged ancestors), not
+// the literal BaseBranch tree. A merged branch has had both its worktree
+// and its local git branch deleted by MarkBranchMerged, so trying to
+// `cd` or `git checkout` it always fails — landing on one would leave the
+// user with an error mid-traversal. Walking via Branch.Parent (the nearest
+// non-merged ancestor, computed in walkTree) and Manager.GetChildren
+// (effective-parent children, excluding merged) keeps navigation in sync
+// with how `goto` and `sync` already treat merged branches: as gone.
+//
+// Up stops at the top of the stack (does NOT go to main/root).
 func navigate(direction string, steps int) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -117,11 +126,8 @@ func navigate(direction string, steps int) error {
 	targetBranch := branch
 	for i := 0; i < steps; i++ {
 		if direction == "up" {
-			// Navigate toward the tree parent (BaseBranch), not the effective parent.
-			// BaseBranch is the original parent in the tree hierarchy.
-			treePar := mgr.GetBranch(targetBranch.BaseBranch)
-			if treePar == nil {
-				// BaseBranch is not in the stack (it's the root) — stop here
+			effPar := effectiveParentForNavigation(mgr, targetBranch)
+			if effPar == nil {
 				if i == 0 {
 					ui.Info("Already at the top of the stack")
 				} else {
@@ -129,17 +135,9 @@ func navigate(direction string, steps int) error {
 				}
 				break
 			}
-			targetBranch = treePar
+			targetBranch = effPar
 		} else {
-			// Navigate toward tree children (branches whose BaseBranch == current).
-			// Skip merged branches whose worktrees are deleted.
-			allChildren := mgr.GetTreeChildren(targetBranch.Name)
-			var children []*config.Branch
-			for _, c := range allChildren {
-				if !c.IsMerged {
-					children = append(children, c)
-				}
-			}
+			children := effectiveChildrenForNavigation(mgr, targetBranch.Name)
 			if len(children) == 0 {
 				if i == 0 {
 					ui.Info("No child branches. Already at stack leaf")
@@ -151,7 +149,6 @@ func navigate(direction string, steps int) error {
 			if len(children) == 1 {
 				targetBranch = children[0]
 			} else {
-				// Multiple children — ask user to choose
 				var options []string
 				for _, c := range children {
 					options = append(options, c.Name)
@@ -169,6 +166,41 @@ func navigate(direction string, steps int) error {
 		return nil // No movement
 	}
 
-	// Navigate to the target
+	// Defensive guard: if for any reason we land on a merged branch
+	// (shouldn't happen with the effective-tree walk above, but the cost
+	// of being wrong is a confusing `git checkout` failure), surface a
+	// clear error matching `goto`'s behavior.
+	if targetBranch.IsMerged {
+		return fmt.Errorf("branch '%s' has been merged and its worktree was deleted", targetBranch.Name)
+	}
+
 	return NavigateToBranch(g, targetBranch.Name, targetBranch.WorktreePath)
+}
+
+// effectiveParentForNavigation returns the branch `up` should land on, or nil
+// if currentBranch sits at the top of its stack. It walks via Branch.Parent
+// (the nearest non-merged ancestor populated by walkTree) so merged ancestors
+// are seamlessly skipped — landing on one would attempt a `git checkout` of a
+// branch MarkBranchMerged already deleted. Pure function (no I/O), exported
+// within the package so navigate_test.go can pin its behavior with a real
+// stack.Manager fixture.
+func effectiveParentForNavigation(mgr *stack.Manager, currentBranch *config.Branch) *config.Branch {
+	return mgr.GetBranch(currentBranch.Parent)
+}
+
+// effectiveChildrenForNavigation returns the non-merged candidates `down`
+// should choose between, sorted alphabetically for determinism. Walks via
+// Manager.GetChildren (effective parent) so a merged intermediate is bridged
+// out: A → B(merged) → C surfaces C as a direct candidate of A. The IsMerged
+// filter is still required because a merged direct child of A keeps
+// Parent=A until walkTree re-points its descendants past it.
+func effectiveChildrenForNavigation(mgr *stack.Manager, branchName string) []*config.Branch {
+	var out []*config.Branch
+	for _, c := range mgr.GetChildren(branchName) {
+		if !c.IsMerged {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
 }

--- a/cmd/ezs/commands/navigate_merged_test.go
+++ b/cmd/ezs/commands/navigate_merged_test.go
@@ -1,0 +1,286 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+)
+
+// Tests pinning the merged-branch handling in navigate's selection helpers.
+// These exercise the effective-tree walk that fixes the up/down regression
+// where a merged ancestor (or a merged intermediate child) caused navigation
+// to fail or stop short. See navigate.go for the fix; the bug is documented
+// in the PR description.
+
+// makeStackChain builds a single linear stack
+//
+//	main → branches[0] → branches[1] → ...
+//
+// without worktrees, then optionally marks any of them as merged. Returns a
+// fresh manager loaded from disk so the in-memory branch structs reflect the
+// merge state (Parent pointers re-routed through walkTree).
+func makeStackChain(t *testing.T, mgr *stack.Manager, repoDir string, branches []string, merged map[string]bool) *stack.Manager {
+	t.Helper()
+
+	parent := "main"
+	stackHash := "new"
+	for _, b := range branches {
+		if _, err := mgr.CreateBranchNoWorktree(b, parent, stackHash); err != nil {
+			t.Fatalf("CreateBranchNoWorktree(%s, %s): %v", b, parent, err)
+		}
+		// Reload between additions: every CreateBranchNoWorktree saves and
+		// the cache is rebuilt from disk, so subsequent calls need a fresh
+		// view.
+		mgr = reloadManager(t, repoDir)
+		parent = b
+		stackHash = "" // only the first branch starts a new stack
+	}
+
+	for name := range merged {
+		if err := mgr.MarkBranchMerged(name); err != nil {
+			t.Fatalf("MarkBranchMerged(%s): %v", name, err)
+		}
+		mgr = reloadManager(t, repoDir)
+	}
+
+	return mgr
+}
+
+// TestEffectiveParentForNavigation_NormalStack walks up an unmerged chain.
+// The bug only manifests with merged branches, but the unmerged baseline is a
+// regression gate: it would fail if we accidentally broke ordinary navigation.
+func TestEffectiveParentForNavigation_NormalStack(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b", "c"}, nil)
+
+	c := mgr.GetBranch("c")
+	if c == nil {
+		t.Fatal("branch c missing")
+	}
+	if got := effectiveParentForNavigation(mgr, c); got == nil || got.Name != "b" {
+		t.Errorf("up from c = %v, want b", got)
+	}
+
+	b := mgr.GetBranch("b")
+	if got := effectiveParentForNavigation(mgr, b); got == nil || got.Name != "a" {
+		t.Errorf("up from b = %v, want a", got)
+	}
+
+	a := mgr.GetBranch("a")
+	if got := effectiveParentForNavigation(mgr, a); got != nil {
+		t.Errorf("up from a (top) = %v, want nil", got)
+	}
+}
+
+// TestEffectiveParentForNavigation_SkipsMergedAncestor is the load-bearing
+// fix for `ezs up`: previously this walked via BaseBranch, landed on the
+// merged ancestor, and then `git checkout` failed because MarkBranchMerged
+// deletes the local git ref. The effective Parent skips merged ancestors so
+// `up` lands on a usable branch.
+func TestEffectiveParentForNavigation_SkipsMergedAncestor(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b", "c"}, map[string]bool{"b": true})
+
+	c := mgr.GetBranch("c")
+	got := effectiveParentForNavigation(mgr, c)
+	if got == nil {
+		t.Fatal("up from c with merged b returned nil; expected to skip to a")
+	}
+	if got.Name != "a" {
+		t.Errorf("up from c with merged b = %s, want a", got.Name)
+	}
+	if got.IsMerged {
+		t.Error("navigation landed on a merged branch — would fail at checkout")
+	}
+}
+
+// TestEffectiveParentForNavigation_SkipsChainOfMerged ensures the skip is
+// transitive: stacked merges in a row still let `up` find the first usable
+// ancestor in one step.
+func TestEffectiveParentForNavigation_SkipsChainOfMerged(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b", "c", "d"}, map[string]bool{
+		"b": true,
+		"c": true,
+	})
+
+	d := mgr.GetBranch("d")
+	got := effectiveParentForNavigation(mgr, d)
+	if got == nil || got.Name != "a" {
+		t.Errorf("up from d with merged b,c = %v, want a", got)
+	}
+}
+
+// TestEffectiveParentForNavigation_AllAncestorsMerged_ReturnsNil exercises the
+// edge case where every ancestor between a non-merged tip and the trunk root
+// is merged. Parent walks to the stack root ("main") which is not stored as a
+// Branch, so we get nil — the "Already at top of stack" message will fire,
+// matching `goto`'s "merged is unreachable" stance.
+func TestEffectiveParentForNavigation_AllAncestorsMerged_ReturnsNil(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b"}, map[string]bool{"a": true})
+
+	b := mgr.GetBranch("b")
+	if got := effectiveParentForNavigation(mgr, b); got != nil {
+		t.Errorf("up from b with all ancestors merged = %v, want nil (top of stack)", got)
+	}
+}
+
+// TestEffectiveChildrenForNavigation_DirectChildrenSorted verifies the
+// alphabetical-sort guarantee. GetChildren walks a map and is not ordered;
+// without the sort, the multi-child selector would shuffle between runs.
+func TestEffectiveChildrenForNavigation_DirectChildrenSorted(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	// Build with intentionally non-alphabetical insertion order.
+	if _, err := mgr.CreateBranchNoWorktree("zeta", "main", "new"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	if _, err := mgr.CreateBranchNoWorktree("alpha", "main", "new"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	if _, err := mgr.CreateBranchNoWorktree("middle", "main", "new"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+
+	// All three are stack roots, so use main as the reference. They each
+	// live in their own stack (targetStackHash="new" each time), so they
+	// appear as separate roots; effective children of "main" cross stacks
+	// because GetChildren walks every stack — which is what we want for
+	// navigation in repos with multiple parallel stacks.
+	got := effectiveChildrenForNavigation(mgr, "main")
+	if len(got) != 3 {
+		t.Fatalf("got %d children, want 3", len(got))
+	}
+	want := []string{"alpha", "middle", "zeta"}
+	for i, b := range got {
+		if b.Name != want[i] {
+			t.Errorf("children[%d] = %s, want %s", i, b.Name, want[i])
+		}
+	}
+}
+
+// TestEffectiveChildrenForNavigation_SkipsMergedDirectChild is the core fix
+// for `ezs down`: when the only direct child is merged, walkTree re-points
+// any non-merged grandchildren's Parent to the grandparent, so they surface
+// as effective children.
+func TestEffectiveChildrenForNavigation_SkipsMergedDirectChild(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b", "c"}, map[string]bool{"b": true})
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	if len(got) != 1 {
+		t.Fatalf("children of a = %d, want 1 (c via merged b)", len(got))
+	}
+	if got[0].Name != "c" {
+		t.Errorf("children of a = %s, want c", got[0].Name)
+	}
+	if got[0].IsMerged {
+		t.Error("returned a merged branch — would fail at checkout")
+	}
+}
+
+// TestEffectiveChildrenForNavigation_GrandchildrenViaMergedChain verifies the
+// transitive case: A → B(merged) → C(merged) → D, `down` from A surfaces D.
+func TestEffectiveChildrenForNavigation_GrandchildrenViaMergedChain(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b", "c", "d"}, map[string]bool{
+		"b": true,
+		"c": true,
+	})
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	if len(got) != 1 {
+		t.Fatalf("children of a = %d, want 1 (d via merged b,c)", len(got))
+	}
+	if got[0].Name != "d" {
+		t.Errorf("children of a = %s, want d", got[0].Name)
+	}
+}
+
+// TestEffectiveChildrenForNavigation_FiltersMergedSibling — when one direct
+// child is merged and another is not, only the unmerged sibling shows up.
+func TestEffectiveChildrenForNavigation_FiltersMergedSibling(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	if _, err := mgr.CreateBranchNoWorktree("a", "main", "new"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	if _, err := mgr.CreateBranchNoWorktree("b1", "a", ""); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	if _, err := mgr.CreateBranchNoWorktree("b2", "a", ""); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	if err := mgr.MarkBranchMerged("b1"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	if len(got) != 1 {
+		t.Fatalf("children of a = %d, want 1 (b2 only)", len(got))
+	}
+	if got[0].Name != "b2" {
+		t.Errorf("children of a = %s, want b2", got[0].Name)
+	}
+}
+
+// TestEffectiveChildrenForNavigation_NoChildren — leaves return an empty
+// slice. The caller treats this as "already at stack leaf".
+func TestEffectiveChildrenForNavigation_NoChildren(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a"}, nil)
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	if len(got) != 0 {
+		t.Errorf("leaf children = %v, want []", got)
+	}
+}
+
+// TestEffectiveChildrenForNavigation_OnlyMergedChildren — a parent whose only
+// child has been merged with no descendants reports zero children. The user
+// gets the leaf message, not a confusing "navigated to a deleted branch"
+// error. This is the regression case for the original `ezs down` bug where
+// merged-direct-child caused a stop, not a step-through.
+func TestEffectiveChildrenForNavigation_OnlyMergedChildren(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mgr = makeStackChain(t, mgr, repoDir, []string{"a", "b"}, map[string]bool{"b": true})
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	if len(got) != 0 {
+		t.Errorf("children of a (only merged b, no descendants) = %v, want []", got)
+	}
+}
+
+// TestEffectiveChildrenForNavigation_MultipleNonMergedChildrenSorted —
+// multi-child selector path. Build siblings in non-alpha order and verify
+// the helper returns them sorted.
+func TestEffectiveChildrenForNavigation_MultipleNonMergedChildrenSorted(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	if _, err := mgr.CreateBranchNoWorktree("a", "main", "new"); err != nil {
+		t.Fatal(err)
+	}
+	mgr = reloadManager(t, repoDir)
+	for _, name := range []string{"zoo", "ant", "moth"} {
+		if _, err := mgr.CreateBranchNoWorktree(name, "a", ""); err != nil {
+			t.Fatal(err)
+		}
+		mgr = reloadManager(t, repoDir)
+	}
+
+	got := effectiveChildrenForNavigation(mgr, "a")
+	want := []string{"ant", "moth", "zoo"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d children, want %d", len(got), len(want))
+	}
+	for i, b := range got {
+		if b.Name != want[i] {
+			t.Errorf("children[%d] = %s, want %s", i, b.Name, want[i])
+		}
+	}
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -615,21 +615,6 @@ func (m *Manager) SetBranchAgentSessionID(branchName, sessionID, mode string) er
 	return m.stackConfig.Save(m.repoDir)
 }
 
-// GetTreeChildren returns child branches based on the original tree structure (BaseBranch),
-// not the effective parent. This is used for navigation (up/down) where we want to
-// follow the tree hierarchy even when parents have been merged and children reparented.
-func (m *Manager) GetTreeChildren(branchName string) []*config.Branch {
-	var children []*config.Branch
-	for _, stack := range m.stackConfig.Stacks {
-		for _, branch := range stack.Branches {
-			if branch.BaseBranch == branchName {
-				children = append(children, branch)
-			}
-		}
-	}
-	return children
-}
-
 // IsMainBranch checks if a branch is the main/master branch.
 // Use only for protection (e.g. preventing deletion of main). For stack-root
 // logic, compare against Stack.Root or use GetStackForBranch instead.

--- a/itests/navigate_test.go
+++ b/itests/navigate_test.go
@@ -1,0 +1,402 @@
+package itests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/cmd/ezs/commands"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+)
+
+// Integration tests for `ezs up` and `ezs down` exercising the merged-branch
+// regression that motivated this PR. The bug: `up` walked via BaseBranch and
+// landed on merged ancestors whose git branch was deleted by MarkBranchMerged,
+// causing `git checkout` to fail mid-traversal; `down` filtered direct merged
+// children but never walked through them, so non-merged grandchildren of a
+// merged child were unreachable.
+//
+// Each test sets up a real stack with worktrees, marks selected branches
+// merged via the manager (the same path the merge command takes), chdirs
+// into a worktree, and invokes commands.Up/Down. With EZS_SHELL_WRAPPER set,
+// successful navigation emits a `cd <path>` line on stdout we can pin against
+// the expected destination.
+
+// changeToWorktreeOf chdirs the process into a branch's worktree for the
+// duration of t. Restores the prior cwd via t.Cleanup so test ordering can't
+// strand subsequent tests in a removed directory.
+func changeToWorktreeOf(t *testing.T, env *TestEnv, branch string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	target := filepath.Join(env.WorktreeDir, branch)
+	if err := os.Chdir(target); err != nil {
+		t.Fatalf("chdir to %s: %v", target, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prev)
+	})
+}
+
+// markMergedReload marks a branch merged through the manager and returns a
+// freshly-loaded view. Mirrors what `ezs pr merge` does internally; we don't
+// go through the CLI because `pr merge` requires the gh stub to coordinate a
+// PR lifecycle and that is orthogonal to the navigation bug under test.
+func markMergedReload(t *testing.T, env *TestEnv, branch string) {
+	t.Helper()
+	mgr, err := stack.NewManager(env.RepoDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.MarkBranchMerged(branch); err != nil {
+		t.Fatalf("MarkBranchMerged(%s): %v", branch, err)
+	}
+}
+
+// assertCd_To verifies the captured shell-wrapper output contains a `cd`
+// directive pointing at the expected worktree path. We use Contains rather
+// than equality because EmitCd may include shell quoting.
+func assertCd_To(t *testing.T, output, expectedPath string) {
+	t.Helper()
+	if !strings.Contains(output, "cd ") {
+		t.Fatalf("expected cd line in output; got:\n%s", output)
+	}
+	if !strings.Contains(output, expectedPath) {
+		t.Errorf("expected cd target %q; got:\n%s", expectedPath, output)
+	}
+}
+
+// assertNoCd verifies no `cd` directive was emitted — the navigation either
+// ran into a "top of stack"/"already at leaf" case or surfaced an error
+// before the cd step. Either way, the user's shell should not move.
+func assertNoCd(t *testing.T, output string) {
+	t.Helper()
+	if strings.Contains(output, "cd ") {
+		t.Errorf("expected no cd line; got:\n%s", output)
+	}
+}
+
+// TestNavigateUp_NormalStack — sanity check that ordinary up navigation in an
+// unmerged stack still works after the BaseBranch → Parent switch. If this
+// regressed we'd take down every existing user, so it's the first gate.
+func TestNavigateUp_NormalStack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "lvl-a", "main")
+	CreateBranchWithCommit(t, env, "lvl-b", "lvl-a")
+	CreateBranchWithCommit(t, env, "lvl-c", "lvl-b")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "lvl-c")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Up(nil) })
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "lvl-b"))
+}
+
+// TestNavigateUp_SkipsMergedAncestor is the regression gate for the original
+// bug: A → B(merged) → C, `ezs up` from C must land on A. Before the fix it
+// landed on B and `git checkout` of the deleted B ref errored out.
+func TestNavigateUp_SkipsMergedAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "anc-a", "main")
+	CreateBranchWithCommit(t, env, "anc-b", "anc-a")
+	CreateBranchWithCommit(t, env, "anc-c", "anc-b")
+
+	markMergedReload(t, env, "anc-b")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "anc-c")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Up(nil) })
+	if err != nil {
+		t.Fatalf("Up across merged ancestor: %v", err)
+	}
+	// Critical: cd target is anc-a (the next live ancestor), NOT anc-b.
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "anc-a"))
+	if strings.Contains(out, filepath.Join(env.WorktreeDir, "anc-b")) {
+		t.Errorf("up landed on merged anc-b; output:\n%s", out)
+	}
+}
+
+// TestNavigateUp_MultiStep_AcrossMergedChain pins multi-step semantics:
+// `ezs up 2` from D in main → A → B(merged) → C(merged) → D should reach A
+// in the requested two steps (D → C-skipped-to-A is one step's worth via
+// effective Parent; the second step from A reaches "top of stack" and stops
+// without error). We verify it lands on A with the no-further-movement
+// indicator rather than crashing.
+func TestNavigateUp_MultiStep_AcrossMergedChain(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "ms-a", "main")
+	CreateBranchWithCommit(t, env, "ms-b", "ms-a")
+	CreateBranchWithCommit(t, env, "ms-c", "ms-b")
+	CreateBranchWithCommit(t, env, "ms-d", "ms-c")
+
+	markMergedReload(t, env, "ms-b")
+	markMergedReload(t, env, "ms-c")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "ms-d")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Up([]string{"2"}) })
+	if err != nil {
+		t.Fatalf("Up 2 across merged chain: %v", err)
+	}
+	// First step: ms-d → ms-a (skipping merged ms-c, ms-b).
+	// Second step: ms-a → top of stack (Parent is "main", not in stack).
+	// Loop breaks; cd target is ms-a.
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "ms-a"))
+}
+
+// TestNavigateUp_TopOfStackEmitsNoCd — at the top, no cd is emitted. The
+// user's shell must not move.
+func TestNavigateUp_TopOfStackEmitsNoCd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "top-only", "main")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "top-only")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Up(nil) })
+	if err != nil {
+		t.Fatalf("Up at top: %v", err)
+	}
+	assertNoCd(t, out)
+}
+
+// TestNavigateUp_AllAncestorsMerged_StopsAtTop — every ancestor between the
+// current branch and the trunk is merged; `up` reports "top of stack" instead
+// of trying to checkout a deleted branch.
+func TestNavigateUp_AllAncestorsMerged_StopsAtTop(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "all-a", "main")
+	CreateBranchWithCommit(t, env, "all-b", "all-a")
+
+	markMergedReload(t, env, "all-a")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "all-b")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Up(nil) })
+	if err != nil {
+		t.Fatalf("Up with all merged ancestors: %v", err)
+	}
+	assertNoCd(t, out)
+}
+
+// TestNavigateDown_NormalStack — single-child down navigation in an unmerged
+// chain still works. Regression gate.
+func TestNavigateDown_NormalStack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "dn-a", "main")
+	CreateBranchWithCommit(t, env, "dn-b", "dn-a")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "dn-a")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Down(nil) })
+	if err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "dn-b"))
+}
+
+// TestNavigateDown_SkipsMergedDirectChild is the regression gate for `down`:
+// A → B(merged) → C should let `down` from A reach C. Before the fix, the
+// merged-direct-child filter saw B, dropped it, and reported "no child
+// branches" — leaving C unreachable from above.
+func TestNavigateDown_SkipsMergedDirectChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "skip-a", "main")
+	CreateBranchWithCommit(t, env, "skip-b", "skip-a")
+	CreateBranchWithCommit(t, env, "skip-c", "skip-b")
+
+	markMergedReload(t, env, "skip-b")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "skip-a")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Down(nil) })
+	if err != nil {
+		t.Fatalf("Down past merged child: %v", err)
+	}
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "skip-c"))
+}
+
+// TestNavigateDown_OnlyMergedChild_StopsAtLeaf — when the only child is
+// merged AND has no descendants, `down` reports "stack leaf" rather than
+// pretending to navigate into a deleted branch.
+func TestNavigateDown_OnlyMergedChild_StopsAtLeaf(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "leaf-a", "main")
+	CreateBranchWithCommit(t, env, "leaf-b", "leaf-a")
+
+	markMergedReload(t, env, "leaf-b")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "leaf-a")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Down(nil) })
+	if err != nil {
+		t.Fatalf("Down with only merged child: %v", err)
+	}
+	assertNoCd(t, out)
+}
+
+// TestNavigateDown_MultiStepThroughMerged exercises a multi-step down that
+// crosses a merged intermediate. Stack: A → B → C(merged) → D.
+// `down 2` from A should land on D — step 1 picks B (only non-merged
+// direct child), step 2 picks D (B's effective children are {C, D}, C is
+// merged so D is the sole candidate).
+func TestNavigateDown_MultiStepThroughMerged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "mt-a", "main")
+	CreateBranchWithCommit(t, env, "mt-b", "mt-a")
+	CreateBranchWithCommit(t, env, "mt-c", "mt-b")
+	CreateBranchWithCommit(t, env, "mt-d", "mt-c")
+
+	markMergedReload(t, env, "mt-c")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "mt-a")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Down([]string{"2"}) })
+	if err != nil {
+		t.Fatalf("Down 2 through merged: %v", err)
+	}
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "mt-d"))
+}
+
+// TestNavigateUpThenDown_RoundTrip verifies the symmetric behavior: after
+// up'ing past a merged ancestor and then down'ing again, you return to the
+// original branch. This guards against asymmetric Parent/Child filtering
+// where one direction sees the tree differently than the other.
+func TestNavigateUpThenDown_RoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "rt-a", "main")
+	CreateBranchWithCommit(t, env, "rt-b", "rt-a")
+	CreateBranchWithCommit(t, env, "rt-c", "rt-b")
+
+	markMergedReload(t, env, "rt-b")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+
+	// Up from rt-c lands on rt-a.
+	changeToWorktreeOf(t, env, "rt-c")
+	var err error
+	upOut := captureStdout(t, func() { err = commands.Up(nil) })
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	assertCd_To(t, upOut, filepath.Join(env.WorktreeDir, "rt-a"))
+
+	// We have to physically chdir into rt-a now since the captureStdout
+	// path doesn't actually evaluate the emitted cd — that's the shell
+	// wrapper's job at runtime. The test process must do it manually so
+	// the next Down() invocation reads the correct cwd.
+	if err := os.Chdir(filepath.Join(env.WorktreeDir, "rt-a")); err != nil {
+		t.Fatalf("chdir rt-a: %v", err)
+	}
+
+	downOut := captureStdout(t, func() { err = commands.Down(nil) })
+	if err != nil {
+		t.Fatalf("Down after up: %v", err)
+	}
+	// The only effective child of rt-a is rt-c (rt-b is merged), so Down
+	// resolves uniquely back to rt-c without prompting.
+	assertCd_To(t, downOut, filepath.Join(env.WorktreeDir, "rt-c"))
+}
+
+// TestNavigateDown_FiltersMergedSibling — when one direct child is merged
+// and another is non-merged, the unmerged sibling is the unique candidate so
+// `down` resolves to it without prompting.
+func TestNavigateDown_FiltersMergedSibling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree semantics")
+	}
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+
+	CreateBranchWithCommit(t, env, "sib-a", "main")
+	CreateBranchWithCommit(t, env, "sib-merged", "sib-a")
+	CreateBranchWithCommit(t, env, "sib-live", "sib-a")
+
+	markMergedReload(t, env, "sib-merged")
+
+	t.Setenv("EZS_SHELL_WRAPPER", "1")
+	changeToWorktreeOf(t, env, "sib-a")
+
+	var err error
+	out := captureStdout(t, func() { err = commands.Down(nil) })
+	if err != nil {
+		t.Fatalf("Down with merged sibling: %v", err)
+	}
+	assertCd_To(t, out, filepath.Join(env.WorktreeDir, "sib-live"))
+	if strings.Contains(out, "sib-merged") {
+		t.Errorf("down surfaced the merged sibling; output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

`ezs up` and `ezs down` broke once branches in the stack got merged. Two distinct bugs, same root cause: navigation walked the *literal* tree (`BaseBranch`) while `MarkBranchMerged` deletes both the worktree and the local git branch — so navigation kept landing on phantom ancestors.

### Bug 1 — \`ezs up\` errored mid-traversal on a merged ancestor
\`navigate.go\` looked up \`BaseBranch\` to walk up. In stack \`A → B(merged) → C\`, \`up\` from C resolved to B (still in the config tree), then \`NavigateToBranch\` saw an empty \`WorktreePath\` and fell through to \`g.CheckoutBranch(\"B\")\` — which failed with \`pathspec did not match any file(s)\` because \`MarkBranchMerged\` had already deleted B's local ref.

### Bug 2 — \`ezs down\` couldn't reach grandchildren past a merged child
\`down\` filtered \`IsMerged\` from \`GetTreeChildren\` results but never recursed through a merged child. In the same stack, \`down\` from A returned \"no child branches\" — leaving C unreachable from above even though it was a perfectly valid worktree.

## Fix

Walk the *effective* tree (the one \`walkTree\` already maintains in \`internal/config/config.go\`):

- **\`up\`**: use \`Branch.Parent\` (nearest non-merged ancestor) instead of \`BaseBranch\`. Topmost branch's \`Parent\` is the stack root, not in the stack — the existing nil check fires \"top of stack\" naturally.
- **\`down\`**: use \`Manager.GetChildren\` (effective parent) instead of \`GetTreeChildren\`. Non-merged grandchildren of a merged direct child surface as direct candidates because their \`Parent\` is re-routed past the merged node.
- Sort the multi-child selector for deterministic ordering across runs.
- Defensive \`IsMerged\` guard before the final cd: belt-and-suspenders so a future regression can't reintroduce the broken \`git checkout\`.
- Removed \`Manager.GetTreeChildren\` — zero remaining callers.

This aligns navigate with how \`goto\` and \`sync\` already treat merged branches: as gone.

## Test plan

- [x] **Unit tests** (\`cmd/ezs/commands/navigate_merged_test.go\`) — extracted \`effectiveParentForNavigation\` and \`effectiveChildrenForNavigation\` are pinned against a real \`stack.Manager\` fixture across:
  - normal stack baseline
  - merged ancestor (single, chain, all-merged-up-to-trunk)
  - merged direct child, grandchildren via merged chain
  - merged sibling filtering
  - leaves and deterministic alphabetical sort
- [x] **Integration tests** (\`itests/navigate_test.go\`) — end-to-end through \`commands.Up\`/\`commands.Down\` with \`EZS_SHELL_WRAPPER=1\`, verifying the emitted \`cd\` targets:
  - normal up/down regression gates
  - up across merged ancestor / chain of merged
  - down past merged child / through merged chain (multi-step)
  - top-of-stack and leaf cases emit no cd
  - up→down round trip ends back at the original branch
  - merged sibling never appears in the unique-candidate path
- [x] \`go test ./...\` — all green
- [x] \`make fmt-check\` and \`go vet ./...\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)