### PR TITLE
fix(pr): strip stale stack section when a stack drops below 2 PRs

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -468,21 +468,7 @@ func (c *Client) runGH(args ...string) (string, error) {
 
 // UpdateStackDescription updates PR descriptions with stack info.
 func (c *Client) UpdateStackDescription(stack *config.Stack, currentBranch string) error {
-	// Count how many PRs are in the stack (including root PR if present)
-	prCount := 0
-	if stack.RootPRNumber > 0 {
-		prCount++
-	}
-	for _, branch := range stack.Branches {
-		if branch.PRNumber > 0 {
-			prCount++
-		}
-	}
-
-	// Only update descriptions when there are 2+ PRs in the stack
-	if prCount < 2 {
-		return nil
-	}
+	prCount := stackPRCount(stack)
 
 	for _, branch := range stack.Branches {
 		if branch.PRNumber == 0 {
@@ -495,12 +481,7 @@ func (c *Client) UpdateStackDescription(stack *config.Stack, currentBranch strin
 			continue
 		}
 
-		// Generate stack section with arrow pointing to THIS PR
-		// Uses PR numbers/URLs from the config cache (.ezstack.json)
-		stackSection := generateStackSection(stack, branch.Name)
-
-		// Update the body with the stack section
-		newBody := updateBodyWithStack(pr.Body, stackSection, branch.Name == currentBranch)
+		newBody := stackDescriptionBody(stack, branch.Name, pr.Body, prCount)
 		if bodyNeedsUpdate(newBody, pr.Body) {
 			if err := c.UpdatePR(branch.PRNumber, newBody); err != nil {
 				return fmt.Errorf("failed to update PR #%d: %w", branch.PRNumber, err)
@@ -513,21 +494,7 @@ func (c *Client) UpdateStackDescription(stack *config.Stack, currentBranch strin
 
 // UpdateStackDescriptionCached updates PR descriptions using pre-fetched PR data to avoid extra API calls.
 func (c *Client) UpdateStackDescriptionCached(stack *config.Stack, currentBranch string, prMap map[int]*PR) error {
-	// Count how many PRs are in the stack (including root PR if present)
-	prCount := 0
-	if stack.RootPRNumber > 0 {
-		prCount++
-	}
-	for _, branch := range stack.Branches {
-		if branch.PRNumber > 0 {
-			prCount++
-		}
-	}
-
-	// Only update descriptions when there are 2+ PRs in the stack
-	if prCount < 2 {
-		return nil
-	}
+	prCount := stackPRCount(stack)
 
 	for _, branch := range stack.Branches {
 		if branch.PRNumber == 0 {
@@ -540,8 +507,7 @@ func (c *Client) UpdateStackDescriptionCached(stack *config.Stack, currentBranch
 			continue
 		}
 
-		stackSection := generateStackSection(stack, branch.Name)
-		newBody := updateBodyWithStack(pr.Body, stackSection, branch.Name == currentBranch)
+		newBody := stackDescriptionBody(stack, branch.Name, pr.Body, prCount)
 		if bodyNeedsUpdate(newBody, pr.Body) {
 			if err := c.UpdatePR(branch.PRNumber, newBody); err != nil {
 				return fmt.Errorf("failed to update PR #%d: %w", branch.PRNumber, err)
@@ -550,6 +516,34 @@ func (c *Client) UpdateStackDescriptionCached(stack *config.Stack, currentBranch
 	}
 
 	return nil
+}
+
+// stackPRCount counts how many PRs are in the stack, including the root PR if present.
+func stackPRCount(stack *config.Stack) int {
+	count := 0
+	if stack.RootPRNumber > 0 {
+		count++
+	}
+	for _, branch := range stack.Branches {
+		if branch.PRNumber > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// stackDescriptionBody renders what a PR's body should look like given the current
+// stack membership. A stack section is only appended when there are 2+ PRs in the
+// stack; below that threshold any previously-appended section is stripped rather
+// than left in place, since a lone remaining PR still carrying a stale multi-PR
+// stack list (e.g. after siblings were merged/unstacked) is itself a bug — see
+// stripStackSections.
+func stackDescriptionBody(stack *config.Stack, branchName, currentBody string, prCount int) string {
+	if prCount < 2 {
+		return strings.TrimSpace(stripStackSections(normalizeBody(currentBody)))
+	}
+	stackSection := generateStackSection(stack, branchName)
+	return updateBodyWithStack(currentBody, stackSection)
 }
 
 func generateStackSection(stack *config.Stack, currentPRBranch string) string {
@@ -595,7 +589,7 @@ func generateStackSection(stack *config.Stack, currentPRBranch string) string {
 	return sb.String()
 }
 
-func updateBodyWithStack(body, stackSection string, isCurrent bool) string {
+func updateBodyWithStack(body, stackSection string) string {
 	body = normalizeBody(body)
 	body = stripStackSections(body)
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -326,6 +326,121 @@ func TestGenerateStackSection(t *testing.T) {
 	}
 }
 
+// TestStackDescriptionBody_StripsStaleStackSectionBelowTwoPRs guards against a
+// bug where UpdateStackDescription/UpdateStackDescriptionCached bailed out
+// entirely whenever a stack had fewer than 2 PRs, skipping stripStackSections
+// along with the append. If a PR's body already carried a stack section from
+// when the stack had 2+ PRs (e.g. siblings later got merged/unstacked/deleted,
+// dropping the stack to a single PR), that stale section — listing branches no
+// longer part of any real stack — was never removed. stackDescriptionBody must
+// still strip any existing section when prCount < 2, it just must not append a
+// fresh one.
+func TestStackDescriptionBody_StripsStaleStackSectionBelowTwoPRs(t *testing.T) {
+	solo := convertTestStack(&Stack{
+		Name: "feature-a",
+		Branches: []*Branch{
+			{Name: "feature-a", PRNumber: 1, PRUrl: "https://github.com/org/repo/pull/1"},
+		},
+	})
+
+	staleBody := "My description" +
+		"\n\n---\n## PR Stack\n\n1. https://github.com/org/repo/pull/1 ← **This PR**\n" +
+		"2. https://github.com/org/repo/pull/2\n\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\n"
+
+	got := stackDescriptionBody(solo, "feature-a", staleBody, stackPRCount(solo))
+
+	if strings.Contains(got, "PR Stack") {
+		t.Errorf("stale stack section survived on a <2-PR stack:\n%s", got)
+	}
+	if !strings.Contains(got, "My description") {
+		t.Errorf("user content was destroyed:\n%s", got)
+	}
+
+	// Applying it again must be a no-op — no flapping between calls.
+	again := stackDescriptionBody(solo, "feature-a", got, stackPRCount(solo))
+	if bodyNeedsUpdate(again, got) {
+		t.Errorf("not idempotent once below 2 PRs:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+}
+
+// TestStackDescriptionBody_NoSpuriousUpdateBelowTwoPRs ensures a PR with no
+// existing stack section, in a stack that has never had 2+ PRs, is left alone
+// (no needless GitHub write on every push/sync).
+func TestStackDescriptionBody_NoSpuriousUpdateBelowTwoPRs(t *testing.T) {
+	solo := convertTestStack(&Stack{
+		Name: "feature-a",
+		Branches: []*Branch{
+			{Name: "feature-a", PRNumber: 1, PRUrl: "https://github.com/org/repo/pull/1"},
+		},
+	})
+
+	body := "Just a plain description, never stacked."
+	got := stackDescriptionBody(solo, "feature-a", body, stackPRCount(solo))
+
+	if bodyNeedsUpdate(got, body) {
+		t.Errorf("expected no update for a body with no stack section on a <2-PR stack, got:\n%s", got)
+	}
+}
+
+// TestStackDescriptionBody_AppendsSectionAtTwoOrMorePRs is the complementary
+// happy path: once a stack has 2+ PRs, a fresh section must be appended.
+func TestStackDescriptionBody_AppendsSectionAtTwoOrMorePRs(t *testing.T) {
+	pair := convertTestStack(&Stack{
+		Name: "feature-a",
+		Branches: []*Branch{
+			{Name: "feature-a", PRNumber: 1, PRUrl: "https://github.com/org/repo/pull/1"},
+			{Name: "feature-b", PRNumber: 2, PRUrl: "https://github.com/org/repo/pull/2"},
+		},
+	})
+
+	got := stackDescriptionBody(pair, "feature-a", "My description", stackPRCount(pair))
+
+	if !strings.Contains(got, "PR Stack") {
+		t.Errorf("expected a stack section to be appended for a 2-PR stack, got:\n%s", got)
+	}
+	if !strings.Contains(got, "pull/2") {
+		t.Errorf("expected sibling PR listed, got:\n%s", got)
+	}
+}
+
+// TestStackPRCount checks the root-PR-inclusive counting used to decide
+// whether a stack section should be rendered at all.
+func TestStackPRCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		stack *config.Stack
+		want  int
+	}{
+		{
+			name:  "no PRs",
+			stack: convertTestStack(&Stack{Branches: []*Branch{{Name: "a"}}}),
+			want:  0,
+		},
+		{
+			name:  "one branch PR",
+			stack: convertTestStack(&Stack{Branches: []*Branch{{Name: "a", PRNumber: 1}}}),
+			want:  1,
+		},
+		{
+			name: "root PR plus one branch PR",
+			stack: func() *config.Stack {
+				s := convertTestStack(&Stack{Branches: []*Branch{{Name: "a", PRNumber: 1}}})
+				s.RootPRNumber = 99
+				return s
+			}(),
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stackPRCount(tt.stack); got != tt.want {
+				t.Errorf("stackPRCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 // Helper types for testing (shadows config types)
 type Stack struct {
 	Name     string
@@ -359,7 +474,6 @@ func TestUpdateBodyWithStack(t *testing.T) {
 		name         string
 		body         string
 		stackSection string
-		isCurrent    bool
 		wantContains []string
 		wantMissing  []string
 	}{
@@ -367,21 +481,18 @@ func TestUpdateBodyWithStack(t *testing.T) {
 			name:         "Empty body",
 			body:         "",
 			stackSection: "\n\n---\n## PR Stack\n\n1. PR #1\n",
-			isCurrent:    true,
 			wantContains: []string{"PR Stack", "PR #1"},
 		},
 		{
 			name:         "Body with existing content",
 			body:         "This is my PR description\n\nSome more text",
 			stackSection: "\n\n---\n## PR Stack\n\n1. PR #1\n",
-			isCurrent:    false,
 			wantContains: []string{"This is my PR description", "PR Stack"},
 		},
 		{
 			name:         "Replace existing stack section",
 			body:         "Description\n\n---\n## PR Stack\n\n1. Old PR\n\n_This stack was created by ezstack_\n",
 			stackSection: "\n\n---\n## PR Stack\n\n1. New PR\n\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\n",
-			isCurrent:    true,
 			wantContains: []string{"New PR"},
 			wantMissing:  []string{"Old PR"},
 		},
@@ -389,7 +500,6 @@ func TestUpdateBodyWithStack(t *testing.T) {
 			name:         "Replace stack section with hyperlink footer",
 			body:         "Description\n\n---\n## PR Stack\n\n1. Old PR\n\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\n",
 			stackSection: "\n\n---\n## PR Stack\n\n1. New PR\n\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\n",
-			isCurrent:    true,
 			wantContains: []string{"New PR"},
 			wantMissing:  []string{"Old PR"},
 		},
@@ -397,7 +507,6 @@ func TestUpdateBodyWithStack(t *testing.T) {
 			name:         "Replace stack section with CRLF line endings",
 			body:         "Description\r\n\r\n---\r\n## PR Stack\r\n\r\n1. Old PR\r\n\r\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\r\n",
 			stackSection: "\n\n---\n## PR Stack\n\n1. New PR\n\n_This stack was created by [ezstack](https://github.com/KulkarniKaustubh/ezstack)_\n",
-			isCurrent:    true,
 			wantContains: []string{"New PR"},
 			wantMissing:  []string{"Old PR"},
 		},
@@ -405,7 +514,7 @@ func TestUpdateBodyWithStack(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateBodyWithStack(tt.body, tt.stackSection, tt.isCurrent)
+			result := updateBodyWithStack(tt.body, tt.stackSection)
 
 			for _, want := range tt.wantContains {
 				if !strings.Contains(result, want) {
@@ -484,7 +593,7 @@ func TestUpdateBodyWithStack_CollapsesDuplicates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateBodyWithStack(tt.body, freshSection, true)
+			result := updateBodyWithStack(tt.body, freshSection)
 
 			// After update there must be EXACTLY one "## PR Stack" heading.
 			// If dedup fails we get 2+ headings.
@@ -498,7 +607,7 @@ func TestUpdateBodyWithStack_CollapsesDuplicates(t *testing.T) {
 			}
 			// Applying the operation a second time must be a no-op (up to the
 			// bodyNeedsUpdate normalization).
-			second := updateBodyWithStack(result, freshSection, true)
+			second := updateBodyWithStack(result, freshSection)
 			if bodyNeedsUpdate(second, result) {
 				t.Errorf("updateBodyWithStack is not idempotent:\nfirst:\n%s\nsecond:\n%s", result, second)
 			}
@@ -541,7 +650,7 @@ func TestUpdateBodyWithStack_MixedMarkerVariants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateBodyWithStack(tt.body, freshSection, true)
+			result := updateBodyWithStack(tt.body, freshSection)
 
 			if got := strings.Count(result, "## PR Stack"); got != 1 {
 				t.Fatalf("expected exactly 1 PR Stack heading (no emoji), got %d\nresult:\n%s", got, result)
@@ -576,9 +685,9 @@ func TestUpdateBodyWithStack_Idempotent(t *testing.T) {
 
 	for i, body := range bodies {
 		t.Run(fmt.Sprintf("body_%d", i), func(t *testing.T) {
-			first := updateBodyWithStack(body, section, true)
-			second := updateBodyWithStack(first, section, true)
-			third := updateBodyWithStack(second, section, true)
+			first := updateBodyWithStack(body, section)
+			second := updateBodyWithStack(first, section)
+			third := updateBodyWithStack(second, section)
 
 			// The rendered body must stabilize after the first call.
 			if first != second || second != third {


### PR DESCRIPTION
## Problem

When a stack drops below 2 PRs (a sibling gets merged/unstacked/deleted, leaving a single PR), the remaining PR could keep a stale "PR Stack" section listing branches that are no longer part of any real stack. `UpdateStackDescription`/`UpdateStackDescriptionCached` bailed out early (`if prCount < 2 { return nil }`) before they could strip that section.

## Fix

- Extract PR counting into `stackPRCount()` and body rendering into `stackDescriptionBody()`.
- When `prCount < 2`, `stackDescriptionBody()` now **strips** any existing stack section instead of leaving it in place; it only appends a fresh section at 2+ PRs. The strip path mirrors `updateBodyWithStack`'s normalization, so it's idempotent and causes no spurious GitHub writes.
- Remove the early return in both update functions so the strip path is reachable for a solo remaining PR.
- Drop the dead `isCurrent` parameter from `updateBodyWithStack` (it was never read; the "← **This PR**" arrow is driven by `generateStackSection`).

## Tests

Adds coverage for: stripping a stale section below 2 PRs, idempotence, no spurious update when there's no section, appending at 2+ PRs, and `stackPRCount` (including the root-PR case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)