### PR TITLE
feat(agent): bind active feature session to stacks created mid-flight

### DIFF
--- a/cmd/ezs/commands/agent.go
+++ b/cmd/ezs/commands/agent.go
@@ -1248,10 +1248,12 @@ func spawnAgentProcess(spec agentSpawnSpec) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	sessionEnvID := ""
+	sessionEnvMode := ""
 	if spec.session != nil && spec.session.injection != nil {
 		sessionEnvID = spec.session.injection.SessionID
+		sessionEnvMode = spec.session.injection.Mode
 	}
-	cmd.Env = agentProcessEnv(os.Environ(), spec.noPush, sessionEnvID)
+	cmd.Env = agentProcessEnv(os.Environ(), spec.noPush, sessionEnvID, sessionEnvMode)
 
 	runErr := cmd.Run()
 
@@ -1287,6 +1289,15 @@ func spawnAgentProcess(spec agentSpawnSpec) error {
 // for user scripts.
 const agentSessionIDEnv = "EZS_AGENT_SESSION_ID"
 
+// agentSessionModeEnv carries the launch mode of the active session
+// (config.AgentSessionWorkMode or config.AgentSessionFeatureMode) into the
+// spawned agent's environment. It's consumed by `ezs new`'s session-adoption
+// path: a freshly-created stack only inherits the active session when the
+// mode is feature, since a feature session is meant to span the stacks the
+// agent spins up while building. Work-mode sessions are scoped to the stack
+// they were launched from and shouldn't leak into unrelated new stacks.
+const agentSessionModeEnv = "EZS_AGENT_SESSION_MODE"
+
 // formatPersistFailureWarning renders the warning surfaced when the
 // best-effort persist of an agent session UUID fails. The message
 // includes the raw UUID and a manual-resume hint so the user has a
@@ -1309,21 +1320,28 @@ func formatPersistFailureWarning(sessionID, agentBinary string, err error) strin
 // the user didn't ask to propagate.
 //
 // sessionID, when non-empty, is exposed to the child as EZS_AGENT_SESSION_ID;
-// any pre-existing inherited value is stripped so a nested agent doesn't see
-// a stale ID from its parent. Empty sessionID strips the var entirely.
+// sessionMode (when both sessionID and sessionMode are non-empty) is exposed
+// as EZS_AGENT_SESSION_MODE so nested `ezs new` calls can decide whether to
+// adopt the active session. Any pre-existing inherited values for both vars
+// are stripped first so a nested agent doesn't see a stale ID/mode from its
+// parent. Empty sessionID strips both vars entirely.
 //
 // Extracted for testability: nothing else about spawnAgentProcess can be
 // exercised without running a real command.
-func agentProcessEnv(parentEnv []string, noPush bool, sessionID string) []string {
+func agentProcessEnv(parentEnv []string, noPush bool, sessionID, sessionMode string) []string {
 	noPushPrefix := agentNoPushEnv + "="
 	sessionPrefix := agentSessionIDEnv + "="
-	env := make([]string, 0, len(parentEnv)+2)
+	modePrefix := agentSessionModeEnv + "="
+	env := make([]string, 0, len(parentEnv)+3)
 	for _, kv := range parentEnv {
 		if strings.HasPrefix(kv, noPushPrefix) {
 			continue // either we'll re-add it or we want it gone
 		}
 		if strings.HasPrefix(kv, sessionPrefix) {
 			continue // ditto for the session ID
+		}
+		if strings.HasPrefix(kv, modePrefix) {
+			continue // and the mode tag — paired with the ID
 		}
 		env = append(env, kv)
 	}
@@ -1332,6 +1350,9 @@ func agentProcessEnv(parentEnv []string, noPush bool, sessionID string) []string
 	}
 	if sessionID != "" {
 		env = append(env, sessionPrefix+sessionID)
+		if sessionMode != "" {
+			env = append(env, modePrefix+sessionMode)
+		}
 	}
 	return env
 }

--- a/cmd/ezs/commands/agent.go
+++ b/cmd/ezs/commands/agent.go
@@ -29,12 +29,14 @@ func Agent(args []string) error {
     ezs agent [options] [-- <agent-args>]   Launch agent scoped to a stack
     ezs agent feature|feat "description"    Launch agent to build a feature as stacked branches
     ezs agent ls|list [filter] [--json]     List tracked AI sessions (current repo only)
+    ezs agent rm|remove <filter>            Forget a tracked AI session binding
     ezs agent prompt <flag> <work|feature>  View or edit agent prompt templates
 
 %sMODES%s
     (default)       Work session — agent is scoped to a stack with full context
     feature (feat)  Feature builder — agent breaks a feature into incremental stacked branches
     ls (list)       List the AI sessions ezs has bound to stacks/branches in this repo
+    rm (remove)     Forget the persisted session binding for a stack/branch/repo
     prompt          View or edit the prompt templates used by the agent
 
 %sOPTIONS%s
@@ -121,6 +123,8 @@ func Agent(args []string) error {
 			return agentPrompt(rest)
 		case "ls", "list":
 			return agentList(rest)
+		case "rm", "remove":
+			return agentRm(rest)
 		}
 	}
 
@@ -221,7 +225,7 @@ func Agent(args []string) error {
 
 	// Reject unknown subcommands (e.g. "ezs agent new" or "ezs agent foo")
 	if fs.NArg() > 0 {
-		return fmt.Errorf("unknown agent subcommand %q.\nValid subcommands: feature (or feat), prompt\nFor help: ezs agent --help", fs.Arg(0))
+		return fmt.Errorf("unknown agent subcommand %q.\nValid subcommands: feature (or feat), ls (or list), rm (or remove), prompt\nFor help: ezs agent --help", fs.Arg(0))
 	}
 
 	// Work mode requires an existing stack
@@ -1094,20 +1098,21 @@ changes in them and add new branches to this stack as needed.
 2. Plan a series of incremental branches — present the plan to the user FIRST.
 3. For each branch after user approves:
    a. Create it: ezs -y new <descriptive-branch-name>
-   b. cd to the worktree path printed in the output
-   c. Implement the focused change for this branch
-   d. Commit: ezs -y commit -m "descriptive message"
-   e. Push: ezs -y push
-4. After the FIRST branch is created (this implicitly creates the stack), give
-   the stack a SHORT descriptive name with: ezs stack rename <stack-hash> <name>
-   - The name MUST be ≤5 words; 1–3 words is strongly preferred.
-   - Lowercase, hyphenated, no quotes (e.g. "jwt-auth", "rate-limiter",
-     "audit-fixes", "cli-ux-pass"). Avoid filler words like "feature", "add",
-     "implement".
-   - Get <stack-hash> from "ezs ls -a" or the stack hash printed by "ezs new".
-   - Do this BEFORE creating any subsequent branches so the rest of the stack
-     inherits the named identity.
-5. After all branches are created, show the final stack with: ezs ls`
+   b. AFTER THE FIRST BRANCH ONLY: name the stack BEFORE doing anything else.
+      Run: ezs stack rename <stack-hash> <name>
+      - <name> MUST be derived from the FEATURE_DESCRIPTION above, ≤5 words;
+        1–3 words is strongly preferred.
+      - Lowercase, hyphenated, no quotes (e.g. "jwt-auth", "rate-limiter",
+        "audit-fixes", "cli-ux-pass"). Avoid filler like "feature", "add",
+        "implement".
+      - Get <stack-hash> from the hash printed by "ezs new" (or "ezs ls -a").
+      - This is mandatory: skip it and the stack stays anonymously hash-named
+        and the session won't be findable in "ezs agent ls".
+   c. cd to the worktree path printed in the output
+   d. Implement the focused change for this branch
+   e. Commit: ezs -y commit -m "descriptive message"
+   f. Push: ezs -y push
+4. After all branches are created, show the final stack with: ezs ls`
 	}
 
 	return buildComposedPrompt(defaultFeaturePromptTemplate, vars, repoPath, "feature")

--- a/cmd/ezs/commands/agent_nopush_test.go
+++ b/cmd/ezs/commands/agent_nopush_test.go
@@ -12,7 +12,7 @@ import (
 func TestAgentProcessEnv_InjectsNoPushFlag(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "HOME=/home/test", "UNRELATED=x"}
 
-	got := agentProcessEnv(parent, true, "")
+	got := agentProcessEnv(parent, true, "", "")
 
 	var seen bool
 	for _, kv := range got {
@@ -45,7 +45,7 @@ func TestAgentProcessEnv_InjectsNoPushFlag(t *testing.T) {
 func TestAgentProcessEnv_DoesNotSetFlagWhenDisabled(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
 
-	got := agentProcessEnv(parent, false, "")
+	got := agentProcessEnv(parent, false, "", "")
 
 	for _, kv := range got {
 		if strings.HasPrefix(kv, agentNoPushEnv+"=") {
@@ -78,7 +78,7 @@ func TestAgentProcessEnv_StripsInheritedGateWhenDisabled(t *testing.T) {
 		"HOME=/home/test",
 	}
 
-	got := agentProcessEnv(parent, false, "")
+	got := agentProcessEnv(parent, false, "", "")
 
 	for _, kv := range got {
 		if strings.HasPrefix(kv, agentNoPushEnv+"=") {
@@ -98,7 +98,7 @@ func TestAgentProcessEnv_DeduplicatesWhenEnabled(t *testing.T) {
 		agentNoPushEnv + "=stale-value",
 	}
 
-	got := agentProcessEnv(parent, true, "")
+	got := agentProcessEnv(parent, true, "", "")
 
 	count := 0
 	for _, kv := range got {
@@ -117,7 +117,7 @@ func TestAgentProcessEnv_DeduplicatesWhenEnabled(t *testing.T) {
 // TestAgentProcessEnv_NilParentDoesNotCrash pins down defensive behavior
 // when the caller passes a nil env (possible in synthetic test contexts).
 func TestAgentProcessEnv_NilParentDoesNotCrash(t *testing.T) {
-	got := agentProcessEnv(nil, true, "")
+	got := agentProcessEnv(nil, true, "", "")
 
 	if len(got) < 1 || got[len(got)-1] != agentNoPushEnv+"=1" {
 		t.Errorf("expected gate var as final element even with nil parent; got %v", got)

--- a/cmd/ezs/commands/agent_rm.go
+++ b/cmd/ezs/commands/agent_rm.go
@@ -146,7 +146,7 @@ func agentRmBranchScope(mgr *stack.Manager, g *git.Git) error {
 	if err := mgr.SetBranchAgentSessionID(branch, "", ""); err != nil {
 		return fmt.Errorf("failed to clear branch session: %w", err)
 	}
-	ui.Success(fmt.Sprintf("Forgot session %s on branch %s", shortAgentSessionID(stored), branch))
+	ui.Success(fmt.Sprintf("Forgot session %s on branch %s", shortSessionID(stored), branch))
 	return nil
 }
 
@@ -164,7 +164,7 @@ func agentRmStackScope(mgr *stack.Manager) error {
 	if err := mgr.SetStackAgentSessionID(s.Hash, "", ""); err != nil {
 		return fmt.Errorf("failed to clear stack session: %w", err)
 	}
-	ui.Success(fmt.Sprintf("Forgot session %s on stack %s", shortAgentSessionID(stored), s.DisplayName()))
+	ui.Success(fmt.Sprintf("Forgot session %s on stack %s", shortSessionID(stored), s.DisplayName()))
 	return nil
 }
 

--- a/cmd/ezs/commands/agent_rm.go
+++ b/cmd/ezs/commands/agent_rm.go
@@ -1,0 +1,225 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/git"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/ui"
+	"github.com/spf13/pflag"
+)
+
+// agentRm implements `ezs agent rm` (alias `ezs agent remove`).
+//
+// Clears the persisted AI session binding for a stack or branch, so the next
+// `ezs agent` invocation in that scope mints a fresh UUID instead of
+// resuming. The agent's underlying conversation history (claude's session
+// journal, etc.) is NOT touched — `rm` only forgets ezs's pointer to it.
+//
+// Filters mirror `ezs agent ls`:
+//
+//   - --branch    forget the session bound to the user's current branch
+//   - --stack     forget the session bound to the user's current stack
+//   - --all       forget every session in the current repo (stack + branch)
+//
+// Filters are mutually exclusive; one is required. The bare `ezs agent rm`
+// errors out with guidance — silently picking a default would risk wiping
+// the wrong session, and the typing cost of one extra flag is trivial.
+//
+// A confirmation prompt protects --all (the only non-recoverable shape since
+// it touches multiple slots in one call). Single-target rm is one slot and
+// easily re-bound by re-launching the agent, so we don't gate it.
+// `ui.YesMode` (set by -y / MCP) bypasses both prompts as usual.
+func agentRm(args []string) error {
+	fs := pflag.NewFlagSet("agent rm", pflag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%sForget a tracked AI session binding%s
+
+%sUSAGE%s
+    ezs agent rm <filter>
+    ezs agent remove <filter>   (alias)
+
+%sFILTERS%s (mutually exclusive — one is required)
+    -b, --branch     Forget the session bound to the current branch
+    -s, --stack      Forget the session bound to the current stack
+    --all            Forget every session in this repo (stack + branch)
+
+%sOPTIONS%s
+    -h, --help       Show this help message
+
+%sDESCRIPTION%s
+    Clears ezs's stored pointer to the AI session for the chosen scope. The
+    next 'ezs agent' invocation against that scope will mint a fresh UUID
+    instead of resuming.
+
+    The agent's own session journal (e.g. claude's transcript) is NOT
+    deleted — only ezs forgets the pointer. To resume the prior session
+    manually after running rm, pass the agent's resume flag explicitly
+    (e.g. 'ezs agent -- --resume <uuid>'); 'ezs agent ls' is the canonical
+    place to find UUIDs before clearing them.
+
+    --all asks for confirmation since it touches multiple bindings at once.
+    -y / YesMode bypasses the prompt.
+`, ui.Bold, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset, ui.Cyan, ui.Reset)
+	}
+	branchFilter := fs.BoolP("branch", "b", false, "Forget the session for the current branch")
+	stackFilter := fs.BoolP("stack", "s", false, "Forget the session for the current stack")
+	allFilter := fs.Bool("all", false, "Forget every session in this repo")
+	helpFlag := fs.BoolP("help", "h", false, "Show help")
+
+	if err := fs.Parse(args); err != nil {
+		if err == pflag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+	if *helpFlag {
+		fs.Usage()
+		return nil
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("ezs agent rm takes no positional arguments (got %q)", fs.Arg(0))
+	}
+
+	picked := 0
+	names := []string{}
+	if *branchFilter {
+		picked++
+		names = append(names, "--branch")
+	}
+	if *stackFilter {
+		picked++
+		names = append(names, "--stack")
+	}
+	if *allFilter {
+		picked++
+		names = append(names, "--all")
+	}
+	switch picked {
+	case 0:
+		return fmt.Errorf("ezs agent rm requires one of --branch, --stack, --all\nFor help: ezs agent rm --help")
+	case 1:
+		// fall through
+	default:
+		return fmt.Errorf("filters %v are mutually exclusive — pick one", names)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	g := git.New(cwd)
+
+	mgr, err := stack.NewManager(cwd)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case *branchFilter:
+		return agentRmBranchScope(mgr, g)
+	case *stackFilter:
+		return agentRmStackScope(mgr)
+	case *allFilter:
+		return agentRmAllScope(mgr)
+	}
+	return nil // unreachable
+}
+
+// agentRmBranchScope clears the session bound to the current branch. We hard
+// fail when the branch isn't tracked or has no session — silent no-ops here
+// would leave the user wondering "did it work?" the same way a silent ls
+// would.
+func agentRmBranchScope(mgr *stack.Manager, g *git.Git) error {
+	branch, err := g.CurrentBranch()
+	if err != nil || branch == "" || branch == "HEAD" {
+		return fmt.Errorf("--branch needs a tracked current branch; HEAD is %q", branch)
+	}
+	if mgr.GetBranch(branch) == nil {
+		return fmt.Errorf("--branch: current branch %q is not tracked by ezstack", branch)
+	}
+	stored := lookupBranchSessionID(mgr.GetRepoDir(), branch)
+	if stored == "" {
+		return fmt.Errorf("no session is bound to branch %q", branch)
+	}
+	if err := mgr.SetBranchAgentSessionID(branch, "", ""); err != nil {
+		return fmt.Errorf("failed to clear branch session: %w", err)
+	}
+	ui.Success(fmt.Sprintf("Forgot session %s on branch %s", shortAgentSessionID(stored), branch))
+	return nil
+}
+
+// agentRmStackScope clears the session bound to the current stack. Same
+// hard-fail policy as the branch variant.
+func agentRmStackScope(mgr *stack.Manager) error {
+	s, _, err := mgr.GetCurrentStack()
+	if err != nil || s == nil {
+		return fmt.Errorf("--stack needs a current stack; %v", err)
+	}
+	if s.AgentSessionID == "" {
+		return fmt.Errorf("no session is bound to stack %s", s.DisplayName())
+	}
+	stored := s.AgentSessionID
+	if err := mgr.SetStackAgentSessionID(s.Hash, "", ""); err != nil {
+		return fmt.Errorf("failed to clear stack session: %w", err)
+	}
+	ui.Success(fmt.Sprintf("Forgot session %s on stack %s", shortAgentSessionID(stored), s.DisplayName()))
+	return nil
+}
+
+// agentRmAllScope clears every session binding in the current repo (stack
+// and branch). Confirmation gate runs unless ui.YesMode is set; the count
+// is included in the prompt so the user knows the blast radius before
+// agreeing.
+func agentRmAllScope(mgr *stack.Manager) error {
+	sc := mgr.GetStackConfig()
+	if sc == nil {
+		return fmt.Errorf("no stack config loaded for this repo")
+	}
+
+	// Snapshot the bindings we'd clear so we can both report a count up
+	// front and skip the save when there's nothing to do (write-skip
+	// avoids touching the config file's mtime for a no-op).
+	stackTargets := []string{}
+	for h, s := range sc.Stacks {
+		if s != nil && s.AgentSessionID != "" {
+			stackTargets = append(stackTargets, h)
+		}
+	}
+	branchTargets := []string{}
+	if sc.Cache != nil {
+		for name, bc := range sc.Cache.Branches {
+			if bc != nil && bc.AgentSessionID != "" {
+				branchTargets = append(branchTargets, name)
+			}
+		}
+	}
+	total := len(stackTargets) + len(branchTargets)
+	if total == 0 {
+		ui.Info("No sessions to forget in this repo.")
+		return nil
+	}
+
+	if !ui.ConfirmTUIWithDefault(
+		fmt.Sprintf("Forget %d AI session binding(s) in this repo?", total), false,
+	) {
+		ui.Warn("Cancelled")
+		return nil
+	}
+
+	for _, h := range stackTargets {
+		if err := mgr.SetStackAgentSessionID(h, "", ""); err != nil {
+			return fmt.Errorf("failed to clear stack %s: %w", h, err)
+		}
+	}
+	for _, name := range branchTargets {
+		if err := mgr.SetBranchAgentSessionID(name, "", ""); err != nil {
+			return fmt.Errorf("failed to clear branch %s: %w", name, err)
+		}
+	}
+
+	ui.Success(fmt.Sprintf("Forgot %d session binding(s) (%d stack, %d branch)",
+		total, len(stackTargets), len(branchTargets)))
+	return nil
+}

--- a/cmd/ezs/commands/agent_rm_test.go
+++ b/cmd/ezs/commands/agent_rm_test.go
@@ -1,0 +1,168 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+)
+
+// Tests for `ezs agent rm`. Each case sets up a minimal stack/branch
+// session binding via the manager API and then runs agentRm directly with
+// the relevant flags, asserting the right slot is cleared (or untouched)
+// and that the cli surface rejects ambiguous/empty flag combinations.
+
+func TestAgentRm_RequiresAFilter(t *testing.T) {
+	setupCLITestEnv(t)
+	// No --branch / --stack / --all is the only realistic typo that could
+	// silently wipe the wrong session if we picked a default. Reject it.
+	err := agentRm([]string{})
+	if err == nil || !strings.Contains(err.Error(), "requires one of --branch, --stack, --all") {
+		t.Errorf("expected guidance error, got %v", err)
+	}
+}
+
+func TestAgentRm_FiltersAreMutuallyExclusive(t *testing.T) {
+	setupCLITestEnv(t)
+	err := agentRm([]string{"--stack", "--all"})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutually-exclusive error, got %v", err)
+	}
+}
+
+func TestAgentRm_RejectsPositional(t *testing.T) {
+	setupCLITestEnv(t)
+	err := agentRm([]string{"--all", "extra"})
+	if err == nil || !strings.Contains(err.Error(), "positional") {
+		t.Errorf("expected positional rejection, got %v", err)
+	}
+}
+
+func TestAgentRm_StackScope_ClearsCurrentStack(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	// Register a real stack rooted at "feat" so GetCurrentStack resolves.
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	stk := mgr.GetStackForBranch("feat")
+	if stk == nil {
+		t.Fatal("stack not found after register")
+	}
+	if err := mgr.SetStackAgentSessionID(stk.Hash, "stale-uuid", config.AgentSessionWorkMode); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if err := agentRm([]string{"-s"}); err != nil {
+		t.Fatalf("agent rm -s: %v", err)
+	}
+
+	mgr2 := reloadManager(t, repoDir)
+	got := mgr2.GetStackConfig().Stacks[stk.Hash]
+	if got.AgentSessionID != "" {
+		t.Errorf("expected stack AgentSessionID cleared; got %q", got.AgentSessionID)
+	}
+	if got.AgentSessionMode != "" {
+		t.Errorf("expected stack AgentSessionMode cleared; got %q", got.AgentSessionMode)
+	}
+}
+
+func TestAgentRm_StackScope_ErrorsWhenNoSession(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// No session bound — rm should be loud, not a silent no-op.
+	err := agentRm([]string{"-s"})
+	if err == nil || !strings.Contains(err.Error(), "no session is bound to stack") {
+		t.Errorf("expected no-session error; got %v", err)
+	}
+}
+
+func TestAgentRm_BranchScope_ClearsCurrentBranch(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := mgr.SetBranchAgentSessionID("feat", "branch-uuid", config.AgentSessionWorkMode); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := agentRm([]string{"-b"}); err != nil {
+		t.Fatalf("agent rm -b: %v", err)
+	}
+
+	mgr2 := reloadManager(t, repoDir)
+	bc := mgr2.GetStackConfig().Cache.Branches["feat"]
+	if bc == nil {
+		t.Fatal("branch cache disappeared")
+	}
+	if bc.AgentSessionID != "" {
+		t.Errorf("expected branch AgentSessionID cleared; got %q", bc.AgentSessionID)
+	}
+}
+
+func TestAgentRm_BranchScope_ErrorsOnUntrackedBranch(t *testing.T) {
+	repoDir, _ := setupCLITestEnv(t)
+	// Stay on main, which is the base branch and not tracked as a stack
+	// member. agentRm -b should refuse.
+	mustGit(t, repoDir, "checkout", "main")
+	err := agentRm([]string{"-b"})
+	if err == nil || !strings.Contains(err.Error(), "not tracked") {
+		t.Errorf("expected not-tracked error; got %v", err)
+	}
+}
+
+func TestAgentRm_AllScope_ClearsEverything(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	// Two stacks + a branch session, all bound.
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register feat: %v", err)
+	}
+	mustGit(t, repoDir, "checkout", "-b", "other")
+	if _, err := mgr.RegisterExistingBranch("other", repoDir, "main"); err != nil {
+		t.Fatalf("register other: %v", err)
+	}
+	stk1 := mgr.GetStackForBranch("feat")
+	stk2 := mgr.GetStackForBranch("other")
+	if stk1 == nil || stk2 == nil {
+		t.Fatal("stacks not found")
+	}
+	if err := mgr.SetStackAgentSessionID(stk1.Hash, "uuid-stack-1", config.AgentSessionFeatureMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.SetStackAgentSessionID(stk2.Hash, "uuid-stack-2", config.AgentSessionWorkMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.SetBranchAgentSessionID("feat", "uuid-branch", config.AgentSessionWorkMode); err != nil {
+		t.Fatal(err)
+	}
+
+	// setupCLITestEnv enables ui.YesMode so the confirmation gate auto-ack.
+	if err := agentRm([]string{"--all"}); err != nil {
+		t.Fatalf("agent rm --all: %v", err)
+	}
+
+	mgr2 := reloadManager(t, repoDir)
+	for _, hash := range []string{stk1.Hash, stk2.Hash} {
+		s := mgr2.GetStackConfig().Stacks[hash]
+		if s.AgentSessionID != "" {
+			t.Errorf("stack %s still has AgentSessionID=%q", hash, s.AgentSessionID)
+		}
+	}
+	if bc := mgr2.GetStackConfig().Cache.Branches["feat"]; bc != nil && bc.AgentSessionID != "" {
+		t.Errorf("branch session still set: %q", bc.AgentSessionID)
+	}
+}
+
+func TestAgentRm_AllScope_NoBindingsIsClean(t *testing.T) {
+	setupCLITestEnv(t)
+	// No sessions bound anywhere — rm --all should succeed without
+	// touching the config and without error.
+	if err := agentRm([]string{"--all"}); err != nil {
+		t.Errorf("expected clean exit when nothing to forget; got %v", err)
+	}
+}

--- a/cmd/ezs/commands/agent_rm_test.go
+++ b/cmd/ezs/commands/agent_rm_test.go
@@ -115,6 +115,26 @@ func TestAgentRm_BranchScope_ErrorsOnUntrackedBranch(t *testing.T) {
 	}
 }
 
+// TestAgentRm_BranchScope_ErrorsWhenNoSession pins the branch-scope variant of
+// the empty-slot guard exercised for stacks in
+// TestAgentRm_StackScope_ErrorsWhenNoSession. A tracked branch with no bound
+// session must hard-fail rather than silently no-op — the user passed
+// --branch expecting *some* effect, and a quiet success would leave them
+// wondering whether anything happened.
+func TestAgentRm_BranchScope_ErrorsWhenNoSession(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// Tracked but never had a session bound — rm should be loud, not a
+	// silent no-op.
+	err := agentRm([]string{"-b"})
+	if err == nil || !strings.Contains(err.Error(), "no session is bound to branch") {
+		t.Errorf("expected no-session error; got %v", err)
+	}
+}
+
 func TestAgentRm_AllScope_ClearsEverything(t *testing.T) {
 	repoDir, mgr := setupCLITestEnv(t)
 	// Two stacks + a branch session, all bound.

--- a/cmd/ezs/commands/agent_session.go
+++ b/cmd/ezs/commands/agent_session.go
@@ -516,20 +516,11 @@ func adoptActiveAgentSession(repoPath, stackHash string) {
 	}
 	if err := persistStackSessionID(repoPath, stackHash, sessionID, config.AgentSessionFeatureMode); err != nil {
 		ui.Warn(fmt.Sprintf("Could not bind active feature session %s to stack %s: %v",
-			shortAgentSessionID(sessionID), stackHash, err))
+			shortSessionID(sessionID), stackHash, err))
 		return
 	}
 	ui.Info(fmt.Sprintf("Bound active feature session %s to new stack %s",
-		shortAgentSessionID(sessionID), stackHash))
-}
-
-// shortAgentSessionID truncates a UUID to its first 8 chars for log lines.
-// Mirrors the format used by `ezs agent ls`.
-func shortAgentSessionID(id string) string {
-	if len(id) <= 8 {
-		return id
-	}
-	return id[:8]
+		shortSessionID(sessionID), stackHash))
 }
 
 // adoptActiveAgentSessionForBranch is a convenience wrapper for callers that

--- a/cmd/ezs/commands/agent_session.go
+++ b/cmd/ezs/commands/agent_session.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
 	"github.com/KulkarniKaustubh/ezstack/v4/internal/stack"
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/ui"
 	"github.com/google/uuid"
 )
 
@@ -169,6 +171,14 @@ type agentSessionInjection struct {
 	SessionID string
 	// Fresh is true if a brand-new session ID was minted (vs reusing one).
 	Fresh bool
+	// Mode is the launch mode (config.AgentSessionWorkMode or
+	// config.AgentSessionFeatureMode). Exposed to the spawned agent via
+	// EZS_AGENT_SESSION_MODE so that nested `ezs new` calls (CLI or MCP) can
+	// decide whether to adopt the active session onto a freshly-created stack.
+	// Adoption only fires for feature mode — work-mode sessions are scoped to
+	// the stack they were launched in and shouldn't follow the agent into
+	// unrelated stacks it spins up later.
+	Mode string
 }
 
 // buildAgentSessionArgs computes the session-related argv (if any) to inject
@@ -188,7 +198,7 @@ type agentSessionInjection struct {
 // For claude-family agents the flags are injected into argv. For other
 // agents Args is empty (we don't risk misparsing flags whose schema we
 // don't know); the session ID still flows through via the env var.
-func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bool) agentSessionInjection {
+func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bool, mode string) agentSessionInjection {
 	isClaude := isClaudeFamily(agentCmd)
 	resuming := storedID != "" && !forceFresh
 
@@ -201,6 +211,7 @@ func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bo
 				IncludePrompt: false,
 				SessionID:     storedID,
 				Fresh:         false,
+				Mode:          mode,
 			}
 		}
 		// Non-claude resume: no CLI args (we don't know the agent's resume
@@ -211,6 +222,7 @@ func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bo
 			IncludePrompt: true,
 			SessionID:     storedID,
 			Fresh:         false,
+			Mode:          mode,
 		}
 	}
 
@@ -221,6 +233,7 @@ func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bo
 			IncludePrompt: true,
 			SessionID:     id,
 			Fresh:         true,
+			Mode:          mode,
 		}
 	}
 	return agentSessionInjection{
@@ -228,6 +241,7 @@ func buildAgentSessionArgs(agentCmd, storedID, displayName string, forceFresh bo
 		IncludePrompt: true,
 		SessionID:     id,
 		Fresh:         true,
+		Mode:          mode,
 	}
 }
 
@@ -289,7 +303,7 @@ func resolveWorkSession(repoPath, agentCmd string, targetStack *config.Stack, br
 			}
 		}
 		label := preferLiveAgentName(stored, forceFresh, sessionDisplayName(branchName, scopeBranch))
-		inj := buildAgentSessionArgs(agentCmd, stored, label, forceFresh)
+		inj := buildAgentSessionArgs(agentCmd, stored, label, forceFresh, config.AgentSessionWorkMode)
 		return &agentSessionPlan{
 			injection: &inj,
 			persist: func(id string) error {
@@ -313,7 +327,7 @@ func resolveWorkSession(repoPath, agentCmd string, targetStack *config.Stack, br
 		}
 	}
 	label := preferLiveAgentName(stored, forceFresh, sessionDisplayName(identifier, scopeStack))
-	inj := buildAgentSessionArgs(agentCmd, stored, label, forceFresh)
+	inj := buildAgentSessionArgs(agentCmd, stored, label, forceFresh, config.AgentSessionWorkMode)
 	return &agentSessionPlan{
 		injection: &inj,
 		persist: func(id string) error {
@@ -353,7 +367,7 @@ func resolveFeatureSession(repoPath, agentCmd string, existingStack *config.Stac
 		// uniqueness suffix on the display label.
 		id := newSessionID()
 		label := sessionDisplayName("feature-"+oneShotFeatureLabel(description, id), scopeStack)
-		inj := buildAgentSessionArgsWithID(agentCmd, label, id)
+		inj := buildAgentSessionArgsWithID(agentCmd, label, id, config.AgentSessionFeatureMode)
 		return &agentSessionPlan{injection: &inj, persist: func(string) error { return nil }}
 	}
 	identifier := existingStack.Name
@@ -361,7 +375,7 @@ func resolveFeatureSession(repoPath, agentCmd string, existingStack *config.Stac
 		identifier = existingStack.Hash
 	}
 	label := preferLiveAgentName(existingStack.AgentSessionID, forceFresh, sessionDisplayName("feature-"+identifier, scopeStack))
-	inj := buildAgentSessionArgs(agentCmd, existingStack.AgentSessionID, label, forceFresh)
+	inj := buildAgentSessionArgs(agentCmd, existingStack.AgentSessionID, label, forceFresh, config.AgentSessionFeatureMode)
 	hash := existingStack.Hash
 	return &agentSessionPlan{
 		injection: &inj,
@@ -413,13 +427,14 @@ func oneShotFeatureLabel(description, sessionID string) string {
 // that have already minted the UUID externally (so it can flow into the
 // display label before the injection plan is built). Always treated as a
 // fresh session — there is no stored ID to resume from.
-func buildAgentSessionArgsWithID(agentCmd, displayName, sessionID string) agentSessionInjection {
+func buildAgentSessionArgsWithID(agentCmd, displayName, sessionID, mode string) agentSessionInjection {
 	if isClaudeFamily(agentCmd) {
 		return agentSessionInjection{
 			Args:          []string{"--session-id", sessionID, "--name", displayName},
 			IncludePrompt: true,
 			SessionID:     sessionID,
 			Fresh:         true,
+			Mode:          mode,
 		}
 	}
 	return agentSessionInjection{
@@ -427,6 +442,7 @@ func buildAgentSessionArgsWithID(agentCmd, displayName, sessionID string) agentS
 		IncludePrompt: true,
 		SessionID:     sessionID,
 		Fresh:         true,
+		Mode:          mode,
 	}
 }
 
@@ -460,6 +476,78 @@ func persistStackSessionID(repoPath, stackHash, sessionID, mode string) error {
 		return err
 	}
 	return mgr.SetStackAgentSessionID(stackHash, sessionID, mode)
+}
+
+// adoptActiveAgentSession binds the EZS_AGENT_SESSION_ID env var (set on the
+// agent process by `ezs agent feature`) onto a freshly-created stack, tagged
+// as feature mode. Called by every `ezs new` codepath right after a new
+// stack is registered, so an agent that creates its first stack mid-feature
+// gets the dangling session UUID stitched onto the new stack — without this,
+// `ezs agent ls` would show nothing for the new stack and a follow-up
+// `ezs agent` inside it would mint a fresh session instead of resuming.
+//
+// Adoption is gated on EZS_AGENT_SESSION_MODE == feature. Work-mode sessions
+// are scoped to the stack they were launched in and would only confuse
+// users if they silently followed the agent into an unrelated new stack.
+// When the mode env is unset (e.g. a session launched by an older ezs
+// before mode tracking, or `ezs new` invoked from a plain shell), this is a
+// no-op — preserving the prior "no adoption" behavior.
+//
+// Re-bind semantics: if the same feature session creates multiple stacks,
+// every new stack gets the same UUID written onto it. claude keys resume by
+// UUID (not by stack), so resuming via either stack lands in the same
+// conversation; `ezs agent ls` will show one row per stack with the same
+// short ID, which truthfully reflects "one session, multiple stacks."
+//
+// Failures persist as a warning, not an error: the stack creation already
+// mutated git state and the user can recover by passing --session-id or
+// --resume manually. We do not want a best-effort bookkeeping failure to
+// fail the whole `ezs new` after the worktree is already on disk.
+func adoptActiveAgentSession(repoPath, stackHash string) {
+	if stackHash == "" {
+		return
+	}
+	sessionID := os.Getenv(agentSessionIDEnv)
+	if sessionID == "" {
+		return
+	}
+	if os.Getenv(agentSessionModeEnv) != config.AgentSessionFeatureMode {
+		return
+	}
+	if err := persistStackSessionID(repoPath, stackHash, sessionID, config.AgentSessionFeatureMode); err != nil {
+		ui.Warn(fmt.Sprintf("Could not bind active feature session %s to stack %s: %v",
+			shortAgentSessionID(sessionID), stackHash, err))
+		return
+	}
+	ui.Info(fmt.Sprintf("Bound active feature session %s to new stack %s",
+		shortAgentSessionID(sessionID), stackHash))
+}
+
+// shortAgentSessionID truncates a UUID to its first 8 chars for log lines.
+// Mirrors the format used by `ezs agent ls`.
+func shortAgentSessionID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
+
+// adoptActiveAgentSessionForBranch is a convenience wrapper for callers that
+// have a branch name but not the new stack's hash yet — it asks the manager
+// for the stack containing branchName and forwards to adoptActiveAgentSession.
+// Used by `ezs new` codepaths where stack creation only returns the branch.
+//
+// The lookup is done lazily here (and not at every `ezs new` site) so paths
+// that don't end up creating a new stack don't pay the cost.
+func adoptActiveAgentSessionForBranch(mgr *stack.Manager, branchName string) {
+	if mgr == nil || branchName == "" {
+		return
+	}
+	s := mgr.GetStackForBranch(branchName)
+	if s == nil {
+		return
+	}
+	adoptActiveAgentSession(mgr.GetRepoDir(), s.Hash)
 }
 
 // sessionLogSuffix returns a short " (resumed: <id>)" or " (fresh session: <id>)"

--- a/cmd/ezs/commands/agent_session_adopt_test.go
+++ b/cmd/ezs/commands/agent_session_adopt_test.go
@@ -240,3 +240,53 @@ func TestAdoptActiveAgentSessionForBranch_UntrackedBranchIsNoOp(t *testing.T) {
 	// return cleanly without writing anything.
 	adoptActiveAgentSessionForBranch(mgr, "ghost-branch")
 }
+
+// TestAdoptActiveAgentSession_SurvivesSubsequentMgrSave pins the ordering
+// requirement in new.go: a same-process Save on `mgr` after adoption (e.g.
+// the user accepting promptStackName with a non-empty value) must not
+// overwrite the freshly-adopted session ID.
+//
+// Adoption persists via a fresh stack.Manager, which means the *original*
+// mgr that called the adoption helper does not see the write. If new.go
+// then runs `mgr.SetStackName` (or any other mgr-mediated mutation), mgr's
+// Save 3-way-merges against a stale origSnapshot — modify-vs-modify on the
+// same stack value, last-writer-wins, mine has session="". Net effect: the
+// session ID disappears silently, breaking the headline `ezs new` flow.
+//
+// new.go avoids this by running promptStackName BEFORE adoption (so the
+// only Save that sees a stale snapshot is the harmless one with no
+// concurrent peer); this test pins that contract by exercising the
+// adopt-first-then-save shape and asserting the session survives.
+//
+// If this test fails, check the call order at every adopt site in new.go:
+// adoption must come AFTER any other mgr.Save you intend to run for the
+// same stack, not before.
+func TestAdoptActiveAgentSession_SurvivesSubsequentMgrSave(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	mustGit(t, repoDir, "checkout", "-b", "feat")
+	if _, err := mgr.RegisterExistingBranch("feat", repoDir, "main"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	hash := mgr.GetStackForBranch("feat").Hash
+
+	t.Setenv(agentSessionIDEnv, "feature-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	// Mirror new.go's required order: rename first (mgr's only Save), then
+	// adopt (fresh-manager write).
+	if err := mgr.SetStackName(hash, "my-feature"); err != nil {
+		t.Fatalf("SetStackName: %v", err)
+	}
+	adoptActiveAgentSessionForBranch(mgr, "feat")
+
+	got := reloadManager(t, repoDir).GetStackConfig().Stacks[hash]
+	if got.AgentSessionID != "feature-uuid" {
+		t.Errorf("AgentSessionID = %q, want feature-uuid", got.AgentSessionID)
+	}
+	if got.Name != "my-feature" {
+		t.Errorf("Name = %q, want my-feature", got.Name)
+	}
+	if got.AgentSessionMode != config.AgentSessionFeatureMode {
+		t.Errorf("AgentSessionMode = %q, want %q", got.AgentSessionMode, config.AgentSessionFeatureMode)
+	}
+}

--- a/cmd/ezs/commands/agent_session_adopt_test.go
+++ b/cmd/ezs/commands/agent_session_adopt_test.go
@@ -1,0 +1,242 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/KulkarniKaustubh/ezstack/v4/internal/config"
+)
+
+// Tests for adoptActiveAgentSession / adoptActiveAgentSessionForBranch.
+//
+// The adoption helper exists so a feature session launched via
+// `ezs agent feature "..."` (which mints a UUID but has no stack to bind to
+// at launch time) can be stitched onto a stack the agent creates mid-flight
+// via `ezs new` or `mcp__ezstack__ezstack_new`. Without this, `ezs agent ls`
+// would show no row for the new stack and a follow-up `ezs agent` inside it
+// would mint a fresh session instead of resuming the agent's conversation.
+//
+// Adoption is gated on EZS_AGENT_SESSION_MODE=feature so work-mode sessions
+// don't silently follow the agent into unrelated stacks the user didn't ask
+// to bind. The cases below pin those rules in place.
+
+// seedStack inserts a bare Stack into the manager's in-memory config (no
+// branches or worktrees) and persists. Side-steps RegisterExistingBranch so
+// these tests don't need real git branches — adoption only touches the
+// AgentSessionID/Mode slot, which is independent of the tree.
+func seedStack(t *testing.T, mgr managerLike, hash, name string) {
+	t.Helper()
+	sc := mgr.GetStackConfig()
+	sc.Stacks[hash] = &config.Stack{Hash: hash, Name: name, Root: "main"}
+	if err := sc.Save(mgr.GetRepoDir()); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+}
+
+// managerLike is the subset of *stack.Manager the seed helper needs. Defined
+// here to keep the helper's signature short and to avoid pulling internal/stack
+// into test-only typing concerns.
+type managerLike interface {
+	GetStackConfig() *config.StackConfig
+	GetRepoDir() string
+}
+
+func TestAdoptActiveAgentSession_NoEnvVarIsNoOp(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "abc1234", "feature-stack")
+
+	// EZS_AGENT_SESSION_ID is unset (no active feature session in flight).
+	// adoptActiveAgentSession must leave the stack's AgentSessionID empty,
+	// preserving the long-standing "ezs new from a plain shell doesn't
+	// touch session bookkeeping" behavior.
+	t.Setenv(agentSessionIDEnv, "")
+	t.Setenv(agentSessionModeEnv, "")
+
+	adoptActiveAgentSession(repoDir, "abc1234")
+
+	mgr2 := reloadManager(t, repoDir)
+	if got := mgr2.GetStackConfig().Stacks["abc1234"].AgentSessionID; got != "" {
+		t.Errorf("stack adopted a session despite no env var; AgentSessionID=%q", got)
+	}
+}
+
+func TestAdoptActiveAgentSession_NoModeEnvIsNoOp(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "def5678", "")
+
+	// ID present, mode absent — happens for sessions launched by an older
+	// ezs binary (before mode propagation existed) that the user hasn't
+	// re-launched yet. We deliberately don't adopt: we don't know whether
+	// the inherited session is feature or work mode, and silently picking
+	// one risks mistagging.
+	t.Setenv(agentSessionIDEnv, "deadbeef-uuid")
+	t.Setenv(agentSessionModeEnv, "")
+
+	adoptActiveAgentSession(repoDir, "def5678")
+
+	mgr2 := reloadManager(t, repoDir)
+	if got := mgr2.GetStackConfig().Stacks["def5678"].AgentSessionID; got != "" {
+		t.Errorf("adopted with no mode tag — should be a no-op; AgentSessionID=%q", got)
+	}
+}
+
+func TestAdoptActiveAgentSession_WorkModeIsNoOp(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "1111111", "")
+
+	// Work-mode sessions are scoped to the stack they were launched in.
+	// If the agent (running inside that work session) creates a new stack,
+	// auto-binding the work session to the new stack would surprise the
+	// user — they'd see two unrelated stacks pointing at the same UUID
+	// with no clear reason. Stay out of work-mode adoption.
+	t.Setenv(agentSessionIDEnv, "work-session-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionWorkMode)
+
+	adoptActiveAgentSession(repoDir, "1111111")
+
+	mgr2 := reloadManager(t, repoDir)
+	if got := mgr2.GetStackConfig().Stacks["1111111"].AgentSessionID; got != "" {
+		t.Errorf("work-mode session must not adopt; AgentSessionID=%q", got)
+	}
+}
+
+func TestAdoptActiveAgentSession_FeatureModeAdopts(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "feabc01", "my-feature")
+
+	// The headline case: `ezs agent feature` minted UUID `S`, the agent
+	// (running in feature mode) called `ezs new` which created stack
+	// `feabc01`. Adoption should bind `S` to `feabc01` tagged feature mode
+	// so `ezs agent ls` surfaces the row and `ezs agent -s feabc01`
+	// resumes the conversation.
+	t.Setenv(agentSessionIDEnv, "feature-session-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	adoptActiveAgentSession(repoDir, "feabc01")
+
+	mgr2 := reloadManager(t, repoDir)
+	s := mgr2.GetStackConfig().Stacks["feabc01"]
+	if s.AgentSessionID != "feature-session-uuid" {
+		t.Errorf("AgentSessionID = %q, want feature-session-uuid", s.AgentSessionID)
+	}
+	if s.AgentSessionMode != config.AgentSessionFeatureMode {
+		t.Errorf("AgentSessionMode = %q, want %q", s.AgentSessionMode, config.AgentSessionFeatureMode)
+	}
+}
+
+func TestAdoptActiveAgentSession_RebindsAcrossMultipleStacks(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "stack-a", "feature-a")
+	seedStack(t, mgr, "stack-b", "feature-b")
+
+	// One feature session, two stacks created in a row. The session UUID
+	// should land on both stacks — claude resumes by UUID (not by stack),
+	// so every stack the session created should be a valid resume target.
+	// `ezs agent ls` will surface one row per stack with the same short
+	// ID, which truthfully reflects "one session, multiple stacks."
+	t.Setenv(agentSessionIDEnv, "shared-feature-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	adoptActiveAgentSession(repoDir, "stack-a")
+	adoptActiveAgentSession(repoDir, "stack-b")
+
+	mgr2 := reloadManager(t, repoDir)
+	for _, hash := range []string{"stack-a", "stack-b"} {
+		s := mgr2.GetStackConfig().Stacks[hash]
+		if s.AgentSessionID != "shared-feature-uuid" {
+			t.Errorf("stack %s AgentSessionID = %q, want shared-feature-uuid", hash, s.AgentSessionID)
+		}
+		if s.AgentSessionMode != config.AgentSessionFeatureMode {
+			t.Errorf("stack %s AgentSessionMode = %q, want %q", hash, s.AgentSessionMode, config.AgentSessionFeatureMode)
+		}
+	}
+}
+
+func TestAdoptActiveAgentSession_OverwritesExistingSlot(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	seedStack(t, mgr, "preowned", "")
+	// Pre-populate with a stale work-mode session (e.g. a stack the user
+	// previously ran `ezs agent` in). When a feature session creates a new
+	// stack and we adopt onto it, last-write-wins is the existing slot
+	// semantic (documented in resolveFeatureSession's comment about
+	// stack/feature sharing the same AgentSessionID slot).
+	if err := mgr.SetStackAgentSessionID("preowned", "stale-work-uuid", config.AgentSessionWorkMode); err != nil {
+		t.Fatalf("seed work session: %v", err)
+	}
+
+	t.Setenv(agentSessionIDEnv, "fresh-feature-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	adoptActiveAgentSession(repoDir, "preowned")
+
+	mgr2 := reloadManager(t, repoDir)
+	s := mgr2.GetStackConfig().Stacks["preowned"]
+	if s.AgentSessionID != "fresh-feature-uuid" {
+		t.Errorf("AgentSessionID = %q, want fresh-feature-uuid (overwrite)", s.AgentSessionID)
+	}
+	if s.AgentSessionMode != config.AgentSessionFeatureMode {
+		t.Errorf("AgentSessionMode = %q, want %q (mode tag updated to match new ID)", s.AgentSessionMode, config.AgentSessionFeatureMode)
+	}
+}
+
+func TestAdoptActiveAgentSession_EmptyStackHashIsNoOp(t *testing.T) {
+	repoDir, _ := setupCLITestEnv(t)
+	t.Setenv(agentSessionIDEnv, "uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	// Defensive: a caller with no stack hash to bind shouldn't trigger
+	// any persistence (and shouldn't crash).
+	adoptActiveAgentSession(repoDir, "")
+}
+
+func TestAdoptActiveAgentSession_UnknownStackHashIsBestEffort(t *testing.T) {
+	repoDir, _ := setupCLITestEnv(t)
+	t.Setenv(agentSessionIDEnv, "uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	// Hash doesn't exist in config — the underlying SetStackAgentSessionID
+	// returns "stack not found", but adoption is best-effort: it should
+	// log and return, not panic or surface an error to the caller (the
+	// stack creation that called it has already mutated git state).
+	adoptActiveAgentSession(repoDir, "missinghash")
+}
+
+func TestAdoptActiveAgentSessionForBranch_LooksUpStack(t *testing.T) {
+	repoDir, mgr := setupCLITestEnv(t)
+	// Use the manager API end-to-end: register a real worktree-rooted
+	// branch so GetStackForBranch resolves correctly.
+	mustGit(t, repoDir, "checkout", "-b", "child")
+	mustGit(t, repoDir, "checkout", "main")
+	if _, err := mgr.RegisterExistingBranch("child", repoDir, "main"); err != nil {
+		t.Fatalf("register branch: %v", err)
+	}
+
+	t.Setenv(agentSessionIDEnv, "branch-feature-uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	mgr2 := reloadManager(t, repoDir)
+	adoptActiveAgentSessionForBranch(mgr2, "child")
+
+	mgr3 := reloadManager(t, repoDir)
+	s := mgr3.GetStackForBranch("child")
+	if s == nil {
+		t.Fatal("branch lost its stack registration")
+	}
+	if s.AgentSessionID != "branch-feature-uuid" {
+		t.Errorf("AgentSessionID = %q, want branch-feature-uuid", s.AgentSessionID)
+	}
+	if s.AgentSessionMode != config.AgentSessionFeatureMode {
+		t.Errorf("AgentSessionMode = %q, want %q", s.AgentSessionMode, config.AgentSessionFeatureMode)
+	}
+}
+
+func TestAdoptActiveAgentSessionForBranch_UntrackedBranchIsNoOp(t *testing.T) {
+	repoDir, _ := setupCLITestEnv(t)
+
+	t.Setenv(agentSessionIDEnv, "uuid")
+	t.Setenv(agentSessionModeEnv, config.AgentSessionFeatureMode)
+
+	mgr := reloadManager(t, repoDir)
+	// Branch has never been registered — no stack to bind to. Helper must
+	// return cleanly without writing anything.
+	adoptActiveAgentSessionForBranch(mgr, "ghost-branch")
+}

--- a/cmd/ezs/commands/agent_session_test.go
+++ b/cmd/ezs/commands/agent_session_test.go
@@ -131,7 +131,7 @@ func TestResolveFeatureSession_OneShotLabelEmbedsDescription(t *testing.T) {
 func TestBuildAgentSessionArgs_ClaudeFreshWhenNoStored(t *testing.T) {
 	withStubSessionID(t, "stub-uuid-1")
 
-	inj := buildAgentSessionArgs("claude", "", "_ezstack-foo", false)
+	inj := buildAgentSessionArgs("claude", "", "_ezstack-foo", false, config.AgentSessionWorkMode)
 
 	if !inj.Fresh {
 		t.Error("expected Fresh=true when no stored session ID")
@@ -151,7 +151,7 @@ func TestBuildAgentSessionArgs_ClaudeFreshWhenNoStored(t *testing.T) {
 func TestBuildAgentSessionArgs_ClaudeResumeWhenStored(t *testing.T) {
 	withStubSessionID(t, "should-not-be-used")
 
-	inj := buildAgentSessionArgs("claude", "existing-id", "_ezstack-bar", false)
+	inj := buildAgentSessionArgs("claude", "existing-id", "_ezstack-bar", false, config.AgentSessionWorkMode)
 
 	if inj.Fresh {
 		t.Error("expected Fresh=false when reusing stored session")
@@ -171,7 +171,7 @@ func TestBuildAgentSessionArgs_ClaudeResumeWhenStored(t *testing.T) {
 func TestBuildAgentSessionArgs_ClaudeForceFreshIgnoresStored(t *testing.T) {
 	withStubSessionID(t, "fresh-uuid")
 
-	inj := buildAgentSessionArgs("claude", "existing-id", "_ezstack-baz", true)
+	inj := buildAgentSessionArgs("claude", "existing-id", "_ezstack-baz", true, config.AgentSessionWorkMode)
 
 	if !inj.Fresh {
 		t.Error("--no-resume must override a stored session ID")
@@ -194,7 +194,7 @@ func TestBuildAgentSessionArgs_ClaudeForceFreshIgnoresStored(t *testing.T) {
 func TestBuildAgentSessionArgs_NonClaudeFreshOmitsArgs(t *testing.T) {
 	withStubSessionID(t, "uuid-non-claude-fresh")
 
-	inj := buildAgentSessionArgs("aider --model gpt-4", "", "_ezstack-foo", false)
+	inj := buildAgentSessionArgs("aider --model gpt-4", "", "_ezstack-foo", false, config.AgentSessionWorkMode)
 
 	if !inj.Fresh {
 		t.Error("expected Fresh=true with no stored ID")
@@ -213,7 +213,7 @@ func TestBuildAgentSessionArgs_NonClaudeFreshOmitsArgs(t *testing.T) {
 func TestBuildAgentSessionArgs_NonClaudeResumeOmitsArgs(t *testing.T) {
 	withStubSessionID(t, "should-not-be-used")
 
-	inj := buildAgentSessionArgs("aider", "stored-id", "_ezstack-bar", false)
+	inj := buildAgentSessionArgs("aider", "stored-id", "_ezstack-bar", false, config.AgentSessionWorkMode)
 
 	if inj.Fresh {
 		t.Error("expected Fresh=false when reusing stored ID")
@@ -232,7 +232,7 @@ func TestBuildAgentSessionArgs_NonClaudeResumeOmitsArgs(t *testing.T) {
 func TestBuildAgentSessionArgs_NonClaudeForceFreshMintsNew(t *testing.T) {
 	withStubSessionID(t, "minted-fresh")
 
-	inj := buildAgentSessionArgs("cursor", "stored-id", "_ezstack-baz", true)
+	inj := buildAgentSessionArgs("cursor", "stored-id", "_ezstack-baz", true, config.AgentSessionWorkMode)
 
 	if !inj.Fresh {
 		t.Error("--no-resume must mint a new ID for non-claude too")
@@ -439,11 +439,15 @@ func TestSplitAgentExtras(t *testing.T) {
 func TestAgentProcessEnv_InjectsSessionID(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
 
-	got := agentProcessEnv(parent, false, "abc-123")
+	got := agentProcessEnv(parent, false, "abc-123", config.AgentSessionFeatureMode)
 
 	wantPair := agentSessionIDEnv + "=abc-123"
 	if !containsString(got, wantPair) {
 		t.Errorf("agent env missing %s; got %v", wantPair, got)
+	}
+	wantMode := agentSessionModeEnv + "=" + config.AgentSessionFeatureMode
+	if !containsString(got, wantMode) {
+		t.Errorf("agent env missing %s; got %v", wantMode, got)
 	}
 }
 
@@ -451,13 +455,17 @@ func TestAgentProcessEnv_StripsInheritedSessionWhenEmpty(t *testing.T) {
 	parent := []string{
 		"PATH=/usr/bin",
 		agentSessionIDEnv + "=stale-id-from-outer-agent",
+		agentSessionModeEnv + "=feature",
 	}
 
-	got := agentProcessEnv(parent, false, "")
+	got := agentProcessEnv(parent, false, "", "")
 
 	for _, kv := range got {
 		if strings.HasPrefix(kv, agentSessionIDEnv+"=") {
 			t.Errorf("expected stale %s to be stripped when sessionID is empty; got %v", agentSessionIDEnv, got)
+		}
+		if strings.HasPrefix(kv, agentSessionModeEnv+"=") {
+			t.Errorf("expected stale %s to be stripped when sessionID is empty; got %v", agentSessionModeEnv, got)
 		}
 	}
 }
@@ -466,11 +474,13 @@ func TestAgentProcessEnv_DeduplicatesSessionID(t *testing.T) {
 	parent := []string{
 		"PATH=/usr/bin",
 		agentSessionIDEnv + "=stale",
+		agentSessionModeEnv + "=work",
 	}
 
-	got := agentProcessEnv(parent, false, "fresh")
+	got := agentProcessEnv(parent, false, "fresh", config.AgentSessionFeatureMode)
 
 	count := 0
+	modeCount := 0
 	for _, kv := range got {
 		if strings.HasPrefix(kv, agentSessionIDEnv+"=") {
 			count++
@@ -478,9 +488,18 @@ func TestAgentProcessEnv_DeduplicatesSessionID(t *testing.T) {
 				t.Errorf("expected session ID = fresh, got %q", kv)
 			}
 		}
+		if strings.HasPrefix(kv, agentSessionModeEnv+"=") {
+			modeCount++
+			if kv != agentSessionModeEnv+"="+config.AgentSessionFeatureMode {
+				t.Errorf("expected mode = %s, got %q", config.AgentSessionFeatureMode, kv)
+			}
+		}
 	}
 	if count != 1 {
 		t.Errorf("expected exactly one %s entry, got %d", agentSessionIDEnv, count)
+	}
+	if modeCount != 1 {
+		t.Errorf("expected exactly one %s entry, got %d", agentSessionModeEnv, modeCount)
 	}
 }
 

--- a/cmd/ezs/commands/agent_test.go
+++ b/cmd/ezs/commands/agent_test.go
@@ -683,8 +683,15 @@ func TestBuildRenderedFeaturePrompt(t *testing.T) {
 	if !strings.Contains(prompt, "≤5 words") {
 		t.Error("feature prompt should pin the stack-name length budget at ≤5 words")
 	}
-	if !strings.Contains(prompt, "FIRST branch") {
+	if !strings.Contains(prompt, "FIRST BRANCH ONLY") {
 		t.Error("feature prompt should specify the rename happens after the first branch")
+	}
+	// The rename instruction must explicitly tie the chosen name to the
+	// FEATURE_DESCRIPTION (not generic "pick a label"). Without this anchor
+	// the agent often picks a name based on whatever the first branch
+	// happens to be, which doesn't reflect the broader feature.
+	if !strings.Contains(prompt, "derived from the FEATURE_DESCRIPTION") {
+		t.Error("feature prompt should anchor the stack name to FEATURE_DESCRIPTION")
 	}
 }
 

--- a/cmd/ezs/commands/new.go
+++ b/cmd/ezs/commands/new.go
@@ -163,10 +163,15 @@ func New(args []string) error {
 			return err
 		}
 
-		adoptActiveAgentSessionForBranch(mgr, branch.Name)
-
-		// Prompt for stack name
+		// Prompt for the stack name first so the user-typed name lands on
+		// `mgr` while its origSnapshot is still consistent with disk. Only
+		// then run adoption — adoption writes via a fresh manager, and if
+		// it ran first, the subsequent SetStackName save would 3-way-merge
+		// against a stale snapshot and silently overwrite the session ID
+		// (modify-vs-modify, mine wins, mine has session=""). See the
+		// regression test in agent_session_adopt_test.go.
 		promptStackName(mgr, branch.Name)
+		adoptActiveAgentSessionForBranch(mgr, branch.Name)
 
 		gh, ghErr := newGitHubClient(g)
 		if ghErr == nil {
@@ -250,14 +255,17 @@ func New(args []string) error {
 			return fmt.Errorf("failed to add branch to stack: %w", err)
 		}
 
+		// Prompt for stack name first so the user-typed name lands on `mgr`
+		// while its origSnapshot is still consistent with disk; adoption
+		// (fresh manager) then writes the session ID without a merge
+		// conflict on the same stack value. See agent_session_adopt_test.go.
+		promptStackName(mgr, userBranch.Name)
+
 		// remote.StackHash refers to the stack created by RegisterRemoteBranch
 		// inside selectAndRegisterRemoteBranch — it's always a fresh stack
 		// when this branch executes, so an active feature session should
 		// adopt it directly.
 		adoptActiveAgentSession(mgr.GetRepoDir(), remote.StackHash)
-
-		// Prompt for stack name (new stack was just created)
-		promptStackName(mgr, userBranch.Name)
 
 		if remote.PRNumber > 0 {
 			ui.Success(fmt.Sprintf("Created stack from PR #%d (%s)", remote.PRNumber, remote.Branch))
@@ -382,8 +390,12 @@ func New(args []string) error {
 		ui.Success(fmt.Sprintf("Created branch '%s' with worktree at '%s'", branch.Name, branch.WorktreePath))
 
 		if isNewStack {
-			adoptActiveAgentSessionForBranch(mgr, branch.Name)
+			// promptStackName must precede adoption: the rename writes via
+			// `mgr` while adoption writes via a fresh manager, and the
+			// reverse order leaves `mgr` with a stale snapshot whose Save
+			// silently overwrites the just-adopted session ID.
 			promptStackName(mgr, branch.Name)
+			adoptActiveAgentSessionForBranch(mgr, branch.Name)
 		}
 
 		if getCdAfterNew(cfg, repoDir, *cdFlag, *noCdFlag) {
@@ -408,8 +420,9 @@ func New(args []string) error {
 		ui.Success(fmt.Sprintf("Created branch '%s'", branch.Name))
 
 		if isNewStack {
-			adoptActiveAgentSessionForBranch(mgr, branch.Name)
+			// See worktree branch above for ordering rationale.
 			promptStackName(mgr, branch.Name)
+			adoptActiveAgentSessionForBranch(mgr, branch.Name)
 		}
 
 		// Switch to the new branch

--- a/cmd/ezs/commands/new.go
+++ b/cmd/ezs/commands/new.go
@@ -163,6 +163,8 @@ func New(args []string) error {
 			return err
 		}
 
+		adoptActiveAgentSessionForBranch(mgr, branch.Name)
+
 		// Prompt for stack name
 		promptStackName(mgr, branch.Name)
 
@@ -247,6 +249,12 @@ func New(args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to add branch to stack: %w", err)
 		}
+
+		// remote.StackHash refers to the stack created by RegisterRemoteBranch
+		// inside selectAndRegisterRemoteBranch — it's always a fresh stack
+		// when this branch executes, so an active feature session should
+		// adopt it directly.
+		adoptActiveAgentSession(mgr.GetRepoDir(), remote.StackHash)
 
 		// Prompt for stack name (new stack was just created)
 		promptStackName(mgr, userBranch.Name)
@@ -374,6 +382,7 @@ func New(args []string) error {
 		ui.Success(fmt.Sprintf("Created branch '%s' with worktree at '%s'", branch.Name, branch.WorktreePath))
 
 		if isNewStack {
+			adoptActiveAgentSessionForBranch(mgr, branch.Name)
 			promptStackName(mgr, branch.Name)
 		}
 
@@ -399,6 +408,7 @@ func New(args []string) error {
 		ui.Success(fmt.Sprintf("Created branch '%s'", branch.Name))
 
 		if isNewStack {
+			adoptActiveAgentSessionForBranch(mgr, branch.Name)
 			promptStackName(mgr, branch.Name)
 		}
 

--- a/cmd/ezs/completions.go
+++ b/cmd/ezs/completions.go
@@ -99,6 +99,8 @@ var agentSubcommandFlags = map[string][]string{
 	"prompt": {"--shipped", "--custom", "--repo", "--edit", "--reset", "--help", "-h"},
 	"ls":     {"--branch", "-b", "--stack", "-s", "--feature", "--json", "--help", "-h"},
 	"list":   {"--branch", "-b", "--stack", "-s", "--feature", "--json", "--help", "-h"},
+	"rm":     {"--branch", "-b", "--stack", "-s", "--all", "--help", "-h"},
+	"remove": {"--branch", "-b", "--stack", "-s", "--all", "--help", "-h"},
 }
 
 // branchPositionalCommands take a branch name as their first positional arg.
@@ -277,6 +279,8 @@ func printCompletions(args []string) {
 			fmt.Println("feat")
 			fmt.Println("ls")
 			fmt.Println("list")
+			fmt.Println("rm")
+			fmt.Println("remove")
 			fmt.Println("prompt")
 			return
 		}

--- a/cmd/ezs/completions_test.go
+++ b/cmd/ezs/completions_test.go
@@ -134,7 +134,7 @@ func TestPrintCompletions_ConfigShowEmitsNothing(t *testing.T) {
 
 func TestPrintCompletions_AgentSubcommands(t *testing.T) {
 	got := captureCompletions(t, []string{"agent", ""})
-	for _, want := range []string{"feature", "feat", "prompt"} {
+	for _, want := range []string{"feature", "feat", "ls", "list", "rm", "remove", "prompt"} {
 		if !contains(got, want) {
 			t.Errorf("missing agent subcommand %q in %v", want, got)
 		}

--- a/itests/agent_session_test.go
+++ b/itests/agent_session_test.go
@@ -434,10 +434,10 @@ func TestAgentFeature_PromptIncludesStackRenameInstruction(t *testing.T) {
 	prompt := argv[len(argv)-1]
 
 	for _, want := range []string{
-		"Add JWT auth",                       // feature description survives template rendering
-		"ezs stack rename",                   // the rename instruction is in the rendered prompt
-		"≤5 words",                           // length budget is preserved
-		"FIRST BRANCH ONLY",                  // timing constraint is preserved
+		"Add JWT auth",                         // feature description survives template rendering
+		"ezs stack rename",                     // the rename instruction is in the rendered prompt
+		"≤5 words",                             // length budget is preserved
+		"FIRST BRANCH ONLY",                    // timing constraint is preserved
 		"derived from the FEATURE_DESCRIPTION", // name is anchored to the description
 	} {
 		if !strings.Contains(prompt, want) {

--- a/itests/agent_session_test.go
+++ b/itests/agent_session_test.go
@@ -434,10 +434,11 @@ func TestAgentFeature_PromptIncludesStackRenameInstruction(t *testing.T) {
 	prompt := argv[len(argv)-1]
 
 	for _, want := range []string{
-		"Add JWT auth",     // feature description survives template rendering
-		"ezs stack rename", // the rename instruction is in the rendered prompt
-		"≤5 words",         // length budget is preserved
-		"FIRST branch",     // timing constraint is preserved
+		"Add JWT auth",                       // feature description survives template rendering
+		"ezs stack rename",                   // the rename instruction is in the rendered prompt
+		"≤5 words",                           // length budget is preserved
+		"FIRST BRANCH ONLY",                  // timing constraint is preserved
+		"derived from the FEATURE_DESCRIPTION", // name is anchored to the description
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("feature prompt missing %q (first 400 chars):\n%s", want, truncate(prompt, 400))


### PR DESCRIPTION
## Summary

- `ezs agent feature "..."` outside a stack used to mint a session UUID and expose it via `EZS_AGENT_SESSION_ID`, but its persist callback was a no-op. When the agent then created a stack via `ezs new` (or `mcp__ezstack__ezstack_new`), nothing wrote the session UUID onto the new stack — `ezs agent ls` showed nothing for it and a follow-up `ezs agent` inside the stack minted a fresh session instead of resuming.
- Propagate the active session's launch mode through a new `EZS_AGENT_SESSION_MODE` env var, and add an adoption helper that every `ezs new` codepath calls after registering a new stack: when the inherited mode is `feature`, the dangling UUID is written onto the new stack tagged `AgentSessionFeatureMode`. Work-mode sessions are deliberately skipped — they're scoped to the stack they were launched in and shouldn't silently follow the agent into unrelated new stacks.
- The MCP path inherits the env vars from claude (its parent process) and runs `commands.New` in-process, so it picks up adoption without any MCP-server changes. Re-bind semantics: a single feature session that creates multiple stacks lands the same UUID on each — claude resumes by UUID so any of those stacks is a valid resume target.

## Test plan

- [x] New unit tests (`agent_session_adopt_test.go`): no env / no mode / work mode all no-op; feature mode adopts; multiple stacks all get bound; pre-existing slot is overwritten; empty + unknown stack hashes are best-effort; branch lookup variant resolves the stack and a no-op when branch is untracked.
- [x] Existing `agentProcessEnv` tests extended to cover the new `EZS_AGENT_SESSION_MODE` variable (set with the ID, stripped when the ID is cleared, deduped on inherit).
- [x] Full `go test ./...` green (commands, mcp, internal, itests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)