### PR TITLE
fix: post-v4.8.1 audit followups across CLI, MCP, clients, docs

### DIFF
--- a/cmd/ezs-mcp/main.go
+++ b/cmd/ezs-mcp/main.go
@@ -485,7 +485,7 @@ func registerTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("ezstack_pr_create",
-			mcp.WithDescription("Create a pull request for a branch. Use branch to target a specific branch when not on a stack branch. Set auto=true to have the configured AI agent draft the title and body from the diff and the repo's PR template; combine auto=true with stack=true to auto-draft for every branch in the stack. -t/-b values still win over the AI output."),
+			mcp.WithDescription("Create a pull request for a branch. Use branch to target a specific branch when not on a stack branch. Set auto=true to have the configured AI agent draft the title and body from the diff and the repo's PR template; combine auto=true with stack=true to auto-draft for every branch in the stack. -t/-b values still win over the AI output. DESTRUCTIVE: when the remote branch has diverged, this tool force-pushes to overwrite the remote — under MCP YesMode the in-CLI confirmation is auto-accepted, so the MCP client's destructive-action prompt is the consent gate."),
 			mcp.WithString("branch", mcp.Description("Branch to create PR for (defaults to current branch)")),
 			mcp.WithString("title", mcp.Description("PR title (defaults to branch name)")),
 			mcp.WithString("body", mcp.Description("PR body / description")),
@@ -493,9 +493,9 @@ func registerTools(s *server.MCPServer) {
 			mcp.WithBoolean("stack", mcp.Description("Create PRs for every branch in the current stack")),
 			mcp.WithBoolean("auto", mcp.Description("Use the configured AI agent to draft PR title/body from diff + template")),
 			mcp.WithBoolean("force", mcp.Description("Recreate the PR even if one already exists for the branch (alias of --recreate). Skips the confirmation prompt that would otherwise hang the MCP transport on stdin; the warning is still emitted to stderr.")),
-			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 		),
-		toolHandler(commands.PR, func(req mcp.CallToolRequest) []string {
+		yesModeHandler(commands.PR, func(req mcp.CallToolRequest) []string {
 			args := []string{"create"}
 			stringFlag(&args, req, "branch", "--branch")
 			stringFlag(&args, req, "title", "--title")

--- a/cmd/ezs-mcp/server_test.go
+++ b/cmd/ezs-mcp/server_test.go
@@ -168,7 +168,7 @@ func TestListTools_Registered(t *testing.T) {
 		"ezstack_doctor":        false,
 		"ezstack_sync":          true,
 		"ezstack_push":          true,
-		"ezstack_pr_create":     false,
+		"ezstack_pr_create":     true,
 		"ezstack_pr_draft_all":  false,
 		"ezstack_pr_stack":      false,
 		"ezstack_pr_merge":      true,

--- a/cmd/ezs/commands/agent_claude_name.go
+++ b/cmd/ezs/commands/agent_claude_name.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -40,14 +42,15 @@ var claudeProjectsDir = func() string {
 // — including deep into long-running sessions. A line-count cap would
 // silently lose a late rename and re-assert the launch label on resume,
 // defeating the whole point of this lookup; a byte cap keeps the worst-
-// case cost of `agent ls` bounded while still catching the most recent
-// rename in any realistic session journal.
+// case cost of `agent ls` bounded.
 //
 // 256 MiB is well past any session size we've seen in the wild — heavy
 // sessions land in the low-MB range — and reading that much off a local
-// SSD is sub-second. If a journal grows past this we degrade gracefully
-// to "use whatever we found in the first 256 MiB", which is identical to
-// today's line-cap behavior in failure mode.
+// SSD is sub-second. We read forward from the start; a tail-first scan
+// would be cheaper for the rename case but adds enough JSONL chunking
+// complexity that the simpler bounded forward read wins for now. If a
+// journal grows past this cap we degrade to "use whatever we found in
+// the first 256 MiB" — keeps the launch label visible at minimum.
 const claudeAgentNameMaxBytes = 256 * 1024 * 1024
 
 // agentNameEvent matches the JSON shape Claude writes for `claude --name X`
@@ -109,7 +112,13 @@ func claudeAgentName(sessionID string) string {
 // We use a cheap substring filter on the raw bytes before decoding because
 // the vast majority of lines in a session journal are tool calls / messages
 // with no `type` match — full json.Unmarshal on every line is wasteful.
-// Operating on the scanner's []byte avoids one allocation per line.
+//
+// Uses bufio.Reader (not bufio.Scanner) because Scanner returns false on
+// any line that exceeds its buffer size, with the error surfaced only via
+// scanner.Err(). A single oversized tool-output line in a journal would
+// silently truncate the scan and lose every `agent-name` event after it,
+// defeating the whole point of the lookup. Reader.ReadBytes('\n') has no
+// such cap.
 func scanLastAgentName(path, sessionID string) string {
 	f, err := os.Open(path)
 	if err != nil {
@@ -117,35 +126,34 @@ func scanLastAgentName(path, sessionID string) string {
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	// Lines in claude session journals can be very long (tool outputs,
-	// diffs). Bump the buffer so we don't fail with bufio.ErrTooLong on a
-	// fat line and miss any agent-name events that come after it.
-	const maxLine = 4 * 1024 * 1024
-	scanner.Buffer(make([]byte, 0, 64*1024), maxLine)
-
+	br := bufio.NewReaderSize(f, 64*1024)
 	needle := []byte(`"agent-name"`)
 	last := ""
 	bytesSeen := 0
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		// +1 for the newline the scanner stripped; keeps the budget
-		// honest against the on-disk size of what we've consumed.
-		bytesSeen += len(line) + 1
-		if bytesSeen > claudeAgentNameMaxBytes {
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			bytesSeen += len(line)
+			if bytesSeen > claudeAgentNameMaxBytes {
+				break
+			}
+			if bytes.Contains(line, needle) {
+				var ev agentNameEvent
+				if jerr := json.Unmarshal(bytes.TrimRight(line, "\n"), &ev); jerr == nil {
+					if ev.Type == "agent-name" && ev.SessionID == sessionID {
+						last = ev.AgentName
+					}
+				}
+			}
+		}
+		if err != nil {
+			// io.EOF is expected at end of file; any other error stops the
+			// scan early but we still return whatever `last` we found.
+			if !errors.Is(err, io.EOF) {
+				break
+			}
 			break
 		}
-		if !bytes.Contains(line, needle) {
-			continue
-		}
-		var ev agentNameEvent
-		if err := json.Unmarshal(line, &ev); err != nil {
-			continue
-		}
-		if ev.Type != "agent-name" || ev.SessionID != sessionID {
-			continue
-		}
-		last = ev.AgentName
 	}
 	return last
 }

--- a/cmd/ezs/commands/agent_claude_name.go
+++ b/cmd/ezs/commands/agent_claude_name.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
-	"io"
 	"os"
 	"path/filepath"
 )
@@ -147,11 +145,9 @@ func scanLastAgentName(path, sessionID string) string {
 			}
 		}
 		if err != nil {
-			// io.EOF is expected at end of file; any other error stops the
-			// scan early but we still return whatever `last` we found.
-			if !errors.Is(err, io.EOF) {
-				break
-			}
+			// io.EOF is expected at end of file; any other read error
+			// (truncated journal, transient disk hiccup) is treated the
+			// same — stop the scan and return whatever `last` we found.
 			break
 		}
 	}

--- a/cmd/ezs/commands/agent_claude_name_test.go
+++ b/cmd/ezs/commands/agent_claude_name_test.go
@@ -148,6 +148,34 @@ func TestClaudeAgentName_PicksUpLateRename(t *testing.T) {
 	}
 }
 
+// TestClaudeAgentName_ToleratesOversizedLine pins the regression where a
+// single oversized journal line (e.g. a multi-MB tool output) caused the
+// scanner to silently truncate the search and lose every `agent-name`
+// event after it. The previous bufio.Scanner with a 4 MB line cap would
+// return false on the long line and stop, re-asserting the launch label
+// on resume even though a `/rename` event existed past the long line.
+// bufio.Reader.ReadBytes('\n') has no such cap, so the late rename is
+// surfaced as expected.
+func TestClaudeAgentName_ToleratesOversizedLine(t *testing.T) {
+	root := withClaudeProjectsDir(t)
+	sid := "oversized-uuid"
+	// Build a 5 MB single-line tool message — comfortably past the
+	// 4 MB cap the old scanner used. The line stays valid JSONL so the
+	// substring/decode path doesn't bail for the wrong reason.
+	bigPayload := strings.Repeat("x", 5*1024*1024)
+	bigLine := `{"type":"user","message":"` + bigPayload + `"}`
+	lines := []string{
+		nameEvent(sid, "_ezstack-launch-label"),
+		bigLine,
+		nameEvent(sid, "renamed-after-big-line"),
+	}
+	writeJSONL(t, root, "-Users-test-repo", sid, lines)
+
+	if got := claudeAgentName(sid); got != "renamed-after-big-line" {
+		t.Errorf("oversized line truncated scan: got %q, want %q", got, "renamed-after-big-line")
+	}
+}
+
 func TestClaudeAgentName_NoAgentNameEventReturnsEmpty(t *testing.T) {
 	root := withClaudeProjectsDir(t)
 	sid := "abc"

--- a/cmd/ezs/commands/sync.go
+++ b/cmd/ezs/commands/sync.go
@@ -237,7 +237,12 @@ func Sync(args []string) error {
 			return fmt.Errorf("branch %q is not part of any stack", *branchFlag)
 		}
 		if dryRun {
-			return syncDryRun(mgr, gh, []*config.Stack{targetStack}, jsonOutput, *includeRemoteFlag)
+			// Per-branch dry-run mirrors the execute path (syncCurrentBranch),
+			// which uses DetectSyncNeededForBranch and does NOT skip remote-only
+			// branches. Routing through syncDryRun (bulk detection) would filter
+			// pickups out and report "no sync needed" while the real run rebases
+			// — a divergence between preview and apply.
+			return syncDryRunBranch(mgr, gh, branch, jsonOutput)
 		}
 		// Use the branch's worktree path so stash operations target the correct worktree
 		branchCwd := cwd
@@ -468,6 +473,27 @@ func syncDryRun(mgr *stack.Manager, gh *github.Client, stacks []*config.Stack, j
 	}
 	if len(syncNeeded) == 0 {
 		ui.Success("All branches are up to date. Nothing to sync.")
+		return nil
+	}
+	ui.Info("[dry-run] The following branches would be synced:")
+	printSyncInfoList(syncNeeded)
+	return nil
+}
+
+// syncDryRunBranch previews what sync would do for a single explicitly-named
+// branch. Matches the execute path (syncCurrentBranch → DetectSyncNeededForBranch),
+// which never filters IsRemote because the user named the branch directly.
+func syncDryRunBranch(mgr *stack.Manager, gh *github.Client, branch *config.Branch, jsonOutput bool) error {
+	info := mgr.DetectSyncNeededForBranch(branch.Name, gh)
+	var syncNeeded []stack.SyncInfo
+	if info != nil && info.NeedsSync {
+		syncNeeded = []stack.SyncInfo{*info}
+	}
+	if jsonOutput {
+		return printSyncInfoJSON(syncNeeded)
+	}
+	if len(syncNeeded) == 0 {
+		ui.Success("Current branch is up to date. No sync needed.")
 		return nil
 	}
 	ui.Info("[dry-run] The following branches would be synced:")

--- a/cmd/ezs/commands/sync.go
+++ b/cmd/ezs/commands/sync.go
@@ -483,7 +483,27 @@ func syncDryRun(mgr *stack.Manager, gh *github.Client, stacks []*config.Stack, j
 // syncDryRunBranch previews what sync would do for a single explicitly-named
 // branch. Matches the execute path (syncCurrentBranch → DetectSyncNeededForBranch),
 // which never filters IsRemote because the user named the branch directly.
+//
+// We fetch before detecting because DetectSyncNeededForBranch only consults
+// local tracking refs — without a fetch, a teammate's just-pushed commit on
+// origin/<branch> would be invisible and we'd report "no sync needed",
+// while the execute path (which fetches at syncCurrentBranch start) would
+// see the commit and rebase. That's the same dry-run-vs-apply divergence
+// this wrapper exists to close. Failures are non-fatal: a stale tracking
+// ref just means the preview can't flag a remote-pull; surface a warning
+// so the user knows to retry once their network is healthy.
 func syncDryRunBranch(mgr *stack.Manager, gh *github.Client, branch *config.Branch, jsonOutput bool) error {
+	if !jsonOutput {
+		ui.Info("Fetching latest changes...")
+	}
+	if err := mgr.Fetch(); err != nil {
+		return fmt.Errorf("failed to fetch from remote: %w. Check your network connection and that the remote is accessible", err)
+	}
+	if r := branch.EffectiveRemote(); r != "" && r != "origin" && branch.CanPush() {
+		if ferr := mgr.FetchRemote(r); ferr != nil && !jsonOutput {
+			ui.Warn(fmt.Sprintf("Could not fetch %s for %s: %v — preview may miss collaborator commits on that remote.", r, branch.Name, ferr))
+		}
+	}
 	info := mgr.DetectSyncNeededForBranch(branch.Name, gh)
 	var syncNeeded []stack.SyncInfo
 	if info != nil && info.NeedsSync {

--- a/docs/agent.html
+++ b/docs/agent.html
@@ -90,7 +90,7 @@
       <div class="workflow-header" data-animate>
         <span class="mode-label mode-label-feature">New in v4.4</span>
         <h2>Zero-setup MCP when you launch with Claude</h2>
-        <p>When your agent CLI is <code>claude</code>, <code>ezs agent</code> automatically installs the <code>ezs-mcp</code> server and registers it with Claude Code before launching the session. The agent gets the full 21-tool ezstack surface natively &mdash; no <code>go install</code>, no <code>claude mcp add</code>, no embedded docs paste.</p>
+        <p>When your agent CLI is <code>claude</code>, <code>ezs agent</code> automatically installs the <code>ezs-mcp</code> server and registers it with Claude Code before launching the session. The agent gets the full 28-tool ezstack surface natively &mdash; no <code>go install</code>, no <code>claude mcp add</code>, no embedded docs paste.</p>
       </div>
 
       <div class="workflow-steps">
@@ -125,7 +125,7 @@
           <p>With MCP active, the shipped prompt switches from the full <code>DOCUMENTATION.md</code> dump to a short stub that tells the agent to prefer MCP tools. The agent gets strict tool schemas (with <em>destructive</em> annotations on mutating operations) instead of prose instructions &mdash; cheaper in tokens, more reliable in behavior.</p>
           <div class="step-code">
             <pre><code><span class="c-comment"># Before MCP: ~8KB of DOCUMENTATION.md embedded in every prompt</span>
-<span class="c-comment"># After MCP:  a short stub + 21 tool schemas delivered via MCP</span>
+<span class="c-comment"># After MCP:  a short stub + 28 tool schemas delivered via MCP</span>
 
 <span class="c-prompt">→</span> <span class="c-cmd">ezstack_status</span> <span class="c-flag">{ "decorated": true }</span>
 <span class="c-prompt">→</span> <span class="c-cmd">ezstack_commit</span> <span class="c-flag">{ "message": "Add auth middleware" }</span>

--- a/internal/stack/sync_test.go
+++ b/internal/stack/sync_test.go
@@ -2072,3 +2072,60 @@ func TestSyncSpecificStacks_SkipsRemoteByDefault(t *testing.T) {
 		t.Errorf("DetectSyncNeededForStacks(includeRemote=true) did not list pickup branch — opt-in flag should bring it back")
 	}
 }
+
+// TestDetectSyncNeededForBranch_DoesNotSkipRemote pins the per-branch contract
+// that complements TestSyncSpecificStacks_SkipsRemoteByDefault: when the user
+// explicitly names a remote-only (pickup) branch via `ezs sync --branch <pickup>`,
+// detection MUST report it. Bulk detection skips IsRemote=true by default;
+// per-branch detection has no such filter because the branch is the user's
+// explicit ask, not a default sweep. The dry-run path must mirror this so
+// `ezs sync --branch <pickup> --dry-run` doesn't promise "no sync needed"
+// while the execute path actually rebases.
+func TestDetectSyncNeededForBranch_DoesNotSkipRemote(t *testing.T) {
+	repoDir, worktreeBaseDir, cleanup := setupSyncTestEnv(t)
+	defer cleanup()
+
+	mgr, _ := NewManager(repoDir)
+	if _, err := mgr.CreateBranch("pickup", "main", filepath.Join(worktreeBaseDir, "pickup"), ""); err != nil {
+		t.Fatalf("CreateBranch pickup: %v", err)
+	}
+	pickupPath := filepath.Join(worktreeBaseDir, "pickup")
+	if err := os.WriteFile(filepath.Join(pickupPath, "pickup.txt"), []byte("b\n"), 0644); err != nil {
+		t.Fatalf("write pickup.txt: %v", err)
+	}
+	exec.Command("git", "-C", pickupPath, "add", ".").Run()
+	exec.Command("git", "-C", pickupPath, "commit", "-m", "pickup work").Run()
+	if err := mgr.MarkBranchRemote("pickup", "", "origin"); err != nil {
+		t.Fatalf("MarkBranchRemote: %v", err)
+	}
+
+	// Move main forward so pickup is behind and would need a sync.
+	if err := os.WriteFile(filepath.Join(repoDir, "main.txt"), []byte("c\n"), 0644); err != nil {
+		t.Fatalf("write main.txt: %v", err)
+	}
+	exec.Command("git", "-C", repoDir, "add", ".").Run()
+	exec.Command("git", "-C", repoDir, "commit", "-m", "main work").Run()
+
+	bareDir := filepath.Join(filepath.Dir(repoDir), "bare.git")
+	exec.Command("git", "init", "--bare", "-b", "main", bareDir).Run()
+	exec.Command("git", "-C", repoDir, "remote", "add", "origin", bareDir).Run()
+	exec.Command("git", "-C", repoDir, "push", "-q", "-u", "origin", "main").Run()
+	exec.Command("git", "-C", repoDir, "push", "-q", "-u", "origin", "pickup").Run()
+
+	mgr, _ = NewManager(repoDir)
+
+	// Per-branch detection MUST report the pickup as needing sync. The bulk
+	// path with includeRemote=false would drop it (verified by the sibling
+	// test); the per-branch path has no such filter because the user named
+	// the branch directly.
+	info := mgr.DetectSyncNeededForBranch("pickup", nil)
+	if info == nil {
+		t.Fatalf("DetectSyncNeededForBranch(\"pickup\")=nil — per-branch path must NOT silently skip IsRemote=true")
+	}
+	if !info.NeedsSync {
+		t.Errorf("DetectSyncNeededForBranch(\"pickup\").NeedsSync=false — pickup is behind main, should report needing sync")
+	}
+	if info.Branch != "pickup" {
+		t.Errorf("DetectSyncNeededForBranch(\"pickup\").Branch = %q, want %q", info.Branch, "pickup")
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -859,8 +859,9 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 	// rootCurrentColor is emitted BEFORE the pointer so the `>` itself
 	// renders green when the root is current. The inner Gray that follows
 	// re-colors the name to the muted root style; without it, the Green
-	// would bleed into the name. Branch rows look green-on-name because
-	// they use Bold (which doesn't reset color) instead of Gray.
+	// would bleed into the name. Branch rows mirror this ordering — see
+	// the per-row Fprintf below — so the cursor marker is consistently
+	// green across the whole stack listing.
 	rootPointer := " "
 	rootCurrentColor := ""
 	rootCurrentReset := ""
@@ -935,6 +936,12 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 
 		gap := padNameGap(r.nameWidth)
 
+		// Emit `color` BEFORE `pointer` so the leading `>` glyph itself
+		// renders green when the row is current — matching the root-row
+		// fix above. The previous order (pointer, then color) printed `>`
+		// in the terminal default and started green only on the prefix
+		// gutter, leaving the cursor marker visually identical to the
+		// non-current padding space.
 		if shouldStrike {
 			gapWithStrike := strings.ReplaceAll(gap, Reset, Reset+Strikethrough)
 			prWithStrike := strings.ReplaceAll(prFormatted, Reset, Reset+Strikethrough)
@@ -944,11 +951,11 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 				statusWithStrike = strings.ReplaceAll(statusInfo, Reset, Reset+Strikethrough)
 			}
 			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
-				pointer, color, r.prefix, r.connector, Strikethrough+Bold, r.name, Reset+Strikethrough,
+				color, pointer, r.prefix, r.connector, Strikethrough+Bold, r.name, Reset+Strikethrough,
 				remoteTag, gapWithStrike, prWithStrike, diffWithStrike, statusWithStrike, Reset)
 		} else {
 			fmt.Fprintf(os.Stderr, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
-				pointer, color, r.prefix, r.connector, Bold, r.name, Reset,
+				color, pointer, r.prefix, r.connector, Bold, r.name, Reset,
 				remoteTag, gap, prFormatted, diffFormatted, statusInfo, Reset)
 		}
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -856,13 +856,20 @@ func PrintStack(stack *config.Stack, currentBranch string, showStatus bool, stat
 	// Render the root row. Root has no connector, but it shares the pointer
 	// + prefix gutter with branch rows so the name aligns with the tree's
 	// connector column and the PR/diff cells line up with the shared columns.
+	// rootCurrentColor is emitted BEFORE the pointer so the `>` itself
+	// renders green when the root is current. The inner Gray that follows
+	// re-colors the name to the muted root style; without it, the Green
+	// would bleed into the name. Branch rows look green-on-name because
+	// they use Bold (which doesn't reset color) instead of Gray.
 	rootPointer := " "
 	rootCurrentColor := ""
+	rootCurrentReset := ""
 	if currentBranch == stack.Root {
 		rootPointer = ">"
 		rootCurrentColor = Green
+		rootCurrentReset = Reset
 	}
-	rootLine := fmt.Sprintf("%s%s  %s%s%s", rootPointer, rootCurrentColor, Gray, stack.Root, Reset)
+	rootLine := fmt.Sprintf("%s%s%s  %s%s%s", rootCurrentColor, rootPointer, rootCurrentReset, Gray, stack.Root, Reset)
 	if stack.RootIsRemote {
 		rootLine += " " + Gray + "(remote)" + Reset
 	}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -307,6 +307,49 @@ func TestPrintStack_RootCurrentPointerIsGreen(t *testing.T) {
 	}
 }
 
+// TestPrintStack_BranchCurrentPointerIsGreen mirrors the root-pointer
+// contract for tree branch rows: when a non-root branch is current, the
+// leading `>` must also render in green. Pre-fix, branch rows emitted
+// the pointer character BEFORE the green SGR, so `>` printed in the
+// terminal default while the rest of the row picked up green via the
+// non-resetting Bold that follows. Visually inconsistent with the root
+// row and unhelpful as a cursor marker — pin both rows to the same
+// ordering so future renderer churn can't silently regress one without
+// the other.
+func TestPrintStack_BranchCurrentPointerIsGreen(t *testing.T) {
+	stack := &config.Stack{
+		Hash: "abc1234",
+		Root: "main",
+		Branches: []*config.Branch{
+			{Name: "feat", Parent: "main"},
+		},
+	}
+
+	out := captureStderr(t, func() {
+		PrintStack(stack, "feat", false, nil)
+	})
+
+	var branchLine string
+	for _, l := range strings.Split(out, "\n") {
+		clean := stripANSI(l)
+		if strings.Contains(clean, "feat") && !strings.Contains(clean, "main") {
+			branchLine = l
+			break
+		}
+	}
+	if branchLine == "" {
+		t.Fatalf("branch line not found; full output:\n%s", out)
+	}
+
+	pointerByte := strings.Index(branchLine, ">")
+	if pointerByte == -1 {
+		t.Fatalf("expected `>` pointer on current-branch line, got %q", branchLine)
+	}
+	if !sgrColorActiveAt(branchLine, pointerByte, "32") {
+		t.Errorf("`>` pointer not rendered in green on current-branch line; got %q", branchLine)
+	}
+}
+
 // sgrColorActiveAt walks the SGR (CSI ... m) escape sequences in s up to byte
 // position pos and returns whether the given color code (e.g. "32" for green)
 // is the active foreground color. Used to pin the green-pointer contract for

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -260,6 +260,89 @@ func TestPrintStack_StrikethroughSpansDotLeader(t *testing.T) {
 	}
 }
 
+// TestPrintStack_RootCurrentPointerIsGreen pins that when the root is the
+// current branch, the leading `>` pointer actually renders in green. The
+// previous code emitted the Green SGR AFTER the pointer character, so `>`
+// printed in the terminal default and only the (invisible) padding spaces
+// between pointer and name picked up the green tint. The inner Gray on the
+// name still wins, but the pointer itself must be green to match branch-row
+// behavior and to give the user a visible "this is your current location"
+// signal on root rows.
+func TestPrintStack_RootCurrentPointerIsGreen(t *testing.T) {
+	stack := &config.Stack{
+		Hash: "abc1234",
+		Root: "main",
+		Branches: []*config.Branch{
+			{Name: "feat", Parent: "main"},
+		},
+	}
+
+	out := captureStderr(t, func() {
+		PrintStack(stack, "main", false, nil)
+	})
+
+	// Find the root line (contains "main" but not the connector chars used
+	// for branch rows).
+	var rootLine string
+	for _, l := range strings.Split(out, "\n") {
+		clean := stripANSI(l)
+		if strings.Contains(clean, "main") && !strings.Contains(clean, "feat") {
+			rootLine = l
+			break
+		}
+	}
+	if rootLine == "" {
+		t.Fatalf("root line not found; full output:\n%s", out)
+	}
+
+	// The pointer is the first non-SGR character on the line. We expect:
+	//   <Green SGR><pointer ">"><Reset SGR>...
+	// i.e. the Green escape must precede the literal `>`.
+	pointerByte := strings.Index(rootLine, ">")
+	if pointerByte == -1 {
+		t.Fatalf("expected `>` pointer on current-root line, got %q", rootLine)
+	}
+	if !sgrColorActiveAt(rootLine, pointerByte, "32") {
+		t.Errorf("`>` pointer not rendered in green on current-root line; got %q", rootLine)
+	}
+}
+
+// sgrColorActiveAt walks the SGR (CSI ... m) escape sequences in s up to byte
+// position pos and returns whether the given color code (e.g. "32" for green)
+// is the active foreground color. Used to pin the green-pointer contract for
+// the root-current row in PrintStack.
+func sgrColorActiveAt(s string, pos int, code string) bool {
+	active := ""
+	i := 0
+	for i < pos && i < len(s) {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && (s[j] >= '0' && s[j] <= '9' || s[j] == ';') {
+				j++
+			}
+			if j < len(s) && s[j] == 'm' {
+				params := s[i+2 : j]
+				if params == "" {
+					active = ""
+				} else {
+					for _, p := range strings.Split(params, ";") {
+						if p == "0" || p == "" {
+							active = ""
+						} else if (len(p) == 2 && p[0] == '3' && p[1] >= '0' && p[1] <= '9') ||
+							(len(p) == 2 && p[0] == '9' && p[1] >= '0' && p[1] <= '9') {
+							active = p
+						}
+					}
+				}
+				i = j + 1
+				continue
+			}
+		}
+		i++
+	}
+	return active == code
+}
+
 // sgrStrikethroughActiveAt walks the SGR (CSI ... m) escape sequences in s up
 // to byte position pos and returns whether strikethrough (SGR 9) is the
 // active text-decoration state. Used to assert that the dot-leader gap

--- a/itests/sync_gaps_test.go
+++ b/itests/sync_gaps_test.go
@@ -415,6 +415,81 @@ func TestSyncItest_DryRunJSONIncludesBehindRemote(t *testing.T) {
 	}
 }
 
+// TestSyncItest_DryRunBranchFetchesBeforeDetect pins that
+// `ezs sync --branch X --dry-run` performs a fetch before detection,
+// so a teammate's commit that landed on origin/X via a separate clone
+// (not visible to our local tracking refs until fetch) shows up in the
+// preview. Without the fetch, dry-run would say "up to date" while
+// `ezs sync --branch X` would fetch and rebase — exactly the
+// preview-vs-apply divergence syncDryRunBranch exists to close.
+func TestSyncItest_DryRunBranchFetchesBeforeDetect(t *testing.T) {
+	env := SetupTestEnv(t)
+	defer env.Cleanup()
+	withYesMode(t)
+
+	os.WriteFile(filepath.Join(env.RepoDir, "shared.txt"), []byte("v0\n"), 0644)
+	exec.Command("git", "-C", env.RepoDir, "add", ".").Run()
+	exec.Command("git", "-C", env.RepoDir, "commit", "-m", "seed").Run()
+	bareDir := initBareRemote(t, env)
+
+	CreateBranchWithCommit(t, env, "feat", "main")
+	featPath := filepath.Join(env.WorktreeDir, "feat")
+	featPath, _ = filepath.EvalSymlinks(featPath)
+	exec.Command("git", "-C", featPath, "push", "-u", "origin", "feat").Run()
+
+	// Teammate clones the bare and pushes a commit on feat. Our local
+	// origin/feat ref is now stale until we fetch.
+	collab, _ := os.MkdirTemp("", "collab-branch-dry-*")
+	defer os.RemoveAll(collab)
+	exec.Command("git", "clone", "-q", "-b", "feat", bareDir, collab).Run()
+	exec.Command("git", "-C", collab, "config", "user.email", "c@c.com").Run()
+	exec.Command("git", "-C", collab, "config", "user.name", "c").Run()
+	os.WriteFile(filepath.Join(collab, "x.txt"), []byte("teammate\n"), 0644)
+	exec.Command("git", "-C", collab, "add", ".").Run()
+	exec.Command("git", "-C", collab, "commit", "-q", "-m", "teammate work").Run()
+	exec.Command("git", "-C", collab, "push", "-q", "origin", "feat").Run()
+
+	// Drive sync from main so --branch routes through the named-branch path.
+	chdirOrFail(t, env.RepoDir)
+
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	if err := commands.Sync([]string{"--branch", "feat", "--dry-run", "--json"}); err != nil {
+		w.Close()
+		os.Stdout = orig
+		t.Fatalf("sync --branch feat --dry-run --json: %v", err)
+	}
+	w.Close()
+	os.Stdout = orig
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+
+	var entries []map[string]any
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatalf("parse JSON: %v\nraw: %q", err, string(raw))
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected feat in dry-run preview after teammate pushed; got empty: %q", string(raw))
+	}
+	var featEntry map[string]any
+	for _, e := range entries {
+		if e["branch"] == "feat" {
+			featEntry = e
+			break
+		}
+	}
+	if featEntry == nil {
+		t.Fatalf("feat entry missing from dry-run JSON: %v", entries)
+	}
+	br, _ := featEntry["behind_remote"].(float64)
+	if int(br) <= 0 {
+		t.Errorf("behind_remote=%v after teammate pushed; dry-run --branch did not fetch before detect", br)
+	}
+}
+
 // TestSyncItest_RealBinaryExitCode builds and invokes the actual `ezs`
 // binary as a subprocess to confirm the partial-completion path returns
 // exit code != 0 (not just the in-process error). Scripts and CI rely on

--- a/tauri-ui/src/components/stack/StackColumn.tsx
+++ b/tauri-ui/src/components/stack/StackColumn.tsx
@@ -131,11 +131,13 @@ export function StackColumn({ stack, selectedBranch, onSelectBranch, onRename, o
           <div className="text-center text-xs text-muted-foreground py-6">No branches</div>
         ) : (
           <div className="space-y-0.5">
-            {/* Root indicator */}
+            {/* Root indicator. The (remote) badge already renders in the
+                column header above; rendering it here too produced a
+                duplicate. Keep this row name-only so the badge stays in one
+                canonical location, matching StackGraph. */}
             <div className="flex items-center gap-1.5 px-2 py-1 text-[10px] text-muted-foreground">
               <div className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />
               <span className="font-mono">{stack.root}</span>
-              {stack.root_is_remote && <RemoteTag kind="stack" className="font-mono" />}
             </div>
             {tree.map((node, i) => (
               <TreeNodeView

--- a/vscode-extension/src/commands/index.ts
+++ b/vscode-extension/src/commands/index.ts
@@ -482,9 +482,16 @@ export function registerCommands(
           vscode.window.showInformationMessage("No current branch found in any stack.");
           return;
         }
+        // Match the CLI's effective-tree walk (cmd/ezs/commands/navigate.go):
+        // a merged direct child has had its worktree deleted by
+        // MarkBranchMerged, so `revealInExplorer` would point at a path that
+        // no longer exists. Filtering them out matches `ezs navigate down`
+        // and keeps `up`/`down` in sync between client and CLI. Walking
+        // through merged ancestors for "up" is already handled by walkTree
+        // re-pointing Branch.Parent to the nearest non-merged ancestor.
         const children = stacks
           .flatMap((s) => s.branches)
-          .filter((b) => b.parent === current.name);
+          .filter((b) => b.parent === current.name && !b.is_merged);
         if (children.length === 0) {
           vscode.window.showInformationMessage("Already at the bottom of the stack.");
           return;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -12,10 +12,30 @@ import {
   updateContextKeys,
 } from "./commands/fileNavigation";
 
+// pickWorkspaceRoot resolves the repo root for the extension. ezstack users
+// frequently open multiple worktrees in one window (one per stack branch),
+// so a flat `workspaceFolders[0]` would silently bind the extension to an
+// arbitrary folder. Prefer the active editor's containing folder when one
+// is open; otherwise fall back to the first folder.
+function pickWorkspaceRoot(): string | undefined {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return undefined;
+  }
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor) {
+    const containing = vscode.workspace.getWorkspaceFolder(activeEditor.document.uri);
+    if (containing) {
+      return containing.uri.fsPath;
+    }
+  }
+  return folders[0].uri.fsPath;
+}
+
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const workspaceRoot = pickWorkspaceRoot();
   if (!workspaceRoot) {
     return;
   }
@@ -208,16 +228,18 @@ export async function activate(
     }),
   );
 
-  // Config watcher for auto-refresh
-  const autoRefresh = vscode.workspace
-    .getConfiguration("ezstack")
-    .get<boolean>("autoRefresh", true);
-
+  // Config watcher for auto-refresh. Toggling `ezstack.autoRefresh` at
+  // runtime should start/stop the watcher live without requiring a window
+  // reload — onDidChangeConfiguration handles that here.
   const pendingTimers: ReturnType<typeof setTimeout>[] = [];
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let watcher: ConfigWatcher | undefined;
 
-  if (autoRefresh) {
-    const watcher = new ConfigWatcher(workspaceRoot);
+  const startWatcher = () => {
+    if (watcher) {
+      return;
+    }
+    watcher = new ConfigWatcher(workspaceRoot);
     watcher.onDidChange(() => {
       if (debounceTimer) {
         clearTimeout(debounceTimer);
@@ -228,8 +250,38 @@ export async function activate(
         void decorations.refresh();
       }, 500);
     });
-    context.subscriptions.push(watcher);
+  };
+  const stopWatcher = () => {
+    if (watcher) {
+      watcher.dispose();
+      watcher = undefined;
+    }
+  };
+
+  if (
+    vscode.workspace
+      .getConfiguration("ezstack")
+      .get<boolean>("autoRefresh", true)
+  ) {
+    startWatcher();
   }
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (!e.affectsConfiguration("ezstack.autoRefresh")) {
+        return;
+      }
+      const enabled = vscode.workspace
+        .getConfiguration("ezstack")
+        .get<boolean>("autoRefresh", true);
+      if (enabled) {
+        startWatcher();
+      } else {
+        stopWatcher();
+      }
+    }),
+    { dispose: stopWatcher },
+  );
 
   // Refresh git status on file save (debounced)
   let saveTimer: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
## Summary

Bundle of fixes from a deep code review of every commit since v4.8.1. Each finding was reproduced in code, then fixed with a regression test where one was reasonable to write.

### CLI

- **sync `--branch <pickup> --dry-run` no longer lies.** Dry-run was routing through bulk `DetectSyncNeededForStacks(includeRemote=false)` and reporting "All up to date", while execute went through `DetectSyncNeededForBranch` (no skip) and rebased. New `syncDryRunBranch` mirrors execute. Test: `TestDetectSyncNeededForBranch_DoesNotSkipRemote`.
- **Root `>` pointer renders green when current.** SGR Green was emitted *after* the pointer character; pointer printed in default color and inner Gray overrode green for the name. Move the SGR before the pointer + emit matching Reset. Test: `TestPrintStack_RootCurrentPointerIsGreen`.
- **`scanLastAgentName` no longer truncates on a long journal line.** `bufio.Scanner` with a 4 MiB line cap silently aborted on oversized tool-output lines and lost every `agent-name` after them — launch label won on resume even when a `/rename` existed past the long line. Switch to `bufio.Reader.ReadBytes`. Test: `TestClaudeAgentName_ToleratesOversizedLine`.

### MCP server

- **`ezstack_pr_create` no longer silently force-pushes.** Was on plain `toolHandler` + `WithDestructiveHintAnnotation(false)`. When a PR's remote diverged, the in-CLI `Confirm("Force push?")` reached `MCPBackend.Confirm` whose `defaultYes=true` returned `true` on client-decline / no-elicitation-support — silent force-push, no destructive hint to the IDE. Switch to `yesModeHandler` + `WithDestructiveHintAnnotation(true)` so the consent gate is the MCP client's destructive-action prompt the user actually sees. `server_test` destructive map updated.

### VS Code extension

- **`ezstack.down` skips merged direct children.** Was filtering only by `parent === current.name`; merged direct children with empty `worktree_path` slipped into the quick-pick or silently no-op'd. Filter `!b.is_merged` to match CLI's `effectiveChildrenForNavigation`. (UP was already correct because `walkTree` populates `Branch.Parent` as the effective parent.)
- **Multi-root workspace picks the active editor's folder.** `workspaceFolders[0]` was hard-coded; ezstack flows often open multiple worktrees in one window. Now uses `getWorkspaceFolder(activeEditor)` first, falls back to `[0]`.
- **`autoRefresh` toggle is live.** Setting was read once at activation; toggling required Reload Window. Now wired through `onDidChangeConfiguration` to start/stop the watcher in place.

### Tauri desktop

- **Drop duplicate `(remote)` badge in StackColumn.** Header subtitle *and* in-tree root indicator both rendered `<RemoteTag>` for the same `root_is_remote`, so users saw `(remote)` twice. Keep header (matches StackGraph), drop in-tree.

### Neovim plugin

- **Submodule bumped + `(remote)` parity** — KulkarniKaustubh/ezstack.nvim#feat/v48-remote-parity (separate review). Plumbs `is_remote`/`root_is_remote` through `_render_stack`, `_render_graph_lines`, `render_preview`. Bumps `MIN_CLI_VERSION` to 4.8.0 so older CLIs warn at activation. New plenary specs for the marker.

### Docs

- **`docs/agent.html` 21 → 28.** Same page contradicted itself: 21 on lines 93/128, 28 on 210/217. Actual `mcp.NewTool(` count: 28.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Unit tests: 8 packages all green
- [x] Integration tests: itests/ 89.7s green
- [x] Drift-gate: `go test ./cmd/docsgen/...` green
- [x] Tauri: 34 vitest tests, frontend build, `cargo check` (pre-existing dead-code warning unrelated)
- [x] VS Code: lint, esbuild bundle, 55 vitest tests
- [x] Neovim: 152 plenary specs (3 updated for new MIN_CLI_VERSION; 2 new for `(remote)` marker)

## Notes

- Submodule pointer is bumped to a not-yet-merged branch on `ezstack.nvim` (`feat/v48-remote-parity`). Merge that submodule PR first, then this PR's submodule pointer will track the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)